### PR TITLE
templates: Cube Root function

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -52,6 +52,7 @@ var (
 		"div":               tmplDiv,
 		"mod":               tmplMod,
 		"fdiv":              tmplFDiv,
+		"cbrt":              tmplCbrt,
 		"sqrt":              tmplSqrt,
 		"pow":               tmplPow,
 		"log":               tmplLog,

--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -517,6 +517,15 @@ func tmplSqrt(arg interface{}) float64 {
 	}
 }
 
+func tmplCbrt(arg interface{}) float64 {
+	switch arg.(type) {
+	case int, int16, int32, int64, uint8, uint16, uint32, uint64, float32, float64:
+		return math.Cbrt(ToFloat64(arg))
+	default:
+		return math.NaN()
+	}
+}
+
 func tmplPow(argX, argY interface{}) float64 {
 	var xyValue float64
 	var xySlice []float64


### PR DESCRIPTION
This is cbrt (cube root) function from golang's math library. It's more convenient and even more presice to use than {{ pow $x (fdiv 1 3) }}