### PR TITLE
remindme: Add codeblock to command response

### DIFF
--- a/reminders/plugin_bot.go
+++ b/reminders/plugin_bot.go
@@ -67,7 +67,7 @@ var cmds = []*commands.YAGCommand{
 				return nil, err
 			}
 
-			return "Set a reminder in " + durString + " from now (" + tStr + ")\nView reminders with the reminders command", nil
+			return "Set a reminder in " + durString + " from now (" + tStr + ")\nView reminders with the `Reminders` command", nil
 		},
 	},
 	{


### PR DESCRIPTION
This should make `Reminders` command easier to find, inside the response message. Also, I've converted it to *Title Case*
I didn't test these changes on a selfhost, but they should work

Should I add Markdown to any other parts? For example, something like this:
> Set a reminder in **2 hours and 16 minutes** from now (`23 Jul 21 21:59 UTC`)