### PR TITLE
customcommands: fix typo in hourly interval error

### DIFF
--- a/customcommands/customcommands.go
+++ b/customcommands/customcommands.go
@@ -174,7 +174,7 @@ func (cc *CustomCommand) Validate(tmpl web.TemplateData) (ok bool) {
 	}
 
 	if cc.TriggerTypeForm == "interval_hours" && (cc.TimeTriggerInterval < MinIntervalTriggerDurationHours || cc.TimeTriggerInterval > MaxIntervalTriggerDurationHours) {
-		tmpl.AddAlerts(web.ErrorAlert(fmt.Sprintf("Hour interval can be between %v and %v", MinIntervalTriggerDurationHours, MaxIntervalTriggerDurationHours)))
+		tmpl.AddAlerts(web.ErrorAlert(fmt.Sprintf("Hourly interval can be between %v and %v", MinIntervalTriggerDurationHours, MaxIntervalTriggerDurationHours)))
 		return false
 	}
 


### PR DESCRIPTION
This PR makes the changes requested [here](https://trello.com/c/nEj73iGd) and changes "hour" to "hourly".