### PR TITLE
stdcommands: fix a typo in wyr and increase favicon size

### DIFF
--- a/stdcommands/wouldyourather/wouldyourather.go
+++ b/stdcommands/wouldyourather/wouldyourather.go
@@ -26,11 +26,11 @@ var Command = &commands.YAGCommand{
 		}
 
 		embed := &discordgo.MessageEmbed{
-			Description: fmt.Sprintf("**EITHER...**\n🇦: %s\n\n**OR...**\n🇧 %s", q1, q2),
+			Description: fmt.Sprintf("**EITHER...**\n🇦 %s\n\n**OR...**\n🇧 %s", q1, q2),
 			Author: &discordgo.MessageEmbedAuthor{
 				Name:    "Would you rather...",
 				URL:     "https://either.io/",
-				IconURL: "https://yagpdb.xyz/static/icons/favicon-16x16.png",
+				IconURL: "https://yagpdb.xyz/static/icons/favicon-32x32.png",
 			},
 			Footer: &discordgo.MessageEmbedFooter{
 				Text:    fmt.Sprintf("Requested by: %s#%s", data.Author.Username, data.Author.Discriminator),


### PR DESCRIPTION
As title states.

There was/is a small typo in the would-you-rather prompt, namely one colon too much.
Also using this opportunity to increase the favicon size used for the author icon, as it is a little blurry standing now.