### PR TITLE
templates: add getAllMessageReactions

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -532,6 +532,7 @@ func baseContextFuncs(c *Context) {
 	c.addContextFunc("deleteMessageReaction", c.tmplDelMessageReaction)
 	c.addContextFunc("deleteAllMessageReactions", c.tmplDelAllMessageReactions)
 	c.addContextFunc("getMessage", c.tmplGetMessage)
+	c.addContextFunc("getAllMessageReactions", c.tmplGetAllMessageReactions)
 	c.addContextFunc("getMember", c.tmplGetMember)
 	c.addContextFunc("getChannel", c.tmplGetChannel)
 	c.addContextFunc("getThread", c.tmplGetThread)


### PR DESCRIPTION
Expose the `MessageReactions` endpoint, which yields the users that reacted with an emoji on a message.
The `MessageReactions` endpoint is paginated (with `before` and `after`) parameters. This PR opts to abstract that out for the user by looping internally until all users are fetched.

To prevent abuse `getAllMessageReactions` is limited to one use per command, and is further limited to fetching 5000 users at maximum (which corresponds to 50 API calls.)

Tested to the best of my ability on a self-host, but I sadly don't have > 100 people to test with so it's possible the inner loop has bugs.

**Some things to consider:**

- Should this function be named `getAllMessageReactions`? It aligns with the API endpoint but I'm afraid the name may suggest that it fetches all message reactions (i.e. emojis.) Should we be more clear and name it something like `getAllReactedUsers`, or is this not a concern?
- Do the limits here make sense? Presently, `getAllMessageReactions` is limited to one use per command and counts as one API call. The problem is that -- being a paginated endpoint -- an unknown number of API requests is needed to fetch all reactions. The implementation here makes 50 API calls at max which are *not* counted toward the total API call counter, to keep the maximum number of reactions returned constant thereby allowing for more reliable error handling within custom commands. Is this behaviour acceptable? (Read the comments below for further context & discussion.)