### PR TITLE
Repo: Rework README and create gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Denote the vendored directory, since its name differs from
+# otherwise recognised names.
+**/vendorr/** linguist-vendored
+
+# Force batch scripts to always have CRLF line endings, so that if this repo
+# is accessed in Windows via file share from *nix, these scripts will still work.
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf
+
+# Force bash/shell scripts to always use LF line endings so that if this repo
+# is accessed in *nix via file share from Windows, these scripts will still work.
+*.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -1,25 +1,6 @@
 # YAGPDB - Yet Another General Purpose Discord Bot
 
-YAGPDB is a multifunctional, modular Discord bot. It is modular in that sense, that for most things plugins exist -- However, some plugins may depend on other plugins.
-
-## Table of Contents
-
-<details>
-<summary>Expand</summary>
-
-* [Plugins](#Plugins)
-* [Useful Links](#Useful-Links)
-* [Selfhosting](#Selfhosting)
-  - [General Setup](#General-Bot-Setup)
-  - [Dockerized](#Hosting-Dockerized)
-  - [Standalone](#Hosting-Standalone)
-    + [Requirements](#Requirements)
-    + [Setting Up](#Setting-Up)
-* [Databases](#Databases)
-  - [Updating](#Updating)
-* [Contributing](#Contributing)
-
-</details>
+YAGPDB is a multifunctional, modular Discord bot. It is modular in the sense that for most things plugins exist -- However, some plugins may depend on other plugins.
 
 ## Plugins
 
@@ -92,7 +73,7 @@ docker-compose -f yagpdb/yagpdb_docker/docker-compose.dev.yml up
 
 #### Requirements
 
-* Recent GoLang (1.16 and newer is recommended)
+* Golang 1.16 or above
 * PostgreSQL 9.6 or later
 * Redis version 3.x or later
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ YAGPDB is a multifunctional, modular Discord bot. It is modular in that sense, t
 
 ## Plugins
 
-* YouTube-Feed
-* Stream-Announcements
+* YouTube Feed
+* Stream Announcements
 * Server Stats
 * Soundboard
 * Reputation
 * Reminders
-* Reddit-Feed
+* Reddit Feed
 * Notifications
 * Moderation
 * Logs

--- a/README.md
+++ b/README.md
@@ -1,34 +1,52 @@
-YAGPDB
-================
+# YAGPDB - Yet Another General Purpose Discord Bot
 
-### Yet another general purpose discord bot
+YAGPDB is a multifunctional, modular Discord bot. It is modular in that sense, that for most things plugins exist -- However, some plugins may depend on other plugins.
 
-YAGPDB is a multifunctional, modular Discord bot. It's modular in that plugins exist for the most part on their own (with exceptions to some lazy things in the main stylesheet), some plugins do however depend on other plugins (most plugins depend on the commands plugin, for example).
+## Table of Contents
 
-**Links**
- - [YAGPDB.xyz](http://yagpdb.xyz)
- - [For updates and support join my discord server](https://discord.gg/4udtcA5)
- - [The documentation of YAGPDB](https://docs.yagpdb.xyz/)
+<details>
+<summary>Expand</summary>
 
-### Running YAGPDB yourself
+* [Plugins](#Plugins)
+* [Useful Links](#Useful-Links)
+* [Selfhosting](#Selfhosting)
+  - [General Setup](#General-Bot-Setup)
+  - [Dockerized](#Hosting-Dockerized)
+  - [Standalone](#Hosting-Standalone)
+    + [Requirements](#Requirements)
+    + [Setting Up](#Setting-Up)
+* [Databases](#Databases)
+  - [Updating](#Updating)
+* [Contributing](#Contributing)
 
-Running this bot may seem challenging, and that's because I don't have time to make it easy to run for everyone, for the most part, it should run fine after the initial work has been done. Please view [this page](https://docs.yagpdb.xyz/development/self-hosting-with-docker) for more information.
+</details>
 
-#### Updating
-Updating after v1 should migrate schemas automatically, but you should always take backups beforehand if things go wrong.
+## Plugins
 
-I will put breaking changes in the breaking_changes.md file, which you should always read before updating.
+* YouTube-Feed
+* Stream-Announcements
+* Server Stats
+* Soundboard
+* Reputation
+* Reminders
+* Reddit-Feed
+* Notifications
+* Moderation
+* Logs
+* Custom Commands
+* And More!
 
-#### There's 2 ways of running this bot
+## Useful Links
 
-1. Using Docker
-2. Standalone
+* [Homepage](https://yagpdb.xyz)
+* [Support Server](https://discord.gg/4udtcA5)
+* [Documentation](https://docs.yagpdb.xyz)
 
-**I will not help with basic problems or how to do unrelated things (how to run it on startup for example), use Google, if those well written tutorials and articles confuse you, how the hell is a guy with English as a second language gonna be any better?**
+## Selfhosting
 
-(There's still a lot of contributing you can do without this though, such as writing docs, fixing my horrible typos and so on)
+There are two ways of selfhosting this bot: [standalone](#Hosting-Standalone), or [dockerized](#Hosting-Dockerized).
 
-#### General Discord bot setup
+### General Bot Setup
 
 Directions on creating an app and getting credentials may be found
 [here](https://github.com/reactiflux/discord-irc/wiki/Creating-a-discord-bot-&-getting-a-token).
@@ -37,129 +55,82 @@ via the Control Panel.
 
 In addition, you will need to add the following urls to the bot's "REDIRECT URI(S)" configuration:
 
-- https://YourHostNameHere/confirm_login
-- https://YourHostNameHere/manage
+* <https://YourHostNameHere/confirm_login>
+* <https://YourHostNameHere/manage>
 
-#### Docker quickstart
+### Hosting Dockerized
 
-If you have docker-compose installed, it will offer the fastest route to getting
-up-and-running.
+If you have docker-compose installed, that might be the fastest route of getting the bot up and running:
 
-```bash
+```shell
 git clone https://github.com/botlabs-gg/yagpdb
 cp yagpdb/yagpdb_docker/{app.example.env,app.env}
 cp yagpdb/yagpdb_docker/{db.example.env,db.env}
 ```
 
-Edit `app.env` and `db.env` to specify the Discord bot values from above.
+Edit both env files accordingly. Make sure ports 80 and 443 are accessible on your network and that you have a proper image in `docker-compose.yml`:
 
-Make sure ports 80 and 443 are accessible on your network and launch:
-
-    docker-compose -f yagpdb/yagpdb_docker/docker-compose.yml up
-
-The bot will connect automatically and the control panel will be available via
-your host after a short setup.
-
-If you are running several bots (or other websites alongside the bot), consider
-running a proxy such as jrcs/letsencrypt-nginx-proxy-companion.
-
-First, start the proxy. This needs to be started only once and is shared by all
-websites:
-
-    docker network create proxy-tier
-    docker-compose -p proxy yagpdb/yagpdb_docker/docker-compose.proxy.yml up
-
-And then start the bot using the proxy:
-
-    docker-compose -f yagpdb/yagpdb_docker/docker-compose.proxied.yml up
-
-#### Standalone/Manual setup
-
-**Requirements**
- - Fairly recent go version (1.11 or later, I use new features as soon as they're out, so watch out in breaking_changes)
- - PostgreSQL 9.6 or later
- - Redis version 3.x or later (maybe it's possible to get it working with earlier versions, however I'm not 100% sure)
-
-I may update the bot at any point to require newer versions of any of these, so you should ALWAYS check breaking_changes before updating.
-
-**First step** is to set those up and get them running:
-
- 1. Install and configure redis and postgres with your desired settings (my DM's are not Google, you'll have to figure at least this much out on your own...)
- 2. Create a user named `yagpdb` and database named `yagpdb` which the user `yagpdb` has write access to
- 3. Update your env vars with the config (see example env file in `cmd/yagpdb/`)
- 4. Done.
-
-**Steps for building:**
-
-YAGPDB currently uses a lot of alternative branches of my projects, mainly because I also use a discordgo fork with a lot of goodies in it (why not push my changes upstream? Cause a ton of breaking changes that would never get accepted)
-
-I'm working towards making YAGPDB fully `go get ...`-able
-
-```bash
-git clone -b yagpdb https://github.com/jonas747/discordgo $GOPATH/src/github.com/jonas747/discordgo
-git clone -b dgofork https://github.com/jonas747/dutil $GOPATH/src/github.com/jonas747/dutil
-git clone -b dgofork https://github.com/jonas747/dshardmanager $GOPATH/src/github.com/jonas747/dshardmanager
-go get -v -d github.com/botlabs-gg/yagpdb/cmd/yagpdb
-cd $GOPATH/src/github.com/botlabs-gg/yagpdb/cmd/yagpdb
-go build
+```shell
+docker-compose -f yagpdb/yagpdb_docker/docker-compose.yml up
 ```
 
-After this, unless you wanna run it in testing mode using `YAGPDB_TESTING=yes` you have to run `cmd/yagpdb/copytemplates.sh` to copy all the plugin specific template files into the `cmd/yagpdb/templates/plugins` folder.
+Alternatively, you can run the bot behind a proxy:
 
-You can now run `./yagpdb`
+```shell
+docker network create proxy-tier
+docker-compose -p proxy yagpdb/yagpdb_docker/docker-compose.proxy.yml up
+docker-compose -f yagpdb/yagpdb_docker/docker-compose.proxied.yml up
+```
 
-Configuration is done through environment variables. See `cmd/yagpdb/sampleenvfile` for what environment variables are available.
+During development, use the `docker-compose.dev.yml` file:
 
-You can run the web server, bot, reddit and youtube parts as separate processes (some smallish limitations require to to run it on the same machine, will likely be removed soon as I'm gonna need to work on horizontal scaling soon)
+```shell
+docker-compose -f yagpdb/yagpdb_docker/docker-compose.dev.yml up
+```
 
-You specify `-bot` to run the bot, `-web` to run the web server, `-feeds "youtube,reddit"` to run the reddit and youtube feeds.
+### Hosting Standalone
 
-The web server by default (unless `-pa`) listens on 5000(http) and 5001(https)
-So if you're behind a NAT, forward those, if not you can either use the `-pa` switch or add an entry to iptables.
+#### Requirements
 
-### Plugins
+* Recent GoLang (1.16 and newer is recommended)
+* PostgreSQL 9.6 or later
+* Redis version 3.x or later
 
-**Standard plugins:**
+#### Setting Up
 
-* Youtube-Feed
-* Stream-announcements
-* Server Stats
-* Soundboard
-* Reputation
-* Reminder
-* Reddit-Feed
-* Notifications
-* Moderation
-* Logs
-* Custom commands
-* And More!
+Configure Redis and Postgres with your desired settings.
 
-**Planned plugins**
+In postgres, create a new user `yagpdb` and database `yagpdb` and grant that user access to that database.
 
-[See the Issues Tab for more](https://github.com/botlabs-gg/yagpdb/issues)
+Set up the environment variables with the credentials from the [general setup](#General-Bot-Setup). See the [sample env file](cmd/yagpdb/sampleenvfile) for a list of all enviroment variables.
 
-### Core packages:
+Afterwards, run the build script located at `/cmd/yagpdb/build.sh` and  start the bot using `./yagpdb`:
 
-- Web: The core web server package, in charge of authentication.
-- Bot: Core bot package, delegates events to plugins.
-- Common: Handles all the common stuff between web and bot (config, discord session, redis pool etc).
-- Feeds: Handles all feeds, personally I like to run each feed as its own service, that way I can start and stop individual feeds without taking everything down.
-- Commands: Handles all commands.
+```shell
+git clone https://github.com/botlabs-gg/yagpdb
+cd yagpdb/cmd/yagpdb
+sh build.sh
+./yagpdb -all
+```
 
-Currently, YAGPDB builds everything into one executable and you run the bot with the -bot switch, the web server with the -web switch and so on (see -h for help).
+See `./yagpdb -help` for all usable run flags. The webserver listens by default on ports 5000 (HTTP) and 5001 (HTTPS).
 
-### Databases
+## Databases
 
-YAGPDB uses redis for light data and caching (and some remnants of configuration).
+YAGPDB uses Redis for light data and caching, and postgresql for most configurations and heavy data, such as logs.
 
-It uses PostgreSQL for most configuration and more heavy data (logs and such).
+### Updating
 
-### Contributing new features
+Updating with v1 and higher should migrate schemas automatically, but you should always make backups.
+
+Breaking changes can be found in breaking_changes.md, which should always be consulted before updating.
+
+## Contributing
+
+Please view the [contributing guidelines](CONTRIBUTING.md) before submitting any contributions.
 
 See bot/plugin for info about bot plugins, web/plugin for web plugins and feeds/plugin for feeds if you wanna make a new fully fledged plugin.
 
 Expect web, bot and feed instances to be run separately.
 
 For basic utility/fun commands, you can just jam them in stdcommands. Use the existing commands there as an example of how to add one.
-
-**If you need any help finding things in the source or have any other questions, don't be afraid of messaging me.**


### PR DESCRIPTION
This pull request reworks the README and adds git attributes.

The README was quite outdated and fairly cluttered. This rewrite aims to make it easier to navigate and read. Important sections with the intention to "sell" this bot have been moved to the top to make them easier spot. Markdown syntax has been updated to be more consistent throughout the file, so that reading the raw document is becoming easier as well.
Some sections have been removed, as they are no longer true or necessary. Additionally, the step for building has been changed from `go build` to instead run the `build.sh` script to make an actually deployed version of the bot -- this has been mentioned several times to new users in `#self-hosting-discussion` on the server, so including that in the README is quite fair.

Git attributes have been introduced in an attempt to normalize line endings for certain files, e.g. shell vs. batch scripts -- these scripts can/will break if they have the wrong line ending (LF (*nix) vs. CRLF (Windows)). Moreover, because the vendored directory has a different name (`vendorr`), we tell linguist -- GitHub's language savant responsible for language statistics -- to exclude these directories from the statistic. Admittedly, a small detail, however I believe it is important, seeing that YAGPDB is in Go rather than JavaScript.

----
Seeing as this is a pull request of not small significance, please take your time to review this request as carefully as possible and do not hesitate to request changes.

Thanks in advance!
