### PR TITLE
web: use bigints for channel permissions

### DIFF
--- a/frontend/static/js/spongebob.js
+++ b/frontend/static/js/spongebob.js
@@ -343,15 +343,15 @@ function initPlugins(partial) {
 var discordPermissions = {
 	read: {
 		name: "Read Messages",
-		perm: 0x400
+		perm: BigInt(0x400),
 	},
 	send: {
 		name: "Send Messages",
-		perm: 0x800
+		perm: BigInt(0x800),
 	},
 	embed: {
 		name: "Embed Links",
-		perm: 0x4000
+		perm: BigInt(0x4000),
 	},
 }
 var cachedChannelPerms = {};
@@ -422,7 +422,7 @@ function validateChannelDropdown(dropdown, currentElem, channel, perms) {
 				return;
 			}
 
-			var channelPerms = parseInt(this.responseText);
+			var channelPerms = BigInt(this.responseText);
 			cachedChannelPerms[channel].perms = channelPerms;
 			cachedChannelPerms[channel].lastChecked = Date.now();
 


### PR DESCRIPTION
Use bigints for channel permissions, as discussed on Discord. This fixes the issue where the control panel claims that YAGPDB's missing some permissions despite it actually having said permissions.

Tested on a few control panel pages with various bot permissions on selfhost, and it appears to work fine.