### PR TITLE
Update custom.js to make indentation easier

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -35,15 +35,16 @@ var (
 		"toByte":     ToByte,
 
 		// string manipulation
-		"joinStr":   joinStrings,
-		"lower":     strings.ToLower,
-		"upper":     strings.ToUpper,
-		"slice":     slice,
-		"urlescape": url.PathEscape,
-		"split":     strings.Split,
-		"title":     strings.Title,
 		"hasPrefix": strings.HasPrefix,
 		"hasSuffix": strings.HasSuffix,
+		"joinStr":   joinStrings,
+		"lower":     strings.ToLower,
+		"slice":     slice,
+		"split":     strings.Split,
+		"title":     strings.Title,
+		"trimSpace": strings.TrimSpace,
+		"upper":     strings.ToUpper,
+		"urlescape": url.PathEscape,
 
 		// math
 		"add":               add,

--- a/frontend/static/js/custom.js
+++ b/frontend/static/js/custom.js
@@ -1,7 +1,7 @@
 /* Add here all your JS customizations */
 
 /* This one is meant for tab-indent to be active in all textarea if marked tags; does not feature undo */
-$(document).delegate('.tab-textbox', 'keydown', function(e) { 
+$(document).delegate('.tab-textbox, .form-control', 'keydown', function(e) { 
 var keyCode = e.keyCode || e.which; 
 
     if (keyCode == 9) {

--- a/frontend/static/js/custom.js
+++ b/frontend/static/js/custom.js
@@ -1,7 +1,7 @@
 /* Add here all your JS customizations */
 
 /* This one is meant for tab-indent to be active in all textarea if marked tags; does not feature undo */
-$(document).delegate('.tab-textbox, .form-control', 'keydown', function(e) { 
+$(document).delegate('.tab-textbox, textarea.form-control', 'keydown', function(e) { 
 var keyCode = e.keyCode || e.which; 
 
     if (keyCode == 9) {


### PR DESCRIPTION
This pull request will cause the `Tab` key to add indentation instead of jumping to the next element when in one of the textareas.