### PR TITLE
common/templates: add templates to pin and unpin messages

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -499,6 +499,8 @@ func baseContextFuncs(c *Context) {
 	c.addContextFunc("sendMessageNoEscapeRetID", c.tmplSendMessage(false, true))
 	c.addContextFunc("editMessage", c.tmplEditMessage(true))
 	c.addContextFunc("editMessageNoEscape", c.tmplEditMessage(false))
+	c.addContextFunc("pinMessage", c.tmplPinMessage)
+	c.addContextFunc("unpinMessage", c.tmplUnpinMessage)
 
 	// Mentions
 	c.addContextFunc("mentionEveryone", c.tmplMentionEveryone)

--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -499,8 +499,8 @@ func baseContextFuncs(c *Context) {
 	c.addContextFunc("sendMessageNoEscapeRetID", c.tmplSendMessage(false, true))
 	c.addContextFunc("editMessage", c.tmplEditMessage(true))
 	c.addContextFunc("editMessageNoEscape", c.tmplEditMessage(false))
-	c.addContextFunc("pinMessage", c.tmplPinMessage)
-	c.addContextFunc("unpinMessage", c.tmplUnpinMessage)
+	c.addContextFunc("pinMessage", c.tmplHandlePinMessage(true))
+	c.addContextFunc("unpinMessage", c.tmplHandlePinMessage(false))
 
 	// Mentions
 	c.addContextFunc("mentionEveryone", c.tmplMentionEveryone)

--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -499,8 +499,8 @@ func baseContextFuncs(c *Context) {
 	c.addContextFunc("sendMessageNoEscapeRetID", c.tmplSendMessage(false, true))
 	c.addContextFunc("editMessage", c.tmplEditMessage(true))
 	c.addContextFunc("editMessageNoEscape", c.tmplEditMessage(false))
-	c.addContextFunc("pinMessage", c.tmplPinMessage(true))
-	c.addContextFunc("unpinMessage", c.tmplPinMessage(false))
+	c.addContextFunc("pinMessage", c.tmplPinMessage(false))
+	c.addContextFunc("unpinMessage", c.tmplPinMessage(true))
 
 	// Mentions
 	c.addContextFunc("mentionEveryone", c.tmplMentionEveryone)

--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -499,8 +499,8 @@ func baseContextFuncs(c *Context) {
 	c.addContextFunc("sendMessageNoEscapeRetID", c.tmplSendMessage(false, true))
 	c.addContextFunc("editMessage", c.tmplEditMessage(true))
 	c.addContextFunc("editMessageNoEscape", c.tmplEditMessage(false))
-	c.addContextFunc("pinMessage", c.tmplHandlePinMessage(true))
-	c.addContextFunc("unpinMessage", c.tmplHandlePinMessage(false))
+	c.addContextFunc("pinMessage", c.tmplPinMessage(true))
+	c.addContextFunc("unpinMessage", c.tmplPinMessage(false))
 
 	// Mentions
 	c.addContextFunc("mentionEveryone", c.tmplMentionEveryone)

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -402,9 +402,9 @@ func (c *Context) tmplEditMessage(filterSpecialMentions bool) func(channel inter
 	}
 }
 
-func (c *Context) tmplHandlePinMessage(mode bool) func(channel, msgID interface{}) (string, error) {
+func (c *Context) tmplPinMessage(unpin bool) func(channel, msgID interface{}) (string, error) {
 	return func(channel, msgID interface{}) (string, error) {
-		if c.IncreaseCheckCallCounter("messagePins", 5) {
+		if c.IncreaseCheckCallCounter("message_pins", 5) {
 			return "", ErrTooManyCalls
 		}
 
@@ -414,17 +414,12 @@ func (c *Context) tmplHandlePinMessage(mode bool) func(channel, msgID interface{
 		}
 		mID := ToInt64(msgID)
 		var err error
-		if mode {
-			err = common.BotSession.ChannelMessagePin(cID, mID)
-		} else {
+		if unpin {
 			err = common.BotSession.ChannelMessageUnpin(cID, mID)
+		} else {
+			err = common.BotSession.ChannelMessagePin(cID, mID)
 		}
-		
-		if err != nil {
-			return "", err
-		}
-
-	return "", nil
+		return "", err
 	}
 }
 

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -402,6 +402,36 @@ func (c *Context) tmplEditMessage(filterSpecialMentions bool) func(channel inter
 	}
 }
 
+func (c *Context) tmplPinMessage(channel, msgID interface{}) (string, error) {
+	cID := c.ChannelArgNoDM(channel)
+	if cID == 0 {
+		return "", errors.New("unknown channel")
+	}
+
+	mID := ToInt64(msgID)
+	err := common.BotSession.ChannelMessagePin(cID, mID)
+	if err != nil {
+		return "", err
+	}
+
+	return "", nil
+}
+
+func (c *Context) tmplUnpinMessage(channel, msgID interface{}) (string, error) {
+	cID := c.ChannelArgNoDM(channel)
+	if cID == 0 {
+		return "", errors.New("unknown channel")
+	}
+
+	mID := ToInt64(msgID)
+	err := common.BotSession.ChannelMessageUnpin(cID, mID)
+	if err != nil {
+		return "", err
+	}
+
+	return "", nil
+}
+
 func (c *Context) tmplMentionEveryone() string {
 	c.CurrentFrame.MentionEveryone = true
 	return "@everyone"

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -402,34 +402,30 @@ func (c *Context) tmplEditMessage(filterSpecialMentions bool) func(channel inter
 	}
 }
 
-func (c *Context) tmplPinMessage(channel, msgID interface{}) (string, error) {
-	cID := c.ChannelArgNoDM(channel)
-	if cID == 0 {
-		return "", errors.New("unknown channel")
-	}
+func (c *Context) tmplHandlePinMessage(mode bool) func(channel, msgID interface{}) (string, error) {
+	return func(channel, msgID interface{}) (string, error) {
+		if c.IncreaseCheckCallCounter("messagePins", 5) {
+			return "", ErrTooManyCalls
+		}
 
-	mID := ToInt64(msgID)
-	err := common.BotSession.ChannelMessagePin(cID, mID)
-	if err != nil {
-		return "", err
-	}
-
-	return "", nil
-}
-
-func (c *Context) tmplUnpinMessage(channel, msgID interface{}) (string, error) {
-	cID := c.ChannelArgNoDM(channel)
-	if cID == 0 {
-		return "", errors.New("unknown channel")
-	}
-
-	mID := ToInt64(msgID)
-	err := common.BotSession.ChannelMessageUnpin(cID, mID)
-	if err != nil {
-		return "", err
-	}
+		cID := c.ChannelArgNoDM(channel)
+		if cID == 0 {
+			return "", errors.New("unknown channel")
+		}
+		mID := ToInt64(msgID)
+		var err error
+		if mode {
+			err = common.BotSession.ChannelMessagePin(cID, mID)
+		} else {
+			err = common.BotSession.ChannelMessageUnpin(cID, mID)
+		}
+		
+		if err != nil {
+			return "", err
+		}
 
 	return "", nil
+	}
 }
 
 func (c *Context) tmplMentionEveryone() string {


### PR DESCRIPTION
Being able to pin/unpin messages with the bot has been a common request. This PR does just that by adding custom command templates which allow pinning/unpinning a message.
The syntax for the template usage will be:
- `pinMessage channel messageID`
- `unpinMessage channel messageID`