### PR TITLE
templates: trimSpace function

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -35,15 +35,16 @@ var (
 		"toByte":     ToByte,
 
 		// string manipulation
-		"joinStr":   joinStrings,
-		"lower":     strings.ToLower,
-		"upper":     strings.ToUpper,
-		"slice":     slice,
-		"urlescape": url.PathEscape,
-		"split":     strings.Split,
-		"title":     strings.Title,
 		"hasPrefix": strings.HasPrefix,
 		"hasSuffix": strings.HasSuffix,
+		"joinStr":   joinStrings,
+		"lower":     strings.ToLower,
+		"slice":     slice,
+		"split":     strings.Split,
+		"title":     strings.Title,
+		"trimSpace": strings.TrimSpace,
+		"upper":     strings.ToUpper,
+		"urlescape": url.PathEscape,
 
 		// math
 		"add":               add,


### PR DESCRIPTION
Users have mentioned the need of trimming white space around string many times, will add the simplest of trims golang strings package offers > all leading and trailing white space as defined by Unicode removed, 

Also starting a trend to alphabetically order StandardFuncmap keys already in the code, but this is not the purpose of this PR.