### PR TITLE
stdcommands: Add songwhip command

### DIFF
--- a/stdcommands/songwhip/songwhip.go
+++ b/stdcommands/songwhip/songwhip.go
@@ -1,0 +1,104 @@
+package songwhip
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"net/url"
+
+	"github.com/jonas747/dcmd/v4"
+	"github.com/jonas747/discordgo/v2"
+	"github.com/jonas747/dstate/v4"
+	"github.com/jonas747/yagpdb/commands"
+	"github.com/jonas747/yagpdb/common"
+)
+
+type Artist struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type Songwhip struct {
+	Url     string    `json:"url"`
+	Image   string    `json:"image"`
+	Name    string    `json:"name"`
+	Artists []*Artist `json:"artists"`
+}
+
+var Command = &commands.YAGCommand{
+	Cooldown:            15,
+	SlashCommandEnabled: true,
+	CmdCategory:         commands.CategoryFun,
+	Name:                "Songwhip",
+	Description:         "Create a songwhip link, to share your music regardless of the platform!",
+	Aliases:             []string{"sw"},
+	RequiredArgs:        1,
+	Arguments: []*dcmd.ArgDef{
+		{Name: "Link", Type: dcmd.String},
+	},
+	RunFunc: func(data *dcmd.Data) (interface{}, error) {
+		songURL := data.Args[0].Str()
+
+		// Check if it is a valid URI to be easy on the API and return early
+		_, err := url.ParseRequestURI(songURL)
+		if err != nil {
+			return fmt.Sprintf("Not a valid URL!\n`%s`", err), err
+		}
+
+		songwhip, err := getSongwhip(songURL)
+		if err != nil {
+			return "Something went wrong with getting the page link! Perhaps an invalid song URL?", err
+		}
+
+		embed := makeEmbed(songwhip, data.GuildData.MS)
+
+		return embed, nil
+	},
+}
+
+func getSongwhip(url string) (*Songwhip, error) {
+	songwhip := Songwhip{}
+	payload := map[string]string{"url": url}
+	jsonValue, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.DefaultClient.Post("https://songwhip.com", "application/json", bytes.NewBuffer(jsonValue))
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&songwhip)
+	if err != nil {
+		return nil, err
+	}
+
+	return &songwhip, nil
+}
+
+func makeEmbed(s *Songwhip, ms *dstate.MemberState) *discordgo.MessageEmbed {
+	embed := &discordgo.MessageEmbed{
+		URL: s.Url,
+		Author: &discordgo.MessageEmbedAuthor{
+			Name:    "Songwhip • Listen on any platform",
+			IconURL: "https://songwhip.com/apple-touch-icon.png",
+		},
+		Footer: &discordgo.MessageEmbedFooter{
+			Text:    fmt.Sprintf("Requested by: %s#%s", ms.User.Username, ms.User.Discriminator),
+			IconURL: discordgo.EndpointUserAvatar(ms.User.ID, ms.User.Avatar),
+		},
+		Thumbnail: &discordgo.MessageEmbedThumbnail{
+			URL: s.Image,
+		},
+		Title:       fmt.Sprintf("%s by %s", s.Name, s.Artists[0].Name),
+		Description: common.CutStringShort(s.Artists[0].Description, 280),
+		Color:       int(rand.Int63n(16777215)),
+	}
+
+	return embed
+}

--- a/stdcommands/stdcommands.go
+++ b/stdcommands/stdcommands.go
@@ -35,6 +35,7 @@ import (
 	"github.com/jonas747/yagpdb/stdcommands/simpleembed"
 	"github.com/jonas747/yagpdb/stdcommands/sleep"
 	"github.com/jonas747/yagpdb/stdcommands/statedbg"
+	"github.com/jonas747/yagpdb/stdcommands/songwhip"
 	"github.com/jonas747/yagpdb/stdcommands/stateinfo"
 	"github.com/jonas747/yagpdb/stdcommands/throw"
 	"github.com/jonas747/yagpdb/stdcommands/toggledbg"
@@ -96,6 +97,7 @@ func (p *Plugin) AddCommands() {
 		topgames.Command,
 		xkcd.Command,
 		howlongtobeat.Command,
+		songwhip.Command,
 
 		// Maintenance
 		stateinfo.Command,


### PR DESCRIPTION
Songwhip is a small website hosted by a one-man army and provides a simple yet effective API.
We can make POST requests with the song URL as payload and receive a page back, listing all platforms which have that song.

I've seen that site used in a music-related Discord server, did a bit of research and found that they provide an API and ended up making a command for it.

Works fine on selfhost, as far as I can tell. Nifty screenshot:
![image](https://user-images.githubusercontent.com/71897876/117509104-f32b1780-af89-11eb-8c97-f6b4abcc39d1.png)

The cooldown might be debatable, but I wanted to be easy on the API.
Cheers!