### PR TITLE
fix not showing dm info

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -386,12 +386,23 @@ func (c *Context) SendResponse(content string) (*discordgo.Message, error) {
 	}
 
 	for _, v := range c.CurrentFrame.EmebdsToSend {
+		if c.CurrentFrame.SendResponseInDM {
+			v.Footer = &discordgo.MessageEmbedFooter{
+				Text:    "Custom Command DM from the server " + c.GS.Name,
+				IconURL: c.GS.Icon,
+			}
+		}
+
 		common.BotSession.ChannelMessageSendEmbed(channelID, v)
 	}
 
 	if strings.TrimSpace(content) == "" || (c.CurrentFrame.DelResponse && c.CurrentFrame.DelResponseDelay < 1) {
 		// no point in sending the response if it gets deleted immedietely
 		return nil, nil
+	}
+
+	if c.CurrentFrame.SendResponseInDM {
+		content = "Custom Command DM from the server **" + c.GS.Name + "**\n" + content
 	}
 
 	m, err := common.BotSession.ChannelMessageSendComplex(channelID, c.MessageSend(content))

--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -385,8 +385,10 @@ func (c *Context) SendResponse(content string) (*discordgo.Message, error) {
 		}
 	}
 
+	isDM := c.CurrentFrame.SendResponseInDM || (c.CurrentFrame.CS != nil && c.CurrentFrame.CS.IsPrivate())
+
 	for _, v := range c.CurrentFrame.EmebdsToSend {
-		if c.CurrentFrame.SendResponseInDM {
+		if isDM {
 			v.Footer = &discordgo.MessageEmbedFooter{
 				Text:    "Custom Command DM from the server " + c.GS.Name,
 				IconURL: c.GS.Icon,
@@ -401,7 +403,7 @@ func (c *Context) SendResponse(content string) (*discordgo.Message, error) {
 		return nil, nil
 	}
 
-	if c.CurrentFrame.SendResponseInDM {
+	if isDM {
 		content = "Custom Command DM from the server **" + c.GS.Name + "**\n" + content
 	}
 


### PR DESCRIPTION
Hi!

This commit https://github.com/botlabs-gg/yagpdb/commit/78dee86a0958565066fe1337b7794d2d758ea10a tried to prevent users being able to send DMs without it showing where it was from. 
It pretty much solved the issue, but there is still a way of doing it. This PR aims to fix this. 