### PR TITLE
ccs: add CCID to rune count error response

### DIFF
--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -730,7 +730,7 @@ func ExecuteCustomCommand(cmd *models.CustomCommand, tmplCtx *templates.Context)
 	out, err := tmplCtx.Execute(chanMsg)
 
 	if utf8.RuneCountInString(out) > 2000 {
-		out = "Custom command response was longer than 2k (contact an admin on the server...)"
+		out = "Custom command (#" + discordgo.StrID(cmd.LocalID) + ") response was longer than 2k (contact an admin on the server...)"
 	}
 
 	go updatePostCommandRan(cmd, err)


### PR DESCRIPTION
This PR adds the CCID to the error message when rune count is bigger than 2k

![image](https://user-images.githubusercontent.com/3849946/128928980-04110726-6e8c-4700-b6e9-3436eae6c61e.png)
