### PR TITLE
stdcommands: add an english dictionary lookup command

### DIFF
--- a/cmd/yagpdb/sampleenvfile
+++ b/cmd/yagpdb/sampleenvfile
@@ -71,6 +71,9 @@ YAGPDB_DISABLE_REQUEST_LOGGING=""
 YAGPDB_AYLIENAPPID="aylien app id here"
 YAGPDB_AYLIENAPPKEY="aylien app key here"
 
+# Owlbot
+YAGPDB_OWLBOT_TOKEN=
+
 # Reddit
 # You'll need to get a permanent refresh token using a script or something, i should probably make a easy way to do it but eh...
 YAGPDB_REDDIT_CLIENTID="Reddit application clientid here"

--- a/stdcommands/owldictionary/owldictionary.go
+++ b/stdcommands/owldictionary/owldictionary.go
@@ -1,0 +1,206 @@
+package owldictionary
+
+import (
+	"encoding/json"
+	"html"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/botlabs-gg/yagpdb/v2/bot/paginatedmessages"
+	"github.com/botlabs-gg/yagpdb/v2/commands"
+	"github.com/botlabs-gg/yagpdb/v2/common"
+	"github.com/botlabs-gg/yagpdb/v2/common/config"
+	"github.com/botlabs-gg/yagpdb/v2/lib/dcmd"
+	"github.com/botlabs-gg/yagpdb/v2/lib/discordgo"
+	"github.com/microcosm-cc/bluemonday"
+)
+
+var confOwlbotToken = config.RegisterOption("yagpdb.owlbot_token", "Owlbot API token", "")
+
+func ShouldRegister() bool {
+	return confOwlbotToken.GetString() != ""
+}
+
+var Command = &commands.YAGCommand{
+	CmdCategory:  commands.CategoryFun,
+	Name:         "OwlDictionary",
+	Aliases:      []string{"owldict", "owl"},
+	Description:  "Get the definition of an English word using the Owlbot API.",
+	RequiredArgs: 1,
+	Cooldown:     5,
+	Arguments: []*dcmd.ArgDef{
+		{Name: "Query", Help: "Word to search for", Type: dcmd.String},
+	},
+	DefaultEnabled:      true,
+	SlashCommandEnabled: true,
+	RunFunc: func(data *dcmd.Data) (interface{}, error) {
+		query := strings.ToLower(data.Args[0].Str())
+		req, err := http.NewRequest("GET", "https://owlbot.info/api/v4/dictionary/"+url.QueryEscape(query), nil)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("Authorization", "Token "+confOwlbotToken.GetString())
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode == 404 {
+			return "Could not find a definition for that word.", nil
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		var res OwlbotResult
+		err = json.Unmarshal(body, &res)
+		if err != nil || len(res.Definitions) == 0 {
+			return "Could not find a definition for that word.", err
+		}
+
+		if len(res.Definitions) == 1 || data.Context().Value(paginatedmessages.CtxKeyNoPagination) != nil {
+			return createOwlbotDefinitionEmbed(&res, res.Definitions[0]), nil
+		}
+
+		_, err = paginatedmessages.CreatePaginatedMessage(data.GuildData.GS.ID, data.ChannelID, 1, len(res.Definitions), func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
+			if page > len(res.Definitions) {
+				return nil, paginatedmessages.ErrNoResults
+			}
+
+			return createOwlbotDefinitionEmbed(&res, res.Definitions[page-1]), nil
+		})
+		return "", err
+	},
+}
+
+func createOwlbotDefinitionEmbed(res *OwlbotResult, def *OwlbotDefinition) *discordgo.MessageEmbed {
+	title := strings.Title(normalizeOutput(res.Word))
+	if def.Emoji != nil {
+		title = title + " " + normalizeOutput(*def.Emoji)
+	}
+
+	embed := &discordgo.MessageEmbed{
+		Author:      &discordgo.MessageEmbedAuthor{Name: "Owlbot", IconURL: "https://i.imgur.com/zgBXENZ.png", URL: "https://owlbot.info/"},
+		Title:       title,
+		Description: common.CutStringShort(capitalizeSentences(normalizeOutput(def.Definition)), 2048),
+		Color:       0x07AB99,
+		Timestamp:   time.Now().Format(time.RFC3339),
+	}
+
+	if def.ImageURL != nil {
+		embed.Thumbnail = &discordgo.MessageEmbedThumbnail{URL: *def.ImageURL}
+	}
+
+	if res.Pronunciation != nil {
+		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+			Name:   "Pronunciation",
+			Value:  normalizeOutput(*res.Pronunciation),
+			Inline: true,
+		})
+	}
+
+	if def.Type != nil {
+		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+			Name:   "Type",
+			Value:  strings.Title(normalizeOutput(*def.Type)),
+			Inline: true,
+		})
+	}
+
+	if def.Example != nil {
+		example := capitalizeSentences(normalizeOutput(*def.Example))
+		if !hasEndOfSentenceSymbol(example) {
+			example = example + "." // add period if no other symbol that ends the sentence is present
+		}
+
+		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+			Name:   "Example",
+			Value:  "*" + common.CutStringShort(example, 1022) + "*",
+			Inline: false,
+		})
+	}
+
+	return embed
+}
+
+var policy = bluemonday.StrictPolicy()
+
+func normalizeOutput(s string) string {
+	// The API occasionally returns HTML tags and escapes as part of output, remove them.
+	decoded := html.UnescapeString(policy.Sanitize(s))
+	// It also sometimes returns non-printable characters, strip them out too.
+	return strings.Map(func(r rune) rune {
+		if unicode.IsGraphic(r) {
+			return r
+		}
+		return -1
+	}, decoded)
+}
+
+func capitalizeSentences(s string) string {
+	var builder strings.Builder
+
+	capitalizeCur := true // whether the current phrase should be capitalized.
+	for i, word := range strings.Fields(s) {
+		if i > 0 {
+			builder.WriteByte(' ')
+		}
+
+		if capitalizeCur {
+			// strings.Title() does not work properly with punctuation: for example, "what's" becomes 'What'S" when passed to it, which is undesirable.
+			// Instead, title-case the first rune manually and write the rest as is, as we know `word` represents a single word.
+			r, size := utf8.DecodeRuneInString(word)
+			if r == utf8.RuneError {
+				// fall back to original text
+				builder.WriteString(word)
+			} else {
+				builder.WriteRune(unicode.ToTitle(r))
+				builder.WriteString(word[size:])
+			}
+		} else {
+			builder.WriteString(word)
+		}
+
+		capitalizeCur = hasEndOfSentenceSymbol(word)
+	}
+
+	return builder.String()
+}
+
+func hasEndOfSentenceSymbol(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+
+	switch s[len(s)-1] {
+	case '.', '?', '!':
+		return true
+	default:
+		return false
+	}
+}
+
+type OwlbotResult struct {
+	Word          string              `json:"word"`
+	Definitions   []*OwlbotDefinition `json:"definitions"`
+	Pronunciation *string             `json:"pronunciation"`
+}
+
+type OwlbotDefinition struct {
+	Type       *string `json:"type"`
+	Definition string  `json:"definition"`
+	Example    *string `json:"example"`
+	ImageURL   *string `json:"image_url"`
+	Emoji      *string `json:"emoji"`
+}

--- a/stdcommands/stdcommands.go
+++ b/stdcommands/stdcommands.go
@@ -29,6 +29,7 @@ import (
 	"github.com/botlabs-gg/yagpdb/v2/stdcommands/listflags"
 	"github.com/botlabs-gg/yagpdb/v2/stdcommands/listroles"
 	"github.com/botlabs-gg/yagpdb/v2/stdcommands/memstats"
+	"github.com/botlabs-gg/yagpdb/v2/stdcommands/owldictionary"
 	"github.com/botlabs-gg/yagpdb/v2/stdcommands/ping"
 	"github.com/botlabs-gg/yagpdb/v2/stdcommands/poll"
 	"github.com/botlabs-gg/yagpdb/v2/stdcommands/roll"
@@ -124,6 +125,12 @@ func (p *Plugin) AddCommands() {
 
 	statedbg.Commands()
 
+	if !owldictionary.ShouldRegister() {
+		common.GetPluginLogger(p).Warn("Owlbot API token not provided, skipping adding dictionary command...")
+		return
+	}
+
+	commands.AddRootCommands(p, owldictionary.Command)
 }
 
 func (p *Plugin) BotInit() {

--- a/yagpdb_docker/app.example.env
+++ b/yagpdb_docker/app.example.env
@@ -38,6 +38,9 @@ YAGPDB_BOTLEAVESJOINS=
 YAGPDB_AYLIENAPPID=aylien app id here
 YAGPDB_AYLIENAPPKEY=aylien app key here
 
+# Owlbot
+YAGPDB_OWLBOT_TOKEN=
+
 #Twitter
 #YAGPDB_TWITTER_ACCESS_TOKEN=Twitter Access Token
 #YAGPDB_TWITTER_ACCESS_TOKEN_SECRET=Twitter Access Token Secret


### PR DESCRIPTION
> **Warning:** Though I believe a dictionary is a useful tool to have as a built-in command, there are undeniably some occasional slight issues with the output of this command due to the API used, so feel free to decline this if you feel it isn't worth it.

This adds an English dictionary command using the [Owlbot API](https://owlbot.info/). I've been testing it for a few days now and while it has some quirks it produces good output in a majority of cases. However, sometimes it does produce improper output -- for example:
![Bad output example 1](https://user-images.githubusercontent.com/56809242/117896666-e3efe680-b275-11eb-8ddc-9e59a7fc5b46.png)
![Bad output example 2](https://user-images.githubusercontent.com/56809242/117896683-f10cd580-b275-11eb-9173-0ca6eba0c550.png)

I will say though that out of the dozens of words I have tried with it that's the very worst that has happened, typically it produces reasonable definitions, as an example:
![Definition of owl](https://user-images.githubusercontent.com/56809242/117896730-14378500-b276-11eb-97b0-56494db6bdaa.png)
![Definition of maligned](https://user-images.githubusercontent.com/56809242/117896762-1f8ab080-b276-11eb-9d22-be8d299f8152.png)

It does require an API key to use, but there are no limitations or bullshit required to sign up (just an email address, which they email the key to immediately). It's also completely free, and is the only dictionary API of this type I've found.