### PR TITLE
common: add fuzzy matching pkg, use it for role group name suggestions

### DIFF
--- a/common/fuzzy/fuzzy.go
+++ b/common/fuzzy/fuzzy.go
@@ -1,0 +1,163 @@
+package fuzzy
+
+import (
+	"math"
+	"sort"
+	"unicode"
+)
+
+const (
+	WinklerThreshold  = 0.7
+	WinklerPrefixSize = 4
+)
+
+// Similarity computes the Jaro-Winkler similarity between two strings with
+// configurable case sensitivity. The result falls in the range 0 (no match) to
+// 1 (perfect match).
+//
+// It is a translation of the code provided here:
+// https://stackoverflow.com/a/19165108
+func Similarity(s1, s2 []rune, caseSensitive bool) float64 {
+	s1Len := len(s1)
+	s2Len := len(s2)
+	if s1Len == 0 {
+		if s2Len == 0 {
+			return 1
+		}
+		return 0
+	}
+
+	searchRange := math.Max(0, math.Max(float64(s1Len), float64(s2Len))/2-1)
+
+	matched1 := make([]bool, s1Len)
+	matched2 := make([]bool, s2Len)
+
+	common := 0
+	for i := 0; i < s1Len; i++ {
+		start := int(math.Max(0, float64(i)-searchRange))
+		end := int(math.Min(float64(i)+searchRange+float64(1), float64(s2Len)))
+		for j := start; j < end; j++ {
+			if matched2[j] {
+				continue
+			}
+			if !runesEq(s1[i], s2[j], caseSensitive) {
+				continue
+			}
+
+			matched1[i] = true
+			matched2[j] = true
+			common++
+			break
+		}
+	}
+
+	if common == 0 {
+		return 0
+	}
+
+	numHalfTransposed := 0
+	k := 0
+	for i := 0; i < s1Len; i++ {
+		if !matched1[i] {
+			continue
+		}
+		for !matched2[k] {
+			k++
+		}
+		if !runesEq(s1[i], s2[k], caseSensitive) {
+			numHalfTransposed++
+		}
+		k++
+	}
+
+	numTransposed := numHalfTransposed / 2
+	weight := (float64(common)/float64(s1Len) + float64(common)/float64(s2Len) + float64(common-numTransposed)/float64(common)) / 3
+	if weight <= WinklerThreshold {
+		return weight // don't apply Winkler modification unless the strings are reasonably similar
+	}
+
+	max := int(math.Min(WinklerPrefixSize, math.Min(float64(s1Len), float64(s2Len))))
+	pos := 0
+	for pos < max && runesEq(s1[pos], s2[pos], caseSensitive) {
+		pos++
+	}
+
+	if pos == 0 {
+		return weight
+	}
+
+	return weight + 0.1*float64(pos)*(1-weight)
+}
+
+func runesEq(r1, r2 rune, caseSensitive bool) bool {
+	if caseSensitive {
+		return r1 == r2
+	}
+	// unfortunate, but no real better way in this context
+	return unicode.ToLower(r1) == unicode.ToLower(r2)
+}
+
+// AdaptiveThreshold is a special value indicating that Select should compute the
+// optimal threshold automatically.
+const AdaptiveThreshold = -1
+
+// Selection is a single selection returned from the Select* methods.
+type Selection struct {
+	Value    string  // The string selected.
+	Distance float64 // The Jaro-Winkler distance between the query and string.
+}
+
+// SelectN returns at most N strings from options for which the Jaro-Winkler
+// distance between the query and the option is greater than or equal to
+// threshold. The selections are sorted in descending order by their
+// Jaro-Winkler distance. If n < 0, there is no limit on the number of returned
+// selections. If threshold == AdaptiveThreshold, an optimal threshold will be
+// computed automatically.
+func SelectN(query string, options []string, threshold float64, caseSensitive bool, n int) []*Selection {
+	if n == 0 {
+		return nil
+	}
+
+	queryRunes := []rune(query)
+	if threshold == AdaptiveThreshold {
+		threshold = computeAdaptiveThreshold(len(queryRunes))
+	}
+
+	var selections []*Selection
+	for _, option := range options {
+		if d := Similarity(queryRunes, []rune(option), caseSensitive); d >= threshold {
+			selections = append(selections, &Selection{Value: option, Distance: d})
+		}
+	}
+
+	sort.Slice(selections, func(i, j int) bool {
+		return selections[i].Distance > selections[j].Distance
+	})
+	if n < 0 || len(selections) <= n {
+		return selections
+	}
+	return selections[:n]
+}
+
+// SelectN returns all the options for which the Jaro-Winkler distance between
+// the query and the option is greater than or equal to threshold.
+// If threshold == AdaptiveThreshold, an optimal threshold will be computed
+// automatically.
+//
+// It is equivalent to SelectN with a limit of -1.
+func SelectAll(query string, options []string, threshold float64, caseSensitive bool) []*Selection {
+	return SelectN(query, options, threshold, caseSensitive, -1)
+}
+
+func computeAdaptiveThreshold(len int) float64 {
+	switch {
+	case len <= 3:
+		return 1
+	case len <= 6:
+		return 0.8
+	case len <= 12:
+		return 0.7
+	default:
+		return 0.6
+	}
+}

--- a/common/fuzzy/fuzzy.go
+++ b/common/fuzzy/fuzzy.go
@@ -139,7 +139,7 @@ func SelectN(query string, options []string, threshold float64, caseSensitive bo
 	return selections[:n]
 }
 
-// SelectN returns all the options for which the Jaro-Winkler distance between
+// SelectAll returns all the options for which the Jaro-Winkler distance between
 // the query and the option is greater than or equal to threshold.
 // If threshold == AdaptiveThreshold, an optimal threshold will be computed
 // automatically.

--- a/common/fuzzy/fuzzy_test.go
+++ b/common/fuzzy/fuzzy_test.go
@@ -73,6 +73,8 @@ func TestSelectN(t *testing.T) {
 		{"roels", []string{"reoles", "othermenu", "role", "roles"}, 0.7, true, 2, []string{"roles", "reoles"}},
 		{"roels", []string{"reoles", "othermenu", "role", "roles"}, 0.7, true, -1, []string{"roles", "reoles", "role"}},
 		{"roels", []string{"reoles", "othermenu", "role", "roles"}, AdaptiveThreshold, true, -1, []string{"roles", "reoles", "role"}},
+		{"zac EFroN", []string{"zAc ePhrOn", "Kai Ephron"}, 0.9, false, 0, nil},
+		{"as", []string{"asd", "bas", "hello", "world"}, AdaptiveThreshold, false, -1, nil},
 
 		{"zac EFroN", []string{"zAc ePhrOn", "Kai Ephron"}, 0.9, false, 1, []string{"zAc ePhrOn"}},
 		{"zac efron", []string{"zAc ePhrOn", "Kai Ephron"}, AdaptiveThreshold, false, 1, []string{"zAc ePhrOn"}},

--- a/common/fuzzy/fuzzy_test.go
+++ b/common/fuzzy/fuzzy_test.go
@@ -1,0 +1,132 @@
+package fuzzy
+
+import (
+	"math"
+	"strconv"
+	"testing"
+)
+
+const tolerance = .01
+
+func TestSimilarity(t *testing.T) {
+	testCases := []struct {
+		s1, s2        string
+		caseSensitive bool
+		want          float64
+	}{
+		{"aa", "a", true, 0.85},
+		{"a", "aa", true, 0.85},
+		{"v", "veryveryverylong", true, 0.68},
+		{"jones", "johnson", true, 0.83},
+		{"fvie", "ten", true, 0},
+		{"henka", "henkan", true, 0.96},
+		{"my string", "my ntrisg", true, 0.89},
+		{"my string", "my tsring", true, 0.97},
+		{"dixon", "dicksonx", true, 0.81},
+		{"dwayne", "duane", true, 0.84},
+		{"martha", "marhta", true, 0.96},
+		{"aaaa", "aaaa", true, 1},
+		{"123", "123", true, 1},
+		{"", "", true, 1},
+		{"", "hi", true, 0},
+		{"abc", "abc", true, 1},
+		{"AA", "a", true, 0},
+
+		{"AA", "a", false, 0.85},
+		{"mY string", "my ntrisg", false, 0.89},
+		{"jOnEs", "jOhNsON", false, 0.83},
+	}
+
+	for i, v := range testCases {
+		t.Run("Case "+strconv.FormatInt(int64(i), 10), func(t *testing.T) {
+			got := Similarity([]rune(v.s1), []rune(v.s2), v.caseSensitive)
+			if math.Abs(got-v.want) > tolerance {
+				t.Errorf("got %.5f, want %.5f", got, v.want)
+			}
+		})
+	}
+}
+
+func selectionsToStrings(selections []*Selection) []string {
+	res := make([]string, len(selections))
+	for i, selection := range selections {
+		res[i] = selection.Value
+	}
+	return res
+}
+
+func TestSelectN(t *testing.T) {
+	testCases := []struct {
+		query         string
+		options       []string
+		threshold     float64
+		caseSensitive bool
+		n             int
+		want          []string
+	}{
+		{"zac efron", []string{"zac ephron", "kai ephron"}, 0.9, true, 1, []string{"zac ephron"}},
+		{"zac efron", []string{"zac ephron", "kai ephron"}, AdaptiveThreshold, true, 1, []string{"zac ephron"}},
+		{"zac efron", []string{"zac ephron", "kai ephron"}, AdaptiveThreshold, true, -1, []string{"zac ephron", "kai ephron"}},
+		{"britney spears", []string{"britney sphears", "spears britney"}, 0.8, true, 1, []string{"britney sphears"}},
+		{"britney spears", []string{"zac ephron", "zac efron", "britney spheres", "brtney speears"}, 0.8, true, -1, []string{"brtney speears", "britney spheres"}},
+		{"britney spears", []string{"zac ephron", "zac efron", "britney spheres", "brtney speears"}, AdaptiveThreshold, true, -1, []string{"brtney speears", "britney spheres"}},
+		{"roels", []string{"reoles", "othermenu", "role", "roles"}, 0.7, true, 2, []string{"roles", "reoles"}},
+		{"roels", []string{"reoles", "othermenu", "role", "roles"}, 0.7, true, -1, []string{"roles", "reoles", "role"}},
+		{"roels", []string{"reoles", "othermenu", "role", "roles"}, AdaptiveThreshold, true, -1, []string{"roles", "reoles", "role"}},
+
+		{"zac EFroN", []string{"zAc ePhrOn", "Kai Ephron"}, 0.9, false, 1, []string{"zAc ePhrOn"}},
+		{"zac efron", []string{"zAc ePhrOn", "Kai Ephron"}, AdaptiveThreshold, false, 1, []string{"zAc ePhrOn"}},
+	}
+
+	for i, v := range testCases {
+		t.Run("Case "+strconv.FormatInt(int64(i), 10), func(t *testing.T) {
+			got := SelectN(v.query, v.options, v.threshold, v.caseSensitive, v.n)
+			if len(got) != len(v.want) {
+				t.Errorf("got %#v, wanted %#v", selectionsToStrings(got), v.want)
+				return
+			}
+			for y, s := range got {
+				if s.Value != v.want[y] {
+					t.Errorf("got %#v, wanted %#v", selectionsToStrings(got), v.want)
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestSelectAll(t *testing.T) {
+	testCases := []struct {
+		query         string
+		options       []string
+		threshold     float64
+		caseSensitive bool
+		want          []string
+	}{
+		{"zac efron", []string{"zac ephron", "kai ephron"}, AdaptiveThreshold, true, []string{"zac ephron", "kai ephron"}},
+		{"britney spears", []string{"zac ephron", "zac efron", "britney spheres", "brtney speears"}, 0.8, true, []string{"brtney speears", "britney spheres"}},
+		{"britney spears", []string{"zac ephron", "zac efron", "britney spheres", "brtney speears"}, AdaptiveThreshold, true, []string{"brtney speears", "britney spheres"}},
+		{"roels", []string{"reoles", "othermenu", "role", "roles"}, 0.7, true, []string{"roles", "reoles", "role"}},
+		{"roels", []string{"reoles", "othermenu", "role", "roles"}, AdaptiveThreshold, true, []string{"roles", "reoles", "role"}},
+		{"roels", []string{"hello", "world", "asdf", "anotherrolemenu"}, AdaptiveThreshold, true, nil},
+
+		{"zac EFroN", []string{"zAc ePhrOn", "Kai Ephron"}, 0.9, false, []string{"zAc ePhrOn"}},
+		{"zac efron", []string{"zAc ePhrOn", "Kai Ephron"}, AdaptiveThreshold, false, []string{"zAc ePhrOn", "Kai Ephron"}},
+	}
+
+	for i, v := range testCases {
+		t.Run("Case "+strconv.FormatInt(int64(i), 10), func(t *testing.T) {
+			got := SelectAll(v.query, v.options, v.threshold, v.caseSensitive)
+			if len(got) != len(v.want) {
+				t.Errorf("got %#v, wanted %#v", selectionsToStrings(got), v.want)
+				return
+			}
+			for y, s := range got {
+				if s.Value != v.want[y] {
+					t.Errorf("got %#v, wanted %#v", selectionsToStrings(got), v.want)
+					return
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Foreward:** Feel free to close this if you don't feel it's worth it, I think having suggestions for invalid input is nice but the complexity added is non-trivial.

This PR adds a very simple fuzzy matching package using the Jaro-Winkler algorithm in `common/`, with assorted unit tests and such. Jaro-Winkler was chosen over the more famous Levenshtein algorithm as [studies](http://users.cecs.anu.edu.au/~Peter.Christen/publications/tr-cs-06-02.pdf) show that it is more accurate for single words than Levenshtein distance. As the use cases of this package are for matching on short phrases (role group names), it seemed more suitable. Furthermore, the algorithm itself is slightly more efficient.

`rolemenu c` is edited to suggest possible alternatives if a user provides a role group name that is invalid using this new package. It was chosen because it's one of the more widely used commands that can error easily due to misspelled input (I have seen many users in help channels add/remove a plural, for example, and wonder why it isn't working). If you like this change, perhaps some other commands could be changed to provide suggestions on invalid input in the future.

![Image of the new rolemenu create error message](https://user-images.githubusercontent.com/56809242/117498893-4459ed80-af2f-11eb-9b49-454d8563e355.png)

