### PR TITLE
verification: revert #1079

### DIFF
--- a/verification/verification_bot.go
+++ b/verification/verification_bot.go
@@ -125,7 +125,6 @@ func (p *Plugin) startVerificationProcess(conf *models.VerificationConfig, guild
 	if strings.TrimSpace(msg) == "" {
 		msg = DefaultDMMessage
 	}
-	msg = "DM sent from server **" + gs.Name + "**(ID: " + discordgo.StrID(gs.ID) + ")\n" + msg
 
 	ms, err := bot.GetMember(guildID, target.ID)
 	if err != nil {


### PR DESCRIPTION
Hi!

It looks like https://github.com/botlabs-gg/yagpdb/pull/1079 's `verification` part was not needed, only the `notifications` part. Reason being that the notification's function `func sendTemplate(...` handles sending the message internally, while the verification's function `func (p *Plugin) startVerificationProcess(...` uses the templates' function `ExecuteAndSendWithErrors` which already handles carrying the server data if a DM is sent. 

I really find this odd because prior to https://github.com/botlabs-gg/yagpdb/pull/1079 being merged, users reported that the verification DM did not contain any server data.

I have tested just simply reverting https://github.com/botlabs-gg/yagpdb/pull/1079 verification's change on my selfhost, and the DMs seem to work as expected. 
I'm opening this PR as a draft though because I really find this weird and would really appreciate others people opinion on this because I can't find a reason as to why the verification DM apparently didn't have any server data before https://github.com/botlabs-gg/yagpdb/pull/1079.