### PR TITLE
templates: add permission checking funcs + bitwise ops

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -76,7 +76,7 @@ var (
 		// bitwise ops
 		"bitwiseAnd":        tmplBitwiseAnd,
 		"bitwiseOr":         tmplBitwiseOr,
-		"bitwiseXOR":        tmplBitwiseXOR,
+		"bitwiseXor":        tmplBitwiseXor,
 		"bitwiseNot":        tmplBitwiseNot,
 		"bitwiseAndNot":     tmplBitwiseAndNot,
 		"bitwiseLeftShift":  tmplBitwiseLeftShift,

--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -73,6 +73,15 @@ var (
 		"sqrt":       tmplSqrt,
 		"sub":        tmplSub,
 
+		// bitwise ops
+		"bitwiseAnd":        tmplBitwiseAnd,
+		"bitwiseOr":         tmplBitwiseOr,
+		"bitwiseXOR":        tmplBitwiseXOR,
+		"bitwiseNot":        tmplBitwiseNot,
+		"bitwiseAndNot":     tmplBitwiseAndNot,
+		"bitwiseLeftShift":  tmplBitwiseLeftShift,
+		"bitwiseRightShift": tmplBitwiseRightShift,
+
 		// misc
 		"humanizeThousands":  tmplHumanizeThousands,
 		"dict":               Dictionary,
@@ -242,6 +251,39 @@ func (c *Context) setupBaseData() {
 	c.Data["TimeMinute"] = time.Minute
 	c.Data["TimeSecond"] = time.Second
 	c.Data["UnixEpoch"] = time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// permissions
+	c.Data["PermissionReadMessages"] = discordgo.PermissionReadMessages
+	c.Data["PermissionSendMessages"] = discordgo.PermissionSendMessages
+	c.Data["PermissionSendTTSMessages"] = discordgo.PermissionSendTTSMessages
+	c.Data["PermissionManageMessages"] = discordgo.PermissionManageMessages
+	c.Data["PermissionEmbedLinks"] = discordgo.PermissionEmbedLinks
+	c.Data["PermissionAttachFiles"] = discordgo.PermissionAttachFiles
+	c.Data["PermissionReadMessageHistory"] = discordgo.PermissionReadMessageHistory
+	c.Data["PermissionMentionEveryone"] = discordgo.PermissionMentionEveryone
+	c.Data["PermissionUseExternalEmojis"] = discordgo.PermissionUseExternalEmojis
+
+	c.Data["PermissionVoiceConnect"] = discordgo.PermissionVoiceConnect
+	c.Data["PermissionVoiceSpeak"] = discordgo.PermissionVoiceSpeak
+	c.Data["PermissionVoiceMuteMembers"] = discordgo.PermissionVoiceMuteMembers
+	c.Data["PermissionVoiceDeafenMembers"] = discordgo.PermissionVoiceDeafenMembers
+	c.Data["PermissionVoiceMoveMembers"] = discordgo.PermissionVoiceMoveMembers
+	c.Data["PermissionVoiceUseVAD"] = discordgo.PermissionVoiceUseVAD
+
+	c.Data["PermissionChangeNickname"] = discordgo.PermissionChangeNickname
+	c.Data["PermissionManageNicknames"] = discordgo.PermissionManageNicknames
+	c.Data["PermissionManageRoles"] = discordgo.PermissionManageRoles
+	c.Data["PermissionManageWebhooks"] = discordgo.PermissionManageWebhooks
+	c.Data["PermissionManageEmojis"] = discordgo.PermissionManageEmojis
+
+	c.Data["PermissionCreateInstantInvite"] = discordgo.PermissionCreateInstantInvite
+	c.Data["PermissionKickMembers"] = discordgo.PermissionKickMembers
+	c.Data["PermissionBanMembers"] = discordgo.PermissionBanMembers
+	c.Data["PermissionAdministrator"] = discordgo.PermissionAdministrator
+	c.Data["PermissionManageChannels"] = discordgo.PermissionManageChannels
+	c.Data["PermissionManageServer"] = discordgo.PermissionManageServer
+	c.Data["PermissionAddReactions"] = discordgo.PermissionAddReactions
+	c.Data["PermissionViewAuditLogs"] = discordgo.PermissionViewAuditLogs
 }
 
 func (c *Context) Parse(source string) (*template.Template, error) {
@@ -543,6 +585,11 @@ func baseContextFuncs(c *Context) {
 
 	c.addContextFunc("targetHasRoleID", c.tmplTargetHasRoleID)
 	c.addContextFunc("targetHasRoleName", c.tmplTargetHasRoleName)
+
+	// permission funcs
+	c.addContextFunc("hasPermissions", c.tmplHasPermissions)
+	c.addContextFunc("targetHasPermissions", c.tmplTargetHasPermissions)
+	c.addContextFunc("getTargetPermissionsIn", c.tmplGetTargetPermissionsIn)
 
 	c.addContextFunc("deleteResponse", c.tmplDelResponse)
 	c.addContextFunc("deleteTrigger", c.tmplDelTrigger)

--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -253,37 +253,39 @@ func (c *Context) setupBaseData() {
 	c.Data["UnixEpoch"] = time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	// permissions
-	c.Data["PermissionReadMessages"] = discordgo.PermissionReadMessages
-	c.Data["PermissionSendMessages"] = discordgo.PermissionSendMessages
-	c.Data["PermissionSendTTSMessages"] = discordgo.PermissionSendTTSMessages
-	c.Data["PermissionManageMessages"] = discordgo.PermissionManageMessages
-	c.Data["PermissionEmbedLinks"] = discordgo.PermissionEmbedLinks
-	c.Data["PermissionAttachFiles"] = discordgo.PermissionAttachFiles
-	c.Data["PermissionReadMessageHistory"] = discordgo.PermissionReadMessageHistory
-	c.Data["PermissionMentionEveryone"] = discordgo.PermissionMentionEveryone
-	c.Data["PermissionUseExternalEmojis"] = discordgo.PermissionUseExternalEmojis
+	c.Data["Permissions"] = map[string]int64{
+		"ReadMessages":       discordgo.PermissionReadMessages,
+		"SendMessages":       discordgo.PermissionSendMessages,
+		"SendTTSMessages":    discordgo.PermissionSendTTSMessages,
+		"ManageMessages":     discordgo.PermissionManageMessages,
+		"EmbedLinks":         discordgo.PermissionEmbedLinks,
+		"AttachFiles":        discordgo.PermissionAttachFiles,
+		"ReadMessageHistory": discordgo.PermissionReadMessageHistory,
+		"MentionEveryone":    discordgo.PermissionMentionEveryone,
+		"UseExternalEmojis":  discordgo.PermissionUseExternalEmojis,
 
-	c.Data["PermissionVoiceConnect"] = discordgo.PermissionVoiceConnect
-	c.Data["PermissionVoiceSpeak"] = discordgo.PermissionVoiceSpeak
-	c.Data["PermissionVoiceMuteMembers"] = discordgo.PermissionVoiceMuteMembers
-	c.Data["PermissionVoiceDeafenMembers"] = discordgo.PermissionVoiceDeafenMembers
-	c.Data["PermissionVoiceMoveMembers"] = discordgo.PermissionVoiceMoveMembers
-	c.Data["PermissionVoiceUseVAD"] = discordgo.PermissionVoiceUseVAD
+		"VoiceConnect":       discordgo.PermissionVoiceConnect,
+		"VoiceSpeak":         discordgo.PermissionVoiceSpeak,
+		"VoiceMuteMembers":   discordgo.PermissionVoiceMuteMembers,
+		"VoiceDeafenMembers": discordgo.PermissionVoiceDeafenMembers,
+		"VoiceMoveMembers":   discordgo.PermissionVoiceMoveMembers,
+		"VoiceUseVAD":        discordgo.PermissionVoiceUseVAD,
 
-	c.Data["PermissionChangeNickname"] = discordgo.PermissionChangeNickname
-	c.Data["PermissionManageNicknames"] = discordgo.PermissionManageNicknames
-	c.Data["PermissionManageRoles"] = discordgo.PermissionManageRoles
-	c.Data["PermissionManageWebhooks"] = discordgo.PermissionManageWebhooks
-	c.Data["PermissionManageEmojis"] = discordgo.PermissionManageEmojis
+		"ChangeNickname":  discordgo.PermissionChangeNickname,
+		"ManageNicknames": discordgo.PermissionManageNicknames,
+		"ManageRoles":     discordgo.PermissionManageRoles,
+		"ManageWebhooks":  discordgo.PermissionManageWebhooks,
+		"ManageEmojis":    discordgo.PermissionManageEmojis,
 
-	c.Data["PermissionCreateInstantInvite"] = discordgo.PermissionCreateInstantInvite
-	c.Data["PermissionKickMembers"] = discordgo.PermissionKickMembers
-	c.Data["PermissionBanMembers"] = discordgo.PermissionBanMembers
-	c.Data["PermissionAdministrator"] = discordgo.PermissionAdministrator
-	c.Data["PermissionManageChannels"] = discordgo.PermissionManageChannels
-	c.Data["PermissionManageServer"] = discordgo.PermissionManageServer
-	c.Data["PermissionAddReactions"] = discordgo.PermissionAddReactions
-	c.Data["PermissionViewAuditLogs"] = discordgo.PermissionViewAuditLogs
+		"CreateInstantInvite": discordgo.PermissionCreateInstantInvite,
+		"KickMembers":         discordgo.PermissionKickMembers,
+		"BanMembers":          discordgo.PermissionBanMembers,
+		"Administrator":       discordgo.PermissionAdministrator,
+		"ManageChannels":      discordgo.PermissionManageChannels,
+		"ManageServer":        discordgo.PermissionManageServer,
+		"AddReactions":        discordgo.PermissionAddReactions,
+		"ViewAuditLogs":       discordgo.PermissionViewAuditLogs,
+	}
 }
 
 func (c *Context) Parse(source string) (*template.Template, error) {

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -996,6 +996,10 @@ func (c *Context) tmplTargetHasPermissions(target interface{}, needed int) (bool
 }
 
 func (c *Context) tmplGetTargetPermissionsIn(target interface{}, channel interface{}) (int, error) {
+	if c.IncreaseCheckGenericAPICall() {
+		return 0, ErrTooManyAPICalls
+	}
+
 	targetID := targetUserID(target)
 	if targetID == 0 {
 		return 0, nil

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -949,7 +949,7 @@ func (c *Context) findRoleByName(name string) *discordgo.Role {
 	return nil
 }
 
-func (c *Context) tmplHasPermissions(needed int) (bool, error) {
+func (c *Context) tmplHasPermissions(needed int64) (bool, error) {
 	if c.IncreaseCheckGenericAPICall() {
 		return false, ErrTooManyAPICalls
 	}
@@ -969,7 +969,7 @@ func (c *Context) tmplHasPermissions(needed int) (bool, error) {
 	return c.msHasPerms(c.MS, c.CurrentFrame.CS.ID, needed)
 }
 
-func (c *Context) tmplTargetHasPermissions(target interface{}, needed int) (bool, error) {
+func (c *Context) tmplTargetHasPermissions(target interface{}, needed int64) (bool, error) {
 	if c.IncreaseCheckGenericAPICall() {
 		return false, ErrTooManyAPICalls
 	}
@@ -995,7 +995,7 @@ func (c *Context) tmplTargetHasPermissions(target interface{}, needed int) (bool
 	return c.msHasPerms(ms, c.CurrentFrame.CS.ID, needed)
 }
 
-func (c *Context) tmplGetTargetPermissionsIn(target interface{}, channel interface{}) (int, error) {
+func (c *Context) tmplGetTargetPermissionsIn(target interface{}, channel interface{}) (int64, error) {
 	if c.IncreaseCheckGenericAPICall() {
 		return 0, ErrTooManyAPICalls
 	}
@@ -1015,11 +1015,11 @@ func (c *Context) tmplGetTargetPermissionsIn(target interface{}, channel interfa
 		return 0, err
 	}
 
-	return c.GS.MemberPermissionsMS(true, channelID, ms)
+	return c.GS.GetMemberPermissions(channelID, ms.User.ID, ms.Member.Roles)
 }
 
-func (c *Context) msHasPerms(ms *dstate.MemberState, channelID int64, needed int) (bool, error) {
-	perms, err := c.GS.MemberPermissionsMS(true, c.CurrentFrame.CS.ID, ms)
+func (c *Context) msHasPerms(ms *dstate.MemberState, channelID int64, needed int64) (bool, error) {
+	perms, err := c.GS.GetMemberPermissions(channelID, ms.User.ID, ms.Member.Roles)
 	if err != nil {
 		return false, err
 	}

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -966,7 +966,7 @@ func (c *Context) tmplHasPermissions(needed int64) (bool, error) {
 		return true, nil
 	}
 
-	return c.msHasPerms(c.MS, c.CurrentFrame.CS.ID, needed)
+	return c.hasPerms(c.MS, c.CurrentFrame.CS.ID, needed)
 }
 
 func (c *Context) tmplTargetHasPermissions(target interface{}, needed int64) (bool, error) {
@@ -992,7 +992,7 @@ func (c *Context) tmplTargetHasPermissions(target interface{}, needed int64) (bo
 		return false, err
 	}
 
-	return c.msHasPerms(ms, c.CurrentFrame.CS.ID, needed)
+	return c.hasPerms(ms, c.CurrentFrame.CS.ID, needed)
 }
 
 func (c *Context) tmplGetTargetPermissionsIn(target interface{}, channel interface{}) (int64, error) {
@@ -1018,7 +1018,7 @@ func (c *Context) tmplGetTargetPermissionsIn(target interface{}, channel interfa
 	return c.GS.GetMemberPermissions(channelID, ms.User.ID, ms.Member.Roles)
 }
 
-func (c *Context) msHasPerms(ms *dstate.MemberState, channelID int64, needed int64) (bool, error) {
+func (c *Context) hasPerms(ms *dstate.MemberState, channelID int64, needed int64) (bool, error) {
 	perms, err := c.GS.GetMemberPermissions(channelID, ms.User.ID, ms.Member.Roles)
 	if err != nil {
 		return false, err

--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -634,6 +634,37 @@ func tmplLog(arguments ...interface{}) (float64, error) {
 	return logarithm, nil
 }
 
+func tmplBitwiseAnd(arg1, arg2 interface{}) int {
+	return tmplToInt(arg1) & tmplToInt(arg2)
+}
+
+func tmplBitwiseOr(args ...interface{}) (res int) {
+	for _, arg := range args {
+		res |= tmplToInt(arg)
+	}
+	return
+}
+
+func tmplBitwiseXOR(arg1, arg2 interface{}) int {
+	return tmplToInt(arg1) ^ tmplToInt(arg2)
+}
+
+func tmplBitwiseNot(arg interface{}) int {
+	return ^tmplToInt(arg)
+}
+
+func tmplBitwiseAndNot(arg1, arg2 interface{}) int {
+	return tmplToInt(arg1) &^ tmplToInt(arg2)
+}
+
+func tmplBitwiseLeftShift(arg1, arg2 interface{}) int {
+	return tmplToInt(arg1) << tmplToInt(arg2)
+}
+
+func tmplBitwiseRightShift(arg1, arg2 interface{}) int {
+	return tmplToInt(arg1) >> tmplToInt(arg2)
+}
+
 //tmplHumanizeThousands comma separates thousands
 func tmplHumanizeThousands(input interface{}) string {
 	var f1, f2 string

--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -645,7 +645,7 @@ func tmplBitwiseOr(args ...interface{}) (res int) {
 	return
 }
 
-func tmplBitwiseXOR(arg1, arg2 interface{}) int {
+func tmplBitwiseXor(arg1, arg2 interface{}) int {
 	return tmplToInt(arg1) ^ tmplToInt(arg2)
 }
 


### PR DESCRIPTION
Often users want to check permissions in CC (i.e. they only want admins to run this command, but don't want to specify a role). Currently the main way of doing this is using `-viewperms` and then using string manipulation to check the permissions. This is 1) possibly unsafe, if the user does not strip the username from the resulting text, 2) easy to get wrong. Furthermore it's basically a waste of an `exec` call just to get user permissions.

This PR adds the following:
* Constants for Discord permission bits on the dot.
* `bitwise*` funcs to manipulate permissions.
* `hasPermissions/targetHasPermissions/getTargetPermissionsInChannel` funcs to get Discord permissions of users. (should `Permissions` be singular or plural here? dunno...)

Works fine on selfhost, as far as I can tell.