### PR TITLE
common/templates: add getPinCount template

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -536,6 +536,7 @@ func baseContextFuncs(c *Context) {
 	c.addContextFunc("getChannel", c.tmplGetChannel)
 	c.addContextFunc("getThread", c.tmplGetThread)
 	c.addContextFunc("getChannelOrThread", c.tmplGetChannelOrThread)
+	c.addContextFunc("getPinCount", c.tmplGetChannelPinCount)
 	c.addContextFunc("getRole", c.tmplGetRole)
 	c.addContextFunc("addReactions", c.tmplAddReactions)
 	c.addContextFunc("addResponseReactions", c.tmplAddResponseReactions)

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -1157,6 +1157,24 @@ func (c *Context) tmplGetChannelOrThread(channel interface{}) (*CtxChannel, erro
 	return CtxChannelFromCS(cstate), nil
 }
 
+func (c *Context) tmplGetChannelPinCount(channel interface{}) (int, error) {
+	if c.IncreaseCheckCallCounterPremium("count_pins", 2, 4) {
+		return 0, ErrTooManyCalls
+	}
+
+	cID := c.ChannelArgNoDM(channel)
+	if cID == 0 {
+		return 0, errors.New("unknown channel")
+	}
+
+	msg, err := common.BotSession.ChannelMessagesPinned(cID)
+	if err != nil {
+		return 0, err
+	}
+
+	return len(msg), nil
+}
+
 func (c *Context) tmplAddReactions(values ...reflect.Value) (reflect.Value, error) {
 	f := func(args []reflect.Value) (reflect.Value, error) {
 		if c.Msg == nil {


### PR DESCRIPTION
This adds the template `getPinCount channel` which returns the total number of pins in a channel. The command is limited to 2 calls per CC for non-premium and 4 calls per CC for premium because it has to get all pinned messages in the channel to be able to find number of pins.