### PR TITLE
Satty9361 exec template

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -152,6 +152,8 @@ type contextFrame struct {
 
 	isNestedTemplate bool
 	parsedTemplate   *template.Template
+	execMode	bool
+	execReturn	 []interface{}
 	SendResponseInDM bool
 }
 
@@ -521,6 +523,9 @@ func baseContextFuncs(c *Context) {
 	c.ContextFuncs["onlineCount"] = c.tmplOnlineCount
 	c.ContextFuncs["onlineCountBots"] = c.tmplOnlineCountBots
 	c.ContextFuncs["editNickname"] = c.tmplEditNickname
+
+	c.ContextFuncs["execTemplate"] = c.tmplExecTemplate
+	c.ContextFuncs["addReturn"] = c.tmplAddReturn
 }
 
 type limitedWriter struct {

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -193,7 +193,7 @@ func (c *Context) sendNestedTemplate(channel interface{}, dm , exec bool, name s
 	if exec {
 		var execReturnStruct CtxExecReturn
 		execReturnStruct.Response = c.MessageSend(resp)
-		execReturnStruct.Return, err = CreateSlice(c.CurrentFrame.execReturn...)
+		execReturnStruct.Return = c.CurrentFrame.execReturn
 		return execReturnStruct, err
 	}
 		

--- a/common/templates/structs.go
+++ b/common/templates/structs.go
@@ -73,7 +73,7 @@ func CtxChannelFromCSLocked(cs *dstate.ChannelState) *CtxChannel {
 
 type CtxExecReturn struct {
 	
-	Return 			Slice
+	Return 			[]interface{}
 	Response		*discordgo.MessageSend
 }
 

--- a/common/templates/structs.go
+++ b/common/templates/structs.go
@@ -70,3 +70,16 @@ func CtxChannelFromCSLocked(cs *dstate.ChannelState) *CtxChannel {
 
 	return ctxChannel
 }
+
+type CtxExecReturn struct {
+	
+	Return 			Slice
+	Response		*discordgo.MessageSend
+}
+
+func (c CtxExecReturn) String() string {
+	if c.Response != nil {
+		return c.Response.Content
+	}
+	return ""
+}	


### PR DESCRIPTION
This allows for usage usage of nested templates in form of functions in much more seamless manner. Added fmt.Stringer support to returned struct which defaults to the Response string. 

addReturn allows returning a slice of upto 10 values to the parent template. 