### PR TITLE
commands: add user required perms to help embed

### DIFF
--- a/commands/help.go
+++ b/commands/help.go
@@ -43,8 +43,37 @@ func cmdFuncHelp(data *dcmd.Data) (interface{}, error) {
 			return CmdNotFound(target), nil
 		}
 
-		// Send short help in same channel
-		return resp, nil
+		// see if we can find the permissions the command needs and add that info to the help message
+		cmd, _ := data.ContainerChain[0].AbsFindCommand(target)
+		if cmd == nil {
+			return resp, nil
+		}
+
+		yc, ok := cmd.Command.(*YAGCommand)
+		if !ok {
+			return resp, nil
+		}
+
+		if len(yc.RequireDiscordPerms) == 0 && yc.RequiredDiscordPermsHelp == "" {
+			return resp, nil
+		}
+
+		requiredPerms := yc.RequiredDiscordPermsHelp
+		if requiredPerms == "" {
+			humanizedPerms := make([]string, 0, len(yc.RequireDiscordPerms))
+			for _, v := range yc.RequireDiscordPerms {
+				h := common.HumanizePermissions(v)
+				joined := strings.Join(h, " and ")
+				humanizedPerms = append(humanizedPerms, "("+joined+")")
+			}
+			requiredPerms = strings.Join(humanizedPerms, " or ")
+		}
+
+		embed := resp[0]
+		embed.Footer = &discordgo.MessageEmbedFooter{
+			Text: "Required permissions: " + requiredPerms,
+		}
+		return embed, nil
 	}
 
 	// Send full help in DM

--- a/commands/help.go
+++ b/commands/help.go
@@ -63,8 +63,12 @@ func cmdFuncHelp(data *dcmd.Data) (interface{}, error) {
 			humanizedPerms := make([]string, 0, len(yc.RequireDiscordPerms))
 			for _, v := range yc.RequireDiscordPerms {
 				h := common.HumanizePermissions(v)
-				joined := strings.Join(h, " and ")
-				humanizedPerms = append(humanizedPerms, "("+joined+")")
+				if len(h) == 1 {
+					humanizedPerms = append(humanizedPerms, h[0])
+				} else {
+					joined := strings.Join(h, " and ")
+					humanizedPerms = append(humanizedPerms, "("+joined+")")
+				}
 			}
 			requiredPerms = strings.Join(humanizedPerms, " or ")
 		}

--- a/commands/yagcommmand.go
+++ b/commands/yagcommmand.go
@@ -111,8 +111,9 @@ type YAGCommand struct {
 	RunInDM      bool // Set to enable this commmand in DM's
 	HideFromHelp bool // Set to hide from help
 
-	RequireDiscordPerms []int64   // Require users to have one of these permission sets to run the command
-	RequireBotPerms     [][]int64 // Discord permissions that the bot needs to run the command, (([0][0] && [0][1] && [0][2]) || ([1][0] && [1][1]...))
+	RequireDiscordPerms      []int64   // Require users to have one of these permission sets to run the command
+	RequiredDiscordPermsHelp string    // Optional message that shows up when users run the help command that documents user permission requirements for the command
+	RequireBotPerms          [][]int64 // Discord permissions that the bot needs to run the command, (([0][0] && [0][1] && [0][2]) || ([1][0] && [1][1]...))
 
 	Middlewares []dcmd.MiddleWareFunc
 

--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -135,9 +135,10 @@ var ModerationCommands = []*commands.YAGCommand{
 			{Name: "d", Help: "Duration", Type: &commands.DurationArg{}, Default: time.Duration(0)},
 			{Name: "ddays", Help: "Delete Days", Type: dcmd.Int},
 		},
-		RequireBotPerms:     [][]int64{{discordgo.PermissionAdministrator}, {discordgo.PermissionManageServer}, {discordgo.PermissionBanMembers}},
-		SlashCommandEnabled: true,
-		DefaultEnabled:      false,
+		RequiredDiscordPermsHelp: "(BanMembers) or (ManageServer)",
+		RequireBotPerms:          [][]int64{{discordgo.PermissionAdministrator}, {discordgo.PermissionManageServer}, {discordgo.PermissionBanMembers}},
+		SlashCommandEnabled:      true,
+		DefaultEnabled:           false,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 			config, target, err := MBaseCmd(parsed, parsed.Args[0].Int64())
 			if err != nil {
@@ -181,9 +182,10 @@ var ModerationCommands = []*commands.YAGCommand{
 			{Name: "User", Type: dcmd.UserID},
 			{Name: "Reason", Type: dcmd.String},
 		},
-		RequireBotPerms:     [][]int64{{discordgo.PermissionAdministrator}, {discordgo.PermissionManageServer}, {discordgo.PermissionBanMembers}},
-		SlashCommandEnabled: true,
-		DefaultEnabled:      false,
+		RequiredDiscordPermsHelp: "(BanMembers) or (ManageServer)",
+		RequireBotPerms:          [][]int64{{discordgo.PermissionAdministrator}, {discordgo.PermissionManageServer}, {discordgo.PermissionBanMembers}},
+		SlashCommandEnabled:      true,
+		DefaultEnabled:           false,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 			config, _, err := MBaseCmd(parsed, 0) //No need to check member role hierarchy as banned members should not be in server
 			if err != nil {
@@ -228,12 +230,12 @@ var ModerationCommands = []*commands.YAGCommand{
 			{Name: "User", Type: dcmd.UserID},
 			{Name: "Reason", Type: dcmd.String},
 		},
+		RequiredDiscordPermsHelp: "(KickMembers) or (ManageServer)",
 		ArgSwitches: []*dcmd.ArgDef{
 			{Name: "cl", Help: "Messages to delete", Type: &dcmd.IntArg{Min: 1, Max: 100}},
 		},
 		RequireBotPerms:     [][]int64{{discordgo.PermissionAdministrator}, {discordgo.PermissionManageServer}, {discordgo.PermissionKickMembers}},
 		SlashCommandEnabled: true,
-		DefaultEnabled:      false,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 			config, target, err := MBaseCmd(parsed, parsed.Args[0].Int64())
 			if err != nil {
@@ -278,10 +280,11 @@ var ModerationCommands = []*commands.YAGCommand{
 			{Name: "Duration", Type: &commands.DurationArg{}},
 			{Name: "Reason", Type: dcmd.String},
 		},
-		RequireBotPerms:     [][]int64{{discordgo.PermissionAdministrator}, {discordgo.PermissionManageServer}, {discordgo.PermissionManageRoles}},
-		ArgumentCombos:      [][]int{{0, 1, 2}, {0, 2, 1}, {0, 1}, {0, 2}, {0}},
-		SlashCommandEnabled: true,
-		DefaultEnabled:      false,
+		RequiredDiscordPermsHelp: "(KickMembers) or (ManageServer)",
+		RequireBotPerms:          [][]int64{{discordgo.PermissionAdministrator}, {discordgo.PermissionManageServer}, {discordgo.PermissionManageRoles}},
+		ArgumentCombos:           [][]int{{0, 1, 2}, {0, 2, 1}, {0, 1}, {0, 2}, {0}},
+		SlashCommandEnabled:      true,
+		DefaultEnabled:           false,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 			config, target, err := MBaseCmd(parsed, parsed.Args[0].Int64())
 			if err != nil {
@@ -336,9 +339,10 @@ var ModerationCommands = []*commands.YAGCommand{
 			{Name: "User", Type: dcmd.UserID},
 			{Name: "Reason", Type: dcmd.String},
 		},
-		RequireBotPerms:     [][]int64{{discordgo.PermissionAdministrator}, {discordgo.PermissionManageServer}, {discordgo.PermissionManageRoles}},
-		SlashCommandEnabled: true,
-		DefaultEnabled:      false,
+		RequiredDiscordPermsHelp: "(KickMembers) or (ManageServer)",
+		RequireBotPerms:          [][]int64{{discordgo.PermissionAdministrator}, {discordgo.PermissionManageServer}, {discordgo.PermissionManageRoles}},
+		SlashCommandEnabled:      true,
+		DefaultEnabled:           false,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 			config, target, err := MBaseCmd(parsed, parsed.Args[0].Int64())
 			if err != nil {
@@ -471,10 +475,11 @@ var ModerationCommands = []*commands.YAGCommand{
 			{Name: "a", Help: "Only remove messages with attachments"},
 			{Name: "to", Help: "Stop at this msg ID", Type: dcmd.BigInt},
 		},
-		RequireBotPerms:     [][]int64{{discordgo.PermissionAdministrator}, {discordgo.PermissionManageServer}, {discordgo.PermissionManageMessages}},
-		ArgumentCombos:      [][]int{{0}, {0, 1}, {1, 0}},
-		SlashCommandEnabled: true,
-		DefaultEnabled:      false,
+		RequiredDiscordPermsHelp: "(ManageMessages) or (ManageServer)",
+		RequireBotPerms:          [][]int64{{discordgo.PermissionAdministrator}, {discordgo.PermissionManageServer}, {discordgo.PermissionManageMessages}},
+		ArgumentCombos:           [][]int{{0}, {0, 1}, {1, 0}},
+		SlashCommandEnabled:      true,
+		DefaultEnabled:           false,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 			botMember, err := bot.GetMember(parsed.GuildData.GS.ID, common.BotUser.ID)
 			if err != nil {
@@ -594,8 +599,9 @@ var ModerationCommands = []*commands.YAGCommand{
 			{Name: "Message-ID", Type: dcmd.BigInt},
 			{Name: "Reason", Type: dcmd.String},
 		},
-		SlashCommandEnabled: true,
-		DefaultEnabled:      false,
+		RequiredDiscordPermsHelp: "(KickMembers) or (ManageServer)",
+		SlashCommandEnabled:      true,
+		DefaultEnabled:           false,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 			config, _, err := MBaseCmd(parsed, 0)
 			if err != nil {
@@ -644,8 +650,9 @@ var ModerationCommands = []*commands.YAGCommand{
 			{Name: "User", Type: dcmd.UserID},
 			{Name: "Reason", Type: dcmd.String},
 		},
-		SlashCommandEnabled: true,
-		DefaultEnabled:      false,
+		RequiredDiscordPermsHelp: "(ManageMessages) or (ManageServer)",
+		SlashCommandEnabled:      true,
+		DefaultEnabled:           false,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 			config, target, err := MBaseCmd(parsed, parsed.Args[0].Int64())
 			if err != nil {
@@ -682,8 +689,9 @@ var ModerationCommands = []*commands.YAGCommand{
 		ArgSwitches: []*dcmd.ArgDef{
 			{Name: "id", Help: "Warning ID", Type: dcmd.Int},
 		},
-		SlashCommandEnabled: true,
-		DefaultEnabled:      false,
+		RequiredDiscordPermsHelp: "(ManageMessages) or (ManageServer)",
+		SlashCommandEnabled:      true,
+		DefaultEnabled:           false,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 			var err error
 			config, _, err := MBaseCmd(parsed, 0)
@@ -733,8 +741,9 @@ var ModerationCommands = []*commands.YAGCommand{
 			{Name: "Id", Type: dcmd.Int},
 			{Name: "NewMessage", Type: dcmd.String},
 		},
-		SlashCommandEnabled: true,
-		DefaultEnabled:      false,
+		RequiredDiscordPermsHelp: "(ManageMessages) or (ManageServer)",
+		SlashCommandEnabled:      true,
+		DefaultEnabled:           false,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 			config, _, err := MBaseCmd(parsed, 0)
 			if err != nil {
@@ -766,8 +775,9 @@ var ModerationCommands = []*commands.YAGCommand{
 		Arguments: []*dcmd.ArgDef{
 			{Name: "Id", Type: dcmd.Int},
 		},
-		SlashCommandEnabled: true,
-		DefaultEnabled:      false,
+		RequiredDiscordPermsHelp: "(ManageMessages) or (ManageServer)",
+		SlashCommandEnabled:      true,
+		DefaultEnabled:           false,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 			config, _, err := MBaseCmd(parsed, 0)
 			if err != nil {
@@ -797,8 +807,9 @@ var ModerationCommands = []*commands.YAGCommand{
 		Arguments: []*dcmd.ArgDef{
 			{Name: "User", Type: dcmd.UserID},
 		},
-		SlashCommandEnabled: true,
-		DefaultEnabled:      false,
+		RequiredDiscordPermsHelp: "(ManageMessages) or (ManageServer)",
+		SlashCommandEnabled:      true,
+		DefaultEnabled:           false,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 
 			config, _, err := MBaseCmd(parsed, 0)
@@ -828,8 +839,9 @@ var ModerationCommands = []*commands.YAGCommand{
 		ArgSwitches: []*dcmd.ArgDef{
 			{Name: "id", Help: "List userIDs"},
 		},
-		SlashCommandEnabled: true,
-		DefaultEnabled:      false,
+		RequiredDiscordPermsHelp: "(ManageMessages) or (ManageServer)",
+		SlashCommandEnabled:      true,
+		DefaultEnabled:           false,
 		RunFunc: paginatedmessages.PaginatedCommand(0, func(parsed *dcmd.Data, p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
 
 			showUserIDs := false
@@ -899,9 +911,10 @@ var ModerationCommands = []*commands.YAGCommand{
 		ArgSwitches: []*dcmd.ArgDef{
 			{Name: "d", Default: time.Duration(0), Help: "Duration", Type: &commands.DurationArg{}},
 		},
-		RequireBotPerms:     [][]int64{{discordgo.PermissionAdministrator}, {discordgo.PermissionManageServer}, {discordgo.PermissionManageRoles}},
-		SlashCommandEnabled: true,
-		DefaultEnabled:      false,
+		RequiredDiscordPermsHelp: "(ManageRoles) or (ManageServer)",
+		RequireBotPerms:          [][]int64{{discordgo.PermissionAdministrator}, {discordgo.PermissionManageServer}, {discordgo.PermissionManageRoles}},
+		SlashCommandEnabled:      true,
+		DefaultEnabled:           false,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 			config, target, err := MBaseCmd(parsed, parsed.Args[0].Int64())
 			if err != nil {
@@ -974,9 +987,10 @@ var ModerationCommands = []*commands.YAGCommand{
 			{Name: "User", Type: dcmd.UserID},
 			{Name: "Role", Type: dcmd.String},
 		},
-		RequireBotPerms:     [][]int64{{discordgo.PermissionAdministrator}, {discordgo.PermissionManageServer}, {discordgo.PermissionManageRoles}},
-		SlashCommandEnabled: true,
-		DefaultEnabled:      false,
+		RequiredDiscordPermsHelp: "(ManageRoles) or (ManageServer)",
+		RequireBotPerms:          [][]int64{{discordgo.PermissionAdministrator}, {discordgo.PermissionManageServer}, {discordgo.PermissionManageRoles}},
+		SlashCommandEnabled:      true,
+		DefaultEnabled:           false,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 			config, target, err := MBaseCmd(parsed, parsed.Args[0].Int64())
 			if err != nil {

--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -135,7 +135,7 @@ var ModerationCommands = []*commands.YAGCommand{
 			{Name: "d", Help: "Duration", Type: &commands.DurationArg{}, Default: time.Duration(0)},
 			{Name: "ddays", Help: "Delete Days", Type: dcmd.Int},
 		},
-		RequiredDiscordPermsHelp: "(BanMembers) or (ManageServer)",
+		RequiredDiscordPermsHelp: "BanMembers or ManageServer",
 		RequireBotPerms:          [][]int64{{discordgo.PermissionAdministrator}, {discordgo.PermissionManageServer}, {discordgo.PermissionBanMembers}},
 		SlashCommandEnabled:      true,
 		DefaultEnabled:           false,
@@ -182,7 +182,7 @@ var ModerationCommands = []*commands.YAGCommand{
 			{Name: "User", Type: dcmd.UserID},
 			{Name: "Reason", Type: dcmd.String},
 		},
-		RequiredDiscordPermsHelp: "(BanMembers) or (ManageServer)",
+		RequiredDiscordPermsHelp: "BanMembers or ManageServer",
 		RequireBotPerms:          [][]int64{{discordgo.PermissionAdministrator}, {discordgo.PermissionManageServer}, {discordgo.PermissionBanMembers}},
 		SlashCommandEnabled:      true,
 		DefaultEnabled:           false,
@@ -230,7 +230,7 @@ var ModerationCommands = []*commands.YAGCommand{
 			{Name: "User", Type: dcmd.UserID},
 			{Name: "Reason", Type: dcmd.String},
 		},
-		RequiredDiscordPermsHelp: "(KickMembers) or (ManageServer)",
+		RequiredDiscordPermsHelp: "KickMembers or ManageServer",
 		ArgSwitches: []*dcmd.ArgDef{
 			{Name: "cl", Help: "Messages to delete", Type: &dcmd.IntArg{Min: 1, Max: 100}},
 		},
@@ -280,7 +280,7 @@ var ModerationCommands = []*commands.YAGCommand{
 			{Name: "Duration", Type: &commands.DurationArg{}},
 			{Name: "Reason", Type: dcmd.String},
 		},
-		RequiredDiscordPermsHelp: "(KickMembers) or (ManageServer)",
+		RequiredDiscordPermsHelp: "KickMembers or ManageServer",
 		RequireBotPerms:          [][]int64{{discordgo.PermissionAdministrator}, {discordgo.PermissionManageServer}, {discordgo.PermissionManageRoles}},
 		ArgumentCombos:           [][]int{{0, 1, 2}, {0, 2, 1}, {0, 1}, {0, 2}, {0}},
 		SlashCommandEnabled:      true,
@@ -339,7 +339,7 @@ var ModerationCommands = []*commands.YAGCommand{
 			{Name: "User", Type: dcmd.UserID},
 			{Name: "Reason", Type: dcmd.String},
 		},
-		RequiredDiscordPermsHelp: "(KickMembers) or (ManageServer)",
+		RequiredDiscordPermsHelp: "KickMembers or ManageServer",
 		RequireBotPerms:          [][]int64{{discordgo.PermissionAdministrator}, {discordgo.PermissionManageServer}, {discordgo.PermissionManageRoles}},
 		SlashCommandEnabled:      true,
 		DefaultEnabled:           false,
@@ -475,7 +475,7 @@ var ModerationCommands = []*commands.YAGCommand{
 			{Name: "a", Help: "Only remove messages with attachments"},
 			{Name: "to", Help: "Stop at this msg ID", Type: dcmd.BigInt},
 		},
-		RequiredDiscordPermsHelp: "(ManageMessages) or (ManageServer)",
+		RequiredDiscordPermsHelp: "ManageMessages or ManageServer",
 		RequireBotPerms:          [][]int64{{discordgo.PermissionAdministrator}, {discordgo.PermissionManageServer}, {discordgo.PermissionManageMessages}},
 		ArgumentCombos:           [][]int{{0}, {0, 1}, {1, 0}},
 		SlashCommandEnabled:      true,
@@ -599,7 +599,7 @@ var ModerationCommands = []*commands.YAGCommand{
 			{Name: "Message-ID", Type: dcmd.BigInt},
 			{Name: "Reason", Type: dcmd.String},
 		},
-		RequiredDiscordPermsHelp: "(KickMembers) or (ManageServer)",
+		RequiredDiscordPermsHelp: "KickMembers or ManageServer",
 		SlashCommandEnabled:      true,
 		DefaultEnabled:           false,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
@@ -650,7 +650,7 @@ var ModerationCommands = []*commands.YAGCommand{
 			{Name: "User", Type: dcmd.UserID},
 			{Name: "Reason", Type: dcmd.String},
 		},
-		RequiredDiscordPermsHelp: "(ManageMessages) or (ManageServer)",
+		RequiredDiscordPermsHelp: "ManageMessages or ManageServer",
 		SlashCommandEnabled:      true,
 		DefaultEnabled:           false,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
@@ -689,7 +689,7 @@ var ModerationCommands = []*commands.YAGCommand{
 		ArgSwitches: []*dcmd.ArgDef{
 			{Name: "id", Help: "Warning ID", Type: dcmd.Int},
 		},
-		RequiredDiscordPermsHelp: "(ManageMessages) or (ManageServer)",
+		RequiredDiscordPermsHelp: "ManageMessages or ManageServer",
 		SlashCommandEnabled:      true,
 		DefaultEnabled:           false,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
@@ -741,7 +741,7 @@ var ModerationCommands = []*commands.YAGCommand{
 			{Name: "Id", Type: dcmd.Int},
 			{Name: "NewMessage", Type: dcmd.String},
 		},
-		RequiredDiscordPermsHelp: "(ManageMessages) or (ManageServer)",
+		RequiredDiscordPermsHelp: "ManageMessages or ManageServer",
 		SlashCommandEnabled:      true,
 		DefaultEnabled:           false,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
@@ -775,7 +775,7 @@ var ModerationCommands = []*commands.YAGCommand{
 		Arguments: []*dcmd.ArgDef{
 			{Name: "Id", Type: dcmd.Int},
 		},
-		RequiredDiscordPermsHelp: "(ManageMessages) or (ManageServer)",
+		RequiredDiscordPermsHelp: "ManageMessages or ManageServer",
 		SlashCommandEnabled:      true,
 		DefaultEnabled:           false,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
@@ -807,7 +807,7 @@ var ModerationCommands = []*commands.YAGCommand{
 		Arguments: []*dcmd.ArgDef{
 			{Name: "User", Type: dcmd.UserID},
 		},
-		RequiredDiscordPermsHelp: "(ManageMessages) or (ManageServer)",
+		RequiredDiscordPermsHelp: "ManageMessages or ManageServer",
 		SlashCommandEnabled:      true,
 		DefaultEnabled:           false,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
@@ -839,7 +839,7 @@ var ModerationCommands = []*commands.YAGCommand{
 		ArgSwitches: []*dcmd.ArgDef{
 			{Name: "id", Help: "List userIDs"},
 		},
-		RequiredDiscordPermsHelp: "(ManageMessages) or (ManageServer)",
+		RequiredDiscordPermsHelp: "ManageMessages or ManageServer",
 		SlashCommandEnabled:      true,
 		DefaultEnabled:           false,
 		RunFunc: paginatedmessages.PaginatedCommand(0, func(parsed *dcmd.Data, p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
@@ -911,7 +911,7 @@ var ModerationCommands = []*commands.YAGCommand{
 		ArgSwitches: []*dcmd.ArgDef{
 			{Name: "d", Default: time.Duration(0), Help: "Duration", Type: &commands.DurationArg{}},
 		},
-		RequiredDiscordPermsHelp: "(ManageRoles) or (ManageServer)",
+		RequiredDiscordPermsHelp: "ManageRoles or ManageServer",
 		RequireBotPerms:          [][]int64{{discordgo.PermissionAdministrator}, {discordgo.PermissionManageServer}, {discordgo.PermissionManageRoles}},
 		SlashCommandEnabled:      true,
 		DefaultEnabled:           false,
@@ -987,7 +987,7 @@ var ModerationCommands = []*commands.YAGCommand{
 			{Name: "User", Type: dcmd.UserID},
 			{Name: "Role", Type: dcmd.String},
 		},
-		RequiredDiscordPermsHelp: "(ManageRoles) or (ManageServer)",
+		RequiredDiscordPermsHelp: "ManageRoles or ManageServer",
 		RequireBotPerms:          [][]int64{{discordgo.PermissionAdministrator}, {discordgo.PermissionManageServer}, {discordgo.PermissionManageRoles}},
 		SlashCommandEnabled:      true,
 		DefaultEnabled:           false,


### PR DESCRIPTION
Document user permission requirements for commands in the `help` response.

Defaults to using a new optional field on `YAGCommand` and falls back to generating a message based on the `RequireDiscordPerms` field.