### PR TITLE
templates: unconditionally include fields in structToSdict

### DIFF
--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -132,7 +132,6 @@ func KindOf(input interface{}, flag ...bool) (string, error) { //flag used only 
 }
 
 func StructToSdict(value interface{}) (SDict, error) {
-
 	val, isNil := indirect(reflect.ValueOf(value))
 	typeOfS := val.Type()
 	if isNil || value == nil {
@@ -146,9 +145,7 @@ func StructToSdict(value interface{}) (SDict, error) {
 	fields := make(map[string]interface{})
 	for i := 0; i < val.NumField(); i++ {
 		curr := val.Field(i)
-		if curr.CanSet() {
-			fields[typeOfS.Field(i).Name] = curr.Interface()
-		}
+		fields[typeOfS.Field(i).Name] = curr.Interface()
 	}
 	return SDict(fields), nil
 


### PR DESCRIPTION
Remove a counterproductive check for the settability of fields in `structToSdict`. This fixes a bug where calling `structToSdict` on a struct of a value type (as opposed to a pointer) resulted in an empty map:

```
{{ $x := index .Guild.Channels 0 }} {{ structToSdict $x }}
{{/* empty map; $x is of type dstate.ChannelState */}}

{{ $y := .Guild.GetChannel .Channel.ID }} {{ structToSdict $y }}
{{/* filled map; $y is of type *dstate.ChannelState */}}
```

After this patch, both produce similar output, as desired.

For context, `reflect.Value.CanSet` reports whether the corresponding field can be written to. Since we are not writing to the fields of the struct -- we're just reading the values -- the check is unnecessary. Further, since only reflection values obtained from a value containing a pointer to a struct have writable fields, the check is incorrect; it prevents valid use of the function with a value type.

Credit for finding this bug goes to `galen#8183`, who commented on the issue on Discord :-)
