### PR TITLE
moderation: show server warning count

### DIFF
--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -863,7 +863,10 @@ var ModerationCommands = []*commands.YAGCommand{
 					out += fmt.Sprintf("#%02d: %4d - %d\n", v.Rank, v.WarnCount, v.UserID)
 				}
 			}
-			out += "```\n"
+			var count int
+			common.GORM.Table("moderation_warnings").Where("guild_id = ?", parsed.GuildData.GS.ID).Count(&count)
+
+			out += "```\n" + fmt.Sprintf("Total Server Warnings: `%d`", count)
 
 			embed.Description = out
 


### PR DESCRIPTION
As title states.
There have been occasions where users were wondering how many warnings have been given on the server, either due to curiosity or simply wanting to have a metric of some sorts.