### PR TITLE
common/templates: allow file renaming

### DIFF
--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -216,11 +216,14 @@ func CreateMessageSend(values ...interface{}) (*discordgo.MessageSend, error) {
 
 	msg := &discordgo.MessageSend{}
 
+	// Default filename
+	filename := "attachment_" + time.Now().Format("2006-01-02_15-04-05")
+
 	for key, val := range messageSdict {
 
 		switch key {
 		case "content":
-			msg.Content = fmt.Sprint(val)
+			msg.Content = ToString(val)
 		case "embed":
 			if val == nil {
 				continue
@@ -231,7 +234,7 @@ func CreateMessageSend(values ...interface{}) (*discordgo.MessageSend, error) {
 			}
 			msg.Embed = embed
 		case "file":
-			stringFile := fmt.Sprint(val)
+			stringFile := ToString(val)
 			if len(stringFile) > 100000 {
 				return nil, errors.New("file length for send message builder exceeded size limit")
 			}
@@ -239,14 +242,20 @@ func CreateMessageSend(values ...interface{}) (*discordgo.MessageSend, error) {
 			buf.WriteString(stringFile)
 
 			msg.File = &discordgo.File{
-				Name:        "Attachment.txt",
 				ContentType: "text/plain",
 				Reader:      &buf,
 			}
+		case "filename":
+			// Cut the filename to a reasonable length if it's too long
+			filename = common.CutStringShort(ToString(val), 64)
 		default:
 			return nil, errors.New(`invalid key "` + key + `" passed to send message builder`)
 		}
 
+	}
+	if msg.File != nil {
+		// We hardcode the extension to .txt to prevent possible abuse via .bat or other possible harmful/easily corruptable file formats
+		msg.File.Name = filename + ".txt"
 	}
 
 	return msg, nil


### PR DESCRIPTION
User suggestion on the server, to allow for more flexibility when outputting files as custom command response.

* We add a new key to `complexMessage`; `"filename"` - its value will be the file's new name instead of `Attachment`.
    * Because this new key is optional, we will default to `Attachment`, if no filename given.
    * The custom filename will be limited to 64 characters, this seems like a reasonable limit.
* The file's extension will be hard-coded to `*.txt` as countermeasures against abuse of `*.bat`, `*.wav` or other wonky fonky file formats.

I decided on no-op when a filename but no file is given. Just doesn't make sense to give a filename without a file, and when it does happen it seemed to much to stop the CC execution over something that has no effect whatsoever.

As far as I can tell, this works fine on selfhost.
![handy dandy screenshot](https://user-images.githubusercontent.com/71897876/119909422-1592ce00-bf55-11eb-8316-2438f9f54824.png)

Thanks to Joe and mrbentarikau for helping me and giving input, and as usual thanks in advance!
