### PR TITLE
Spelling correction in comment.

### DIFF
--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -704,7 +704,7 @@ func ExecuteCustomCommand(cmd *models.CustomCommand, tmplCtx *templates.Context)
 		"channel_name": csCop.Name,
 	})
 
-	// do not allow concurrect executions of the same custom command, to prevent most common kinds of abuse
+	// do not allow concurrent executions of the same custom command, to prevent most common kinds of abuse
 	lockKey := CCExecKey{
 		GuildID: cmd.GuildID,
 		CCID:    cmd.LocalID,


### PR DESCRIPTION
Concurrect is not a word.
Concurrent is. And used in several other comments, and should be searchable.