### PR TITLE
templates: add [S]Dict.HasKey method

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -630,6 +630,11 @@ func (d Dict) Del(key interface{}) string {
 	return ""
 }
 
+func (d Dict) HasKey(k interface{}) (ok bool) {
+	_, ok = d[k]
+	return
+}
+
 type SDict map[string]interface{}
 
 func (d SDict) Set(key string, value interface{}) string {
@@ -644,6 +649,11 @@ func (d SDict) Get(key string) interface{} {
 func (d SDict) Del(key string) string {
 	delete(d, key)
 	return ""
+}
+
+func (d SDict) HasKey(k string) (ok bool) {
+	_, ok = d[k]
+	return
 }
 
 type Slice []interface{}


### PR DESCRIPTION
Add `Dict.HasKey` and `SDict.HasKey`, for checking whether the dictionary contains an entry for a particular key.

Presently, the status quo for checking whether a dictionary contains some key is to look up the entry and see if the value is truthy:

```
{{ if $d.Get $k }}
    {{/* $d has an entry for $k */}}
{{ end }}
```

The `HasKey` method improves on this in two ways:

1) It makes the code more self-documenting -- `$d.HasKey $k` is clear in intent.
2) It is more correct in edge cases -- if the dictionary can contain entries with zero values (e.g. 0, false) then `if $d.Get $k` may erroneously report that $d has no entry for $k.