### PR TITLE
templates: add reQuoteMeta func to escape metachars

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -53,6 +53,9 @@ var (
 		"println":     withOutputLimit(fmt.Sprintln, MaxStringLength),
 		"printf":      withOutputLimitF(fmt.Sprintf, MaxStringLength),
 
+		// regexp
+		"reQuoteMeta": regexp.QuoteMeta,
+
 		// math
 		"add":        add,
 		"cbrt":       tmplCbrt,


### PR DESCRIPTION
Make `regexp.QuoteMeta` accessible in templates.
Often users want to embed strings into regexps to be matched literally (i.e. a server prefix), currently they have to do one of two things: use `\Q...\E`, or escape all metacharacters using `reReplace`. Both are easy to get wrong: it's easy to overlook an important detail when using the former approach or forget a metacharacter when using the latter.