### PR TITLE
moderation: add "delwarn" and "deletewarning" alias to the delwarning command

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Denote the vendored directory, since its name differs from
+# otherwise recognised names.
+**/vendorr/** linguist-vendored
+
+# Force batch scripts to always have CRLF line endings, so that if this repo
+# is accessed in Windows via file share from *nix, these scripts will still work.
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf
+
+# Force bash/shell scripts to always use LF line endings so that if this repo
+# is accessed in *nix via file share from Windows, these scripts will still work.
+*.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -1,160 +1,113 @@
-YAGPDB
-================
+# YAGPDB - Yet Another General Purpose Discord Bot
 
-### Yet another general purpose discord bot
+YAGPDB is a multifunctional, modular Discord bot. It is modular in the sense that for most things plugins exist -- However, some plugins may depend on other plugins.
 
-YAGPDB is a multifunctional, modular Discord bot. It's modular in that plugins exist for the most part on their own (with exceptions to some lazy things in the main stylesheet), some plugins do however depend on other plugins (most plugins depend on the commands plugin, for example).
+## Plugins
 
-**Links**
- - [YAGPDB.xyz](http://yagpdb.xyz)
- - [For updates and support join my discord server](https://discord.gg/4udtcA5)
- - [The documentation of YAGPDB](https://docs.yagpdb.xyz/)
+* YouTube Feed
+* Stream Announcements
+* Server Stats
+* Soundboard
+* Reputation
+* Reminders
+* Reddit Feed
+* Notifications
+* Moderation
+* Logs
+* Custom Commands
+* And More!
 
-### Running YAGPDB yourself
+## Useful Links
 
-Running this bot may seem challenging, and that's because I don't have time to make it easy to run for everyone, for the most part, it should run fine after the initial work has been done. Please view [this page](https://docs.yagpdb.xyz/development/self-hosting-with-docker) for more information.
+* [Homepage](https://yagpdb.xyz)
+* [Support Server](https://discord.gg/4udtcA5)
+* [Documentation](https://docs.yagpdb.xyz)
 
-#### Updating
-Updating after v1 should migrate schemas automatically, but you should always take backups beforehand if things go wrong.
+## Selfhosting
 
-I will put breaking changes in the breaking_changes.md file, which you should always read before updating.
+There are two ways of selfhosting this bot: [standalone](#Hosting-Standalone), or [dockerized](#Hosting-Dockerized).
 
-#### There's 2 ways of running this bot
-
-1. Using Docker
-2. Standalone
-
-**I will not help with basic problems or how to do unrelated things (how to run it on startup for example), use Google, if those well written tutorials and articles confuse you, how the hell is a guy with English as a second language gonna be any better?**
-
-(There's still a lot of contributing you can do without this though, such as writing docs, fixing my horrible typos and so on)
-
-#### General Discord bot setup
+### General Bot Setup
 
 Directions on creating an app and getting credentials may be found
 [here](https://github.com/reactiflux/discord-irc/wiki/Creating-a-discord-bot-&-getting-a-token).
-YAGPDB does not require you to authorize the bot: all of that will be handled
-via the Control Panel.
+	@@ -37,129 +36,82 @@ via the Control Panel.
 
 In addition, you will need to add the following urls to the bot's "REDIRECT URI(S)" configuration:
 
-- https://YourHostNameHere/confirm_login
-- https://YourHostNameHere/manage
+* <https://YourHostNameHere/confirm_login>
+* <https://YourHostNameHere/manage>
 
-#### Docker quickstart
+### Hosting Dockerized
 
-If you have docker-compose installed, it will offer the fastest route to getting
-up-and-running.
+If you have docker-compose installed, that might be the fastest route of getting the bot up and running:
 
-```bash
+```shell
 git clone https://github.com/botlabs-gg/yagpdb
 cp yagpdb/yagpdb_docker/{app.example.env,app.env}
 cp yagpdb/yagpdb_docker/{db.example.env,db.env}
 ```
 
-Edit `app.env` and `db.env` to specify the Discord bot values from above.
+Edit both env files accordingly. Make sure ports 80 and 443 are accessible on your network and that you have a proper image in `docker-compose.yml`:
 
-Make sure ports 80 and 443 are accessible on your network and launch:
-
-    docker-compose -f yagpdb/yagpdb_docker/docker-compose.yml up
-
-The bot will connect automatically and the control panel will be available via
-your host after a short setup.
-
-If you are running several bots (or other websites alongside the bot), consider
-running a proxy such as jrcs/letsencrypt-nginx-proxy-companion.
-
-First, start the proxy. This needs to be started only once and is shared by all
-websites:
-
-    docker network create proxy-tier
-    docker-compose -p proxy yagpdb/yagpdb_docker/docker-compose.proxy.yml up
-
-And then start the bot using the proxy:
-
-    docker-compose -f yagpdb/yagpdb_docker/docker-compose.proxied.yml up
-
-#### Standalone/Manual setup
-
-**Requirements**
- - Fairly recent go version (1.11 or later, I use new features as soon as they're out, so watch out in breaking_changes)
- - PostgreSQL 9.6 or later
- - Redis version 3.x or later (maybe it's possible to get it working with earlier versions, however I'm not 100% sure)
-
-I may update the bot at any point to require newer versions of any of these, so you should ALWAYS check breaking_changes before updating.
-
-**First step** is to set those up and get them running:
-
- 1. Install and configure redis and postgres with your desired settings (my DM's are not Google, you'll have to figure at least this much out on your own...)
- 2. Create a user named `yagpdb` and database named `yagpdb` which the user `yagpdb` has write access to
- 3. Update your env vars with the config (see example env file in `cmd/yagpdb/`)
- 4. Done.
-
-**Steps for building:**
-
-YAGPDB currently uses a lot of alternative branches of my projects, mainly because I also use a discordgo fork with a lot of goodies in it (why not push my changes upstream? Cause a ton of breaking changes that would never get accepted)
-
-I'm working towards making YAGPDB fully `go get ...`-able
-
-```bash
-git clone -b yagpdb https://github.com/jonas747/discordgo $GOPATH/src/github.com/jonas747/discordgo
-git clone -b dgofork https://github.com/jonas747/dutil $GOPATH/src/github.com/jonas747/dutil
-git clone -b dgofork https://github.com/jonas747/dshardmanager $GOPATH/src/github.com/jonas747/dshardmanager
-go get -v -d github.com/botlabs-gg/yagpdb/cmd/yagpdb
-cd $GOPATH/src/github.com/botlabs-gg/yagpdb/cmd/yagpdb
-go build
+```shell
+docker-compose -f yagpdb/yagpdb_docker/docker-compose.yml up
 ```
 
-After this, unless you wanna run it in testing mode using `YAGPDB_TESTING=yes` you have to run `cmd/yagpdb/copytemplates.sh` to copy all the plugin specific template files into the `cmd/yagpdb/templates/plugins` folder.
+Alternatively, you can run the bot behind a proxy:
 
-You can now run `./yagpdb`
+```shell
+docker network create proxy-tier
+docker-compose -p proxy yagpdb/yagpdb_docker/docker-compose.proxy.yml up
+docker-compose -f yagpdb/yagpdb_docker/docker-compose.proxied.yml up
+```
 
-Configuration is done through environment variables. See `cmd/yagpdb/sampleenvfile` for what environment variables are available.
+During development, use the `docker-compose.dev.yml` file:
 
-You can run the web server, bot, reddit and youtube parts as separate processes (some smallish limitations require to to run it on the same machine, will likely be removed soon as I'm gonna need to work on horizontal scaling soon)
+```shell
+docker-compose -f yagpdb/yagpdb_docker/docker-compose.dev.yml up
+```
 
-You specify `-bot` to run the bot, `-web` to run the web server, `-feeds "youtube,reddit"` to run the reddit and youtube feeds.
+### Hosting Standalone
 
-The web server by default (unless `-pa`) listens on 5000(http) and 5001(https)
-So if you're behind a NAT, forward those, if not you can either use the `-pa` switch or add an entry to iptables.
+#### Requirements
 
-### Plugins
+* Golang 1.16 or above
+* PostgreSQL 9.6 or later
+* Redis version 3.x or later
 
-**Standard plugins:**
+#### Setting Up
 
-* Youtube-Feed
-* Stream-announcements
-* Server Stats
-* Soundboard
-* Reputation
-* Reminder
-* Reddit-Feed
-* Notifications
-* Moderation
-* Logs
-* Custom commands
-* And More!
+Configure Redis and Postgres with your desired settings.
 
-**Planned plugins**
+In postgres, create a new user `yagpdb` and database `yagpdb` and grant that user access to that database.
 
-[See the Issues Tab for more](https://github.com/botlabs-gg/yagpdb/issues)
+Set up the environment variables with the credentials from the [general setup](#General-Bot-Setup). See the [sample env file](cmd/yagpdb/sampleenvfile) for a list of all enviroment variables.
 
-### Core packages:
+Afterwards, run the build script located at `/cmd/yagpdb/build.sh` and  start the bot using `./yagpdb`:
 
-- Web: The core web server package, in charge of authentication.
-- Bot: Core bot package, delegates events to plugins.
-- Common: Handles all the common stuff between web and bot (config, discord session, redis pool etc).
-- Feeds: Handles all feeds, personally I like to run each feed as its own service, that way I can start and stop individual feeds without taking everything down.
-- Commands: Handles all commands.
+```shell
+git clone https://github.com/botlabs-gg/yagpdb
+cd yagpdb/cmd/yagpdb
+sh build.sh
+./yagpdb -all
+```
 
-Currently, YAGPDB builds everything into one executable and you run the bot with the -bot switch, the web server with the -web switch and so on (see -h for help).
+See `./yagpdb -help` for all usable run flags. The webserver listens by default on ports 5000 (HTTP) and 5001 (HTTPS).
 
-### Databases
+## Databases
 
-YAGPDB uses redis for light data and caching (and some remnants of configuration).
+YAGPDB uses Redis for light data and caching, and postgresql for most configurations and heavy data, such as logs.
 
-It uses PostgreSQL for most configuration and more heavy data (logs and such).
+### Updating
 
-### Contributing new features
+Updating with v1 and higher should migrate schemas automatically, but you should always make backups.
+
+Breaking changes can be found in breaking_changes.md, which should always be consulted before updating.
+
+## Contributing
+
+Please view the [contributing guidelines](CONTRIBUTING.md) before submitting any contributions.
 
 See bot/plugin for info about bot plugins, web/plugin for web plugins and feeds/plugin for feeds if you wanna make a new fully fledged plugin.
 
@@ -162,4 +115,4 @@ Expect web, bot and feed instances to be run separately.
 
 For basic utility/fun commands, you can just jam them in stdcommands. Use the existing commands there as an example of how to add one.
 
-**If you need any help finding things in the source or have any other questions, don't be afraid of messaging me.**
+Please check CONTRIBUTING.md for further details.

--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -385,13 +385,26 @@ func (c *Context) SendResponse(content string) (*discordgo.Message, error) {
 		}
 	}
 
+	isDM := c.CurrentFrame.SendResponseInDM || (c.CurrentFrame.CS != nil && c.CurrentFrame.CS.IsPrivate())
+
 	for _, v := range c.CurrentFrame.EmebdsToSend {
+		if isDM {
+			v.Footer = &discordgo.MessageEmbedFooter{
+				Text:    "Custom Command DM from the server " + c.GS.Name,
+				IconURL: c.GS.Icon,
+			}
+		}
+
 		common.BotSession.ChannelMessageSendEmbed(channelID, v)
 	}
 
 	if strings.TrimSpace(content) == "" || (c.CurrentFrame.DelResponse && c.CurrentFrame.DelResponseDelay < 1) {
 		// no point in sending the response if it gets deleted immedietely
 		return nil, nil
+	}
+
+	if isDM {
+		content = "Custom Command DM from the server **" + c.GS.Name + "**\n" + content
 	}
 
 	m, err := common.BotSession.ChannelMessageSendComplex(channelID, c.MessageSend(content))

--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -730,7 +730,7 @@ func ExecuteCustomCommand(cmd *models.CustomCommand, tmplCtx *templates.Context)
 	out, err := tmplCtx.Execute(chanMsg)
 
 	if utf8.RuneCountInString(out) > 2000 {
-		out = "Custom command response was longer than 2k (contact an admin on the server...)"
+		out = "Custom command (#" + discordgo.StrID(cmd.LocalID) + ") response was longer than 2k (contact an admin on the server...)"
 	}
 
 	go updatePostCommandRan(cmd, err)

--- a/frontend/templates/cp_selectserver.html
+++ b/frontend/templates/cp_selectserver.html
@@ -1,7 +1,7 @@
 {{define "cp_selectserver"}}
 
 {{template "cp_head" .}}
-<header class="page-header"><h2>News and updates</h2></header>
+<header class="page-header"><h2>News and Updates</h2></header>
 <div class="row">
     <div class="col-lg-7">
 
@@ -11,8 +11,8 @@
                 <h2 class="card-title">Bot added to <b>{{.JoinedGuild.Name}}!</b></h2>
             </header>
             <div class="card-body">
-                <p>You manage this bot through a web control panel, if you need any help or want to contact the owner you can join the support server (There is a link above)</p>
-                <p>I'm working on adding proper documentation and guides but at this moment the documentation is very lacking, and it may seem a bit complicated. As as I said earlier, join the support server if you have any questions, although please do try a little on your own first, as I and the support team's time is limited.</p>
+                <p>You manage this bot through a web control panel, if you need any help you can join the support server (There is a link above)</p>
+                <p>The documentation for the bot can be found at <a class="link" href="https://docs.yagpdb.xyz/">docs.yagpdb.xyz</a>. Join the support server if you have any questions, although please do try a little on your own first, as the support team's time is limited.</p>
                 {{if .User}}
                 <a class="btn btn-primary" href="/manage/{{.JoinedGuild.ID}}/home">Click here to start managing it</a><br/>
                 {{else}}
@@ -63,7 +63,7 @@
         {{if .patreonActive}}
         <section class="card">
             <header class="card-header">
-                <h2 class="card-title">Thanks to my patrons!</h2>
+                <h2 class="card-title">Thanks to our patrons!</h2>
             </header>
             <div class="card-body">
                 {{range .activePatrons}}{{if ge .AmountCents 1000}}
@@ -80,9 +80,8 @@
                 <h2 class="card-title">Check out...</h2>
             </header>
             <div class="card-body">
-                <p>YAGPDB is open source! The project is hosted on github here: <a href="https://github.com/botlabs-gg/yagpdb">jonas747/yagpdb</a>.</p>
-                <p><a href="https://docs.yagpdb.xyz/donating" target="_blank">Donate using patreon, bitcoin and other cryptos!</a> Donating $3 or more will grant you premium slots you can assign to servers!</p>
-                <p>Looking to buy the ad space? <a href="https://docs.yagpdb.xyz/donating#advertisement" target="_blank">Click here for more info</a>.</p>
+                <p>YAGPDB is open source! The project is hosted on GitHub here: <a href="https://github.com/botlabs-gg/yagpdb">botlabs-gg/yagpdb</a>.</p>
+                <p><a href="https://docs.yagpdb.xyz/donating" target="_blank">Donate via patreon!</a> Donating $3 or more will grant you premium slots you can assign to servers!</p>
                 <p>Looking for the YAGPDB <a href="https://discord.gg/4udtcA5">Discord server</a>?</p>
             </div>
         </section>

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -254,7 +254,7 @@
               <li>The YAGPDB Community Server for support, suggestions, feedback and general talk can be joined
                 <a class="link" href="https://discord.gg/4udtcA5">here</a>
               </li>
-              <li>If you want to donate using Patreon or cryptocurrencies, check out
+              <li>If you want to donate via Patreon, check out
                 <a class="link" href="https://docs.yagpdb.xyz/donating">this page</a>
               </li>
             </ul>

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/jonas747/dice v0.0.0-20170619144252-7735f6ee7b69
 	github.com/jonas747/discordgo/v2 v2.0.6
 	github.com/jonas747/dshardorchestrator/v3 v3.0.0
-	github.com/jonas747/dstate/v4 v4.0.4
+	github.com/jonas747/dstate/v4 v4.0.5-0.20211005064429-2e2fa8a2a1cd
 	github.com/jonas747/go-reddit v0.1.2
 	github.com/jonas747/go-twitter v0.0.0-20200706234916-1d17060b92bc
 	github.com/jonas747/jdshardmanager/v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -394,6 +394,8 @@ github.com/jonas747/dshardorchestrator/v3 v3.0.0/go.mod h1:rBuluqm4X+z439q8a6X1k
 github.com/jonas747/dstate/v4 v4.0.1/go.mod h1:WRIGuYoVmr+N4ecy/8P61byGBscd3+W4aj26avbhSn0=
 github.com/jonas747/dstate/v4 v4.0.4 h1:P261MCVr7c68578daAqKUwO6MFPqHTB3zdgIUB6EWMQ=
 github.com/jonas747/dstate/v4 v4.0.4/go.mod h1:JI2U//DFUa1PIZhXZ3YhYztMuwWcUcHIFbXPMlfBK5w=
+github.com/jonas747/dstate/v4 v4.0.5-0.20211005064429-2e2fa8a2a1cd h1:lCrfoAUwhc+r12LkA45ZZ97kGBYuB31jBtBlC03iLU4=
+github.com/jonas747/dstate/v4 v4.0.5-0.20211005064429-2e2fa8a2a1cd/go.mod h1:JI2U//DFUa1PIZhXZ3YhYztMuwWcUcHIFbXPMlfBK5w=
 github.com/jonas747/go-reddit v0.1.2 h1:SDgHvC9ouFIdtbB+dlu8T5lHxAjoypz1NE7CuQN+YOI=
 github.com/jonas747/go-reddit v0.1.2/go.mod h1:9HN8PKMjEmDmJE3C71GsR6piXo1AxPrkxjQ/nZOe8Lo=
 github.com/jonas747/go-twitter v0.0.0-20200706234916-1d17060b92bc h1:yVJb07+MRPLTZ6wz3mgZeRp5+jly+zSOFnGmTGGVR+k=

--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -750,7 +750,7 @@ var ModerationCommands = []*commands.YAGCommand{
 		CustomEnabled: true,
 		CmdCategory:   commands.CategoryModeration,
 		Name:          "DelWarning",
-		Aliases:       []string{"dw"},
+		Aliases:       []string{"dw", "delwarn", "deletewarning"},
 		Description:   "Deletes a warning, id is the first number of each warning from the warnings command",
 		RequiredArgs:  1,
 		Arguments: []*dcmd.ArgDef{

--- a/premium/assets/premium.html
+++ b/premium/assets/premium.html
@@ -16,14 +16,9 @@
 
             <div class="card-body">
                 <p>Here you can redeem codes from giveaways and assign premium slots to servers.</p>
-                <p>Keeping Discord bots running isn't cheap when they're on tens of thousands of servers, and Patreon
-                    donations alone without any benefits aside from priority support didn't get enough income to run
-                    YAGPDB without a loss, therefore I've had implement a premium functionality to increase the
-                    incentive to support the bot. You can find the features behind the paywall in the list below.</p>
-                <p><b>If you come across any issues with premium, please let me know!</b></p>
-                <p><b>Note:</b> This is still a hobby project run by 1 guy in his spare time with occasional code
-                    contributions here and there and support provided by unpaid volunteers in their free time. The
-                    premium functionality is just a bonus for supporting the bot and not a "product".</p>
+                <p>You can find the features behind the paywall in the list below.</p>
+                <p><b>If you come across any issues with premium, please let us know!</b></p>
+                <p><b>Note:</b> The premium functionality is just a bonus for supporting the bot and not a "product".</p>
 
                 <button class="btn btn-primary mb-2" type="button" data-toggle="collapse"
                     data-target="#premium-how-to-get" aria-expanded="false" aria-controls="premium-how-to-get">
@@ -33,9 +28,9 @@
                     <section class="card">
                         <div class="card-body">
                             <ul>
-                                <li>Make a pledge on my <a href="https://patreon.com/yagpdb">Patreon</a>. Tiers above $3
-                                    will grant you premium slots. It will take 2 minutes from you make a pledge to it
-                                    being processed here.</li>
+                                <li>Make a pledge on our <a href="https://patreon.com/yagpdb">Patreon</a>. Tiers above $3
+                                    will grant you premium slots. It can take up to 10 minutes from you making a pledge to it
+                                    being processed on our side. (If you do not see your premium slots after that time, please contact us through the support server.)</li>
                             </ul>
                         </div>
                     </section>
@@ -49,8 +44,6 @@
                         <div class="card-body">
                             <b>General goodies</b>
                             <ul>
-                                <li>Infinite server stats retention (not that this is not retroactive, i do not store
-                                    your stats at all if you don't have premium)</li>
                                 <li>Twitter feeds</li>
                                 <li>Priority support</li>
                             </ul>

--- a/stdcommands/define/define.go
+++ b/stdcommands/define/define.go
@@ -2,22 +2,37 @@ package define
 
 import (
 	"fmt"
+	"math/rand"
+	"net/url"
+	"regexp"
 
+	"github.com/botlabs-gg/yagpdb/bot/paginatedmessages"
 	"github.com/botlabs-gg/yagpdb/commands"
+	"github.com/botlabs-gg/yagpdb/common"
 	"github.com/dpatrie/urbandictionary"
 	"github.com/jonas747/dcmd/v4"
+	"github.com/jonas747/discordgo/v2"
 )
 
 var Command = &commands.YAGCommand{
 	CmdCategory:  commands.CategoryFun,
 	Name:         "Define",
 	Aliases:      []string{"df"},
-	Description:  "Look up an urban dictionary definition",
+	Description:  "Look up an urban dictionary definition, default paginated view.",
 	RequiredArgs: 1,
 	Arguments: []*dcmd.ArgDef{
 		{Name: "Topic", Type: dcmd.String},
 	},
+	ArgSwitches: []*dcmd.ArgDef{
+		{Name: "raw", Help: "Raw output"},
+	},
 	RunFunc: func(data *dcmd.Data) (interface{}, error) {
+		var paginatedView bool
+		paginatedView = true
+
+		if data.Switches["raw"].Value != nil && data.Switches["raw"].Value.(bool) {
+			paginatedView = false
+		}
 
 		qResp, err := urbandictionary.Query(data.Args[0].Str())
 		if err != nil {
@@ -28,13 +43,67 @@ var Command = &commands.YAGCommand{
 			return "No result :(", nil
 		}
 
-		result := qResp.Results[0]
+		if paginatedView {
+			_, err := paginatedmessages.CreatePaginatedMessage(
+				data.GuildData.GS.ID, data.ChannelID, 1, len(qResp.Results), func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
+					i := page - 1
 
-		cmdResp := fmt.Sprintf("**%s**: %s\n*%s*\n*(<%s>)*", result.Word, result.Definition, result.Example, result.Permalink)
-		if len(qResp.Results) > 1 {
-			cmdResp += fmt.Sprintf(" *%d more results*", len(qResp.Results)-1)
+					paginatedEmbed := embedCreator(qResp.Results, i)
+					return paginatedEmbed, nil
+				})
+			if err != nil {
+				return "Something went wrong", nil
+			}
+		} else {
+			result := qResp.Results[0]
+
+			cmdResp := fmt.Sprintf("**%s**: %s\n*%s*\n*(<%s>)*", result.Word, result.Definition, result.Example, result.Permalink)
+			if len(qResp.Results) > 1 {
+				cmdResp += fmt.Sprintf(" *%d more results*", len(qResp.Results)-1)
+			}
+			return cmdResp, nil
 		}
 
-		return cmdResp, nil
+		return nil, nil
 	},
+}
+
+func embedCreator(udResult []urbandictionary.Result, i int) *discordgo.MessageEmbed {
+	definition := udResult[i].Definition
+	if len(definition) > 2000 {
+		definition = common.CutStringShort(definition, 2000) + "\n\n(definition too long)"
+	}
+	example := "None given"
+	if len(udResult[i].Example) > 0 {
+		example = linkReferencedTerms(udResult[i].Example)
+	}
+	embed := &discordgo.MessageEmbed{
+		Author: &discordgo.MessageEmbedAuthor{
+			Name: udResult[i].Word,
+			URL:  udResult[i].Permalink,
+		},
+		Description: fmt.Sprintf("**Definition**: %s", linkReferencedTerms(definition)),
+		Color:       int(rand.Int63n(16777215)),
+		Fields: []*discordgo.MessageEmbedField{
+			&discordgo.MessageEmbedField{Name: "Example:", Value: example},
+			&discordgo.MessageEmbedField{Name: "Author:", Value: udResult[i].Author},
+			&discordgo.MessageEmbedField{Name: "Votes:", Value: fmt.Sprintf("Upvotes: %d\nDownvotes: %d", udResult[i].Upvote, udResult[i].Downvote)},
+		},
+		Thumbnail: &discordgo.MessageEmbedThumbnail{
+			URL: "https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/UD_logo-01.svg/512px-UD_logo-01.svg.png",
+		},
+	}
+
+	return embed
+}
+
+const urbanDictionaryDefineEndpoint = "https://www.urbandictionary.com/define.php?term="
+
+var termRefRe = regexp.MustCompile(`\[.+?\]`)
+
+func linkReferencedTerms(def string) string {
+	return termRefRe.ReplaceAllStringFunc(def, func(match string) string {
+		term := match[1 : len(match)-1]
+		return fmt.Sprintf("[%s](%s%s)", term, urbanDictionaryDefineEndpoint, url.QueryEscape(term))
+	})
 }

--- a/stdcommands/poll/poll.go
+++ b/stdcommands/poll/poll.go
@@ -11,10 +11,11 @@ import (
 var (
 	pollReactions = [...]string{"1⃣", "2⃣", "3⃣", "4⃣", "5⃣", "6⃣", "7⃣", "8⃣", "9⃣", "🔟"}
 	Command       = &commands.YAGCommand{
-		CmdCategory:  commands.CategoryTool,
-		Name:         "Poll",
-		Description:  "Create very simple reaction poll. Example: `poll \"favorite color?\" blue red pink`",
-		RequiredArgs: 3,
+		CmdCategory:         commands.CategoryTool,
+		Name:                "Poll",
+		Description:         "Create very simple reaction poll. Example: `poll \"favorite color?\" blue red pink`",
+		RequiredArgs:        3,
+		SlashCommandEnabled: true,
 		Arguments: []*dcmd.ArgDef{
 			{
 				Name: "Topic",

--- a/stdcommands/wouldyourather/wouldyourather.go
+++ b/stdcommands/wouldyourather/wouldyourather.go
@@ -26,11 +26,11 @@ var Command = &commands.YAGCommand{
 		}
 
 		embed := &discordgo.MessageEmbed{
-			Description: fmt.Sprintf("**EITHER...**\n🇦: %s\n\n**OR...**\n🇧 %s", q1, q2),
+			Description: fmt.Sprintf("**EITHER...**\n🇦 %s\n\n**OR...**\n🇧 %s", q1, q2),
 			Author: &discordgo.MessageEmbedAuthor{
 				Name:    "Would you rather...",
 				URL:     "https://either.io/",
-				IconURL: "https://yagpdb.xyz/static/icons/favicon-16x16.png",
+				IconURL: "https://yagpdb.xyz/static/icons/favicon-32x32.png",
 			},
 			Footer: &discordgo.MessageEmbedFooter{
 				Text:    fmt.Sprintf("Requested by: %s#%s", data.Author.Username, data.Author.Discriminator),


### PR DESCRIPTION
Being a command that isn't used very often, it seems to a common problem where users cannot remember what the command is called. This PR adds two aliases, a little more intuitive and easy to remember.