### PR TITLE
Update help error message

### DIFF
--- a/commands/help.go
+++ b/commands/help.go
@@ -91,7 +91,7 @@ For more in depth help and information you should visit https://docs.yagpdb.xyz/
 		return embed, nil
 	})
 	if err != nil {
-		return "Something went wrong, make sure you don't have the bot blocked!", err
+		return "Something went wrong, make sure you don't have the bot blocked or your DMs closed!", err
 
 	}
 

--- a/stdcommands/throw/throwthings.go
+++ b/stdcommands/throw/throwthings.go
@@ -115,4 +115,5 @@ var throwThings = []string{
 	"doors",
 	"pie",
 	"squares",
+	"a duck",
 }


### PR DESCRIPTION
This is a command that is used quite often, and people can get confused with the "bot blocked" part in the error, as simple having your direct messages closed also prompts the same error. Just adding the "DMs closed" to the error could make things better