### PR TITLE
templates: add CanInterface check to structToSdict

### DIFF
--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -145,7 +145,9 @@ func StructToSdict(value interface{}) (SDict, error) {
 	fields := make(map[string]interface{})
 	for i := 0; i < val.NumField(); i++ {
 		curr := val.Field(i)
-		fields[typeOfS.Field(i).Name] = curr.Interface()
+		if curr.CanInterface() {
+			fields[typeOfS.Field(i).Name] = curr.Interface()
+		}
 	}
 	return SDict(fields), nil
 
@@ -315,7 +317,7 @@ func indirect(v reflect.Value) (rv reflect.Value, isNil bool) {
 func in(l interface{}, v interface{}) bool {
 	lv, _ := indirect(reflect.ValueOf(l))
 	vv := reflect.ValueOf(v)
-	
+
 	if !reflect.ValueOf(vv).IsZero() {
 		switch lv.Kind() {
 		case reflect.Array, reflect.Slice:


### PR DESCRIPTION
Follow-up to #1122.

The original check, `CanSet`, was too narrow (as explained in the prior PR), excluding fields on struct value types. However, removing the check entirely resulted in a regression; `structToSdict` would attempt to include unexported fields which resulting in panics.

This patch adds back a different check, `CanInterface`, which only excludes unexported fields. This avoids panics (`CanInterface` is true iff `Interface` does not panic) while still fixing the issue mentioned in #1122.

Thank you to @mrbentarikau for alerting me to this issue and to @buthed010203 for discovering it.

@ashishjh-bst, this fixes a regression introduced by a previous PR that has not yet been deployed (and so it's important to either revert the previous PR or merge this one before the next deploy.)