### PR TITLE
context data: CCTrigger

### DIFF
--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -695,6 +695,7 @@ func ExecuteCustomCommand(cmd *models.CustomCommand, tmplCtx *templates.Context)
 	tmplCtx.Name = "CC #" + strconv.Itoa(int(cmd.LocalID))
 	tmplCtx.Data["CCID"] = cmd.LocalID
 	tmplCtx.Data["CCRunCount"] = cmd.RunCount + 1
+	tmplCtx.Data["CCTrigger"] = cmd.TextTrigger
 
 	csCop := tmplCtx.CurrentFrame.CS
 	f := logger.WithFields(logrus.Fields{


### PR DESCRIPTION
Another thing users have requested is to query for the trigger's "name"... especially useful when dealing with regex. So it will add another context data element {{ .CCTrigger }}.