### PR TITLE
reminders: add -channel flag to set reminder channel

### DIFF
--- a/reminders/plugin_bot.go
+++ b/reminders/plugin_bot.go
@@ -14,6 +14,7 @@ import (
 	seventsmodels "github.com/botlabs-gg/yagpdb/v2/common/scheduledevents2/models"
 	"github.com/botlabs-gg/yagpdb/v2/lib/dcmd"
 	"github.com/botlabs-gg/yagpdb/v2/lib/discordgo"
+	"github.com/botlabs-gg/yagpdb/v2/lib/dstate"
 	"github.com/jinzhu/gorm"
 )
 
@@ -44,6 +45,9 @@ var cmds = []*commands.YAGCommand{
 			{Name: "Time", Type: &commands.DurationArg{}},
 			{Name: "Message", Type: dcmd.String},
 		},
+		ArgSwitches: []*dcmd.ArgDef{
+			{Name: "channel", Type: dcmd.Channel},
+		},
 		SlashCommandEnabled: true,
 		DefaultEnabled:      true,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
@@ -62,7 +66,21 @@ var cmds = []*commands.YAGCommand{
 				return "Can be max 365 days from now...", nil
 			}
 
-			_, err := NewReminder(parsed.Author.ID, parsed.GuildData.GS.ID, parsed.ChannelID, parsed.Args[1].Str(), when)
+			id := parsed.ChannelID
+			if c := parsed.Switch("channel"); c.Value != nil {
+				id = c.Value.(*dstate.ChannelState).ID
+
+				hasPerms, err := bot.AdminOrPermMS(parsed.GuildData.GS.ID, id, parsed.GuildData.MS, discordgo.PermissionSendMessages|discordgo.PermissionReadMessages)
+				if err != nil {
+					return "Failed checking permissions, please try again or join the support server.", err
+				}
+
+				if !hasPerms {
+					return "You do not have permissions to send messages there", nil
+				}
+			}
+
+			_, err := NewReminder(parsed.Author.ID, parsed.GuildData.GS.ID, id, parsed.Args[1].Str(), when)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Allow users to set the channel in which their reminder is sent, provided they have read and send message permission in said channel.
This was a user suggestion on the server, also fixes #953.
Works fine on selfhost.