### PR TITLE
logs: Fix unable logging threads

### DIFF
--- a/logs/logs.go
+++ b/logs/logs.go
@@ -91,7 +91,7 @@ func CreateChannelLog(ctx context.Context, config *models.GuildLoggingConfig, gu
 	}
 
 	// Make a light copy of the channel
-	channel := gs.GetChannel(channelID)
+	channel := gs.GetChannelOrThread(channelID)
 	if channel == nil {
 		return nil, errors.New("Unknown channel")
 	}


### PR DESCRIPTION
Since yag has been able to see threads, it also happens that logs were created in threads.
For the time being, this always threw an error; this pull request fixes that regression.

Attached you'll see me in a thread together with my selfhosted instance. First, the error the user sees and the error that's been logged is shown, then the fix.
![image](https://user-images.githubusercontent.com/71897876/136703914-4356b257-78c9-4195-8a84-bf8a2cd3959a.png)
