### PR TITLE
templates: improve randInt error when start >= stop

### DIFF
--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -665,7 +665,7 @@ func roleIsAbove(a, b *discordgo.Role) bool {
 	return common.IsRoleAbove(a, b)
 }
 
-func randInt(args ...interface{}) int {
+func randInt(args ...interface{}) (int, error) {
 	min := int64(0)
 	max := int64(10)
 	if len(args) >= 2 {
@@ -675,8 +675,13 @@ func randInt(args ...interface{}) int {
 		max = ToInt64(args[0])
 	}
 
-	r := rand.Int63n(max - min)
-	return int(r + min)
+	diff := max - min
+	if diff <= 0 {
+		return 0, errors.New("start must be strictly less than stop")
+	}
+
+	r := rand.Int63n(diff)
+	return int(r + min), nil
 }
 
 func tmplRound(args ...interface{}) float64 {


### PR DESCRIPTION
A rather cryptic error pops up when you run `randInt a b` where `a >= b`: `invalid argument to Int63n`. Improve it a bit so that the error is easier to understand without needing to look through Go docs for what `Int63n` is.