### PR TITLE
stdcommands/roll: make command case insensitive

### DIFF
--- a/stdcommands/roll/roll.go
+++ b/stdcommands/roll/roll.go
@@ -25,7 +25,7 @@ var Command = &commands.YAGCommand{
 	RunFunc: func(data *dcmd.Data) (interface{}, error) {
 		if data.Args[1].Value != nil {
 			// Special dice syntax if string
-			r, _, err := dice.Roll(data.Args[1].Str())
+			r, _, err := dice.Roll(strings.ToLower(data.Args[1].Str()))
 			if err != nil {
 				return err.Error(), nil
 			}


### PR DESCRIPTION
As title states -- sometimes users use uppercase letters for their RPG-format and receiving an error over case sensitivity is not a good experience.

The screenshot showcases the behaviour:
![image](https://user-images.githubusercontent.com/71897876/132129104-e641c992-c4de-4272-9155-ef3d1e28b3c2.png)

Thanks in advance!