### PR TITLE
moderation: use discord unix timestamp in warnings

### DIFF
--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -698,7 +698,7 @@ var ModerationCommands = []*commands.YAGCommand{
 
 				return &discordgo.MessageEmbed{
 					Title:       fmt.Sprintf("Warning#%d - User : %s", warn[0].ID, warn[0].UserID),
-					Description: fmt.Sprintf("`%20s` - **Reason** : %s", warn[0].CreatedAt.UTC().Format(time.RFC822), warn[0].Message),
+					Description: fmt.Sprintf("<t:%d:f> - **Reason** : %s", warn[0].CreatedAt.Unix(), warn[0].Message),
 					Footer:      &discordgo.MessageEmbedFooter{Text: fmt.Sprintf("By: %s (%13s)", warn[0].AuthorUsernameDiscrim, warn[0].AuthorID)},
 				}, nil
 			}
@@ -1165,7 +1165,7 @@ func PaginateWarnings(parsed *dcmd.Data) func(p *paginatedmessages.PaginatedMess
 
 			for _, entry := range result {
 
-				entry_formatted := fmt.Sprintf("#%d: `%20s` - By: **%s** (%13s) \n **Reason:** %s", entry.ID, entry.CreatedAt.UTC().Format(time.RFC822), entry.AuthorUsernameDiscrim, entry.AuthorID, entry.Message)
+				entry_formatted := fmt.Sprintf("#%d: <t:%d:f> - By: **%s** (%13s) \n **Reason:** %s", entry.ID, entry.CreatedAt.Unix(), entry.AuthorUsernameDiscrim, entry.AuthorID, entry.Message)
 				if len([]rune(entry_formatted)) > 900 {
 					entry_formatted = common.CutStringShort(entry_formatted, 900)
 				}


### PR DESCRIPTION
Discord allows unix timestamp formatting which makes it a lot easier to see the time in the local timezone. This PR makes changes to allow the `warnings/warns` command to use discord's timestamp formatting instead of the current UTC timestamp string.
![image](https://user-images.githubusercontent.com/67655446/142805865-e18eb766-f0ca-4d2b-96a6-3dc6d783b013.png)
