### PR TITLE
FIX: customcommands: fix execCC in threads

### DIFF
--- a/customcommands/tmplextensions.go
+++ b/customcommands/tmplextensions.go
@@ -190,7 +190,7 @@ func tmplRunCC(ctx *templates.Context) interface{} {
 			return "", errors.New("Unknown channel")
 		}
 
-		cs := ctx.GS.GetChannel(channelID)
+		cs := ctx.GS.GetChannelOrThread(channelID)
 		if cs == nil {
 			return "", errors.New("Channel not in state")
 		}

--- a/customcommands/tmplextensions.go
+++ b/customcommands/tmplextensions.go
@@ -270,7 +270,7 @@ func tmplScheduleUniqueCC(ctx *templates.Context) interface{} {
 			return "", errors.New("Unknown channel")
 		}
 
-		cs := ctx.GS.GetChannel(channelID)
+		cs := ctx.GS.GetChannelOrThread(channelID)
 		if cs == nil {
 			return "", errors.New("Channel not in state")
 		}


### PR DESCRIPTION
Any execCC calls currently break the command they're used in if said command is executed in a thread. This should hopefully fix that!

![image](https://user-images.githubusercontent.com/39113451/148590651-8033bc35-ea6d-431b-964b-dab12c97550d.png)
