### PR TITLE
Added case "image" to createMessageSend declaration so yag can post l…

### DIFF
--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -244,7 +244,7 @@ func CreateMessageSend(values ...interface{}) (*discordgo.MessageSend, error) {
 
 		case "image":
 			if val == nil {
-				return nil, errors.New("need an arguement for the image")
+				return nil, errors.New("need an argument for the image")
 			}
 			str := fmt.Sprint(val)
 			img, err := http.Get(str)

--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"math"
 	"math/rand"
 	"reflect"
@@ -240,6 +241,29 @@ func CreateMessageSend(values ...interface{}) (*discordgo.MessageSend, error) {
 				ContentType: "text/plain",
 				Reader:      &buf,
 			}
+
+		case "image":
+			if val == nil {
+				return nil, errors.New("need an arguement for the image")
+			}
+			str := fmt.Sprint(val)
+			img, err := http.Get(str)
+			if err != nil {
+				return nil, errors.New("error while trying to get the image")
+			}
+
+			imageName := "image.png"
+			imageType := "image/png"
+			if strings.HasSuffix(strings.ToLower(str), ".gif") {
+				imageName = "image.gif"
+				imageType = "image/gif"
+			}
+			msg.File = &discordgo.File{
+				Name: imageName,
+				ContentType: imageType,
+				Reader: img.Body,
+			}
+
 		default:
 			return nil, errors.New(`invalid key "` + key + `" passed to send message builder`)
 		}


### PR DESCRIPTION
This was made by @Spongerooski to make our self-host be able to post image attachments. It simply adds a new case to complexMessage, so the usage would be:
(complexMessage "image" "link") 
Yag will then post the given link as an attachment. This is useful for a lot of things, such as logging; It is also a very good work around for broken images (which happens when the attachment is deleted and you have a YAG message with it).
[Example](https://media.discordapp.net/attachments/808023716847681567/885096788468576276/AmEXUzjkGD.gif)

I hope my PR was understandable, if you have any questions please feel free to DM me in discord or ping me in the YAGPDB support server: @mangowhite#0001