### PR TITLE
commands: add a note explaining the effects of prefix change on flags

### DIFF
--- a/commands/assets/commands.html
+++ b/commands/assets/commands.html
@@ -60,7 +60,7 @@
                                 <div class="form-group">
                                     <label for="prefix">Command Prefix<br><b>Note: Changing the prefix does not change the flag usage in commands. They will still begin with <code>-</code></b></label>
                                     <div class="row-lg-6">
-                                        <p id="example-command-usage">Example command usage: <code>{{.CommandPrefix}}clean 10 -nopin</code></p>
+                                        <p id="example-command-usage">Example command usage: <code>{{.CommandPrefix}}rolemenu create &lt;name&gt; -nodm</code></p>
                                     </div>
                                     <input type="text" class="form-control" id="prefix" name="Prefix"
                                         value="{{.CommandPrefix}}">

--- a/commands/assets/commands.html
+++ b/commands/assets/commands.html
@@ -130,7 +130,7 @@
 	function handlePrefixChange(prefix) {
 		if (prefix.length === 0) return;
 
-		$("#example-command-usage > code").text(`${prefix}ping`);
+		$("#example-command-usage > code").text(`${prefix}rolemenu create <name> -nodm`);
 
 		const existingWarning = $("#trailing-space-warning");
 		if (prefix[prefix.length - 1] === " ") {

--- a/commands/assets/commands.html
+++ b/commands/assets/commands.html
@@ -58,9 +58,9 @@
                         <div class="row">
                             <div class="col-lg-6">
                                 <div class="form-group">
-                                    <label for="prefix">Command Prefix</label>
+                                    <label for="prefix">Command Prefix<br><b>Note: Changing the prefix does not change the flag usage in commands. They will still begin with <code>-</code></b></label>
                                     <div class="row-lg-6">
-                                        <p id="example-command-usage">Example command usage: <code>{{.CommandPrefix}}ping</code></p>
+                                        <p id="example-command-usage">Example command usage: <code>{{.CommandPrefix}}clean 10 -nopin</code></p>
                                     </div>
                                     <input type="text" class="form-control" id="prefix" name="Prefix"
                                         value="{{.CommandPrefix}}">


### PR DESCRIPTION
Users often get confused and think flags also change along with the prefix. This PR adds a note talking about this, and also uses `rolemenu create` instead of `ping` in the example, to show the usage of flags with the user's set prefix.


![image](https://user-images.githubusercontent.com/67655446/127734824-355ed1b6-1022-4067-92c7-5270c5b52d6a.png)