### PR TITLE
Added validations for Autodelete trigger and response deletion delay

### DIFF
--- a/commands/assets/commands.html
+++ b/commands/assets/commands.html
@@ -238,7 +238,7 @@
                             {{if .Override.AutodeleteTrigger}}checked{{end}}>
                     </span>
                 </span>
-                <input type="number" min="0" max="3600" class="form-control" placeholder="Seconds..."
+                <input type="number" min="0" max="2678400" class="form-control" placeholder="Seconds..."
                     value="{{if .Override}}{{.Override.AutodeleteTriggerDelay}}{{else}}10{{end}}"
                     name="AutodeleteTriggerDelay">
             </div>
@@ -252,7 +252,7 @@
                             {{if .Override.AutodeleteResponse}}checked{{end}}>
                     </span>
                 </span>
-                <input type="number" min="0" max="3600" class="form-control" placeholder="Seconds..."
+                <input type="number" min="0" max="2678400" class="form-control" placeholder="Seconds..."
                     value="{{if .Override}}{{.Override.AutodeleteResponseDelay}}{{else}}10{{end}}"
                     name="AutodeleteResponseDelay">
             </div>
@@ -357,7 +357,7 @@
                                         {{if .Override.AutodeleteTrigger}}checked{{end}}>
                                 </span>
                             </span>
-                            <input type="number" min="0" max="3600" class="form-control" placeholder="Seconds..."
+                            <input type="number" min="0" max="2678400" class="form-control" placeholder="Seconds..."
                                 value="{{if .Override}}{{.Override.AutodeleteTriggerDelay}}{{else}}10{{end}}"
                                 name="AutodeleteTriggerDelay">
                         </div>
@@ -371,7 +371,7 @@
                                         {{if .Override.AutodeleteResponse}}checked{{end}}>
                                 </span>
                             </span>
-                            <input type="number" min="0" max="3600" class="form-control" placeholder="Seconds..."
+                            <input type="number" min="0" max="2678400" class="form-control" placeholder="Seconds..."
                                 value="{{if .Override}}{{.Override.AutodeleteResponseDelay}}{{else}}10{{end}}"
                                 name="AutodeleteResponseDelay">
                         </div>

--- a/commands/assets/commands.html
+++ b/commands/assets/commands.html
@@ -238,7 +238,7 @@
                             {{if .Override.AutodeleteTrigger}}checked{{end}}>
                     </span>
                 </span>
-                <input type="number" min="0" class="form-control" placeholder="Seconds..."
+                <input type="number" min="0" max="3600" class="form-control" placeholder="Seconds..."
                     value="{{if .Override}}{{.Override.AutodeleteTriggerDelay}}{{else}}10{{end}}"
                     name="AutodeleteTriggerDelay">
             </div>
@@ -252,7 +252,7 @@
                             {{if .Override.AutodeleteResponse}}checked{{end}}>
                     </span>
                 </span>
-                <input type="number" min="0" class="form-control" placeholder="Seconds..."
+                <input type="number" min="0" max="3600" class="form-control" placeholder="Seconds..."
                     value="{{if .Override}}{{.Override.AutodeleteResponseDelay}}{{else}}10{{end}}"
                     name="AutodeleteResponseDelay">
             </div>
@@ -357,7 +357,7 @@
                                         {{if .Override.AutodeleteTrigger}}checked{{end}}>
                                 </span>
                             </span>
-                            <input type="number" class="form-control" placeholder="Seconds..."
+                            <input type="number" min="0" max="3600" class="form-control" placeholder="Seconds..."
                                 value="{{if .Override}}{{.Override.AutodeleteTriggerDelay}}{{else}}10{{end}}"
                                 name="AutodeleteTriggerDelay">
                         </div>
@@ -371,7 +371,7 @@
                                         {{if .Override.AutodeleteResponse}}checked{{end}}>
                                 </span>
                             </span>
-                            <input type="number" min="0" class="form-control" placeholder="Seconds..."
+                            <input type="number" min="0" max="3600" class="form-control" placeholder="Seconds..."
                                 value="{{if .Override}}{{.Override.AutodeleteResponseDelay}}{{else}}10{{end}}"
                                 name="AutodeleteResponseDelay">
                         </div>

--- a/commands/plugin_web.go
+++ b/commands/plugin_web.go
@@ -38,8 +38,8 @@ type ChannelOverrideForm struct {
 	CommandsEnabled         bool
 	AutodeleteResponse      bool
 	AutodeleteTrigger       bool
-	AutodeleteResponseDelay int
-	AutodeleteTriggerDelay  int
+	AutodeleteResponseDelay int     `valid:"0,3600"`
+	AutodeleteTriggerDelay  int     `valid:"0,3600"`
 	RequireRoles            []int64 `valid:"role,true"`
 	IgnoreRoles             []int64 `valid:"role,true"`
 }
@@ -49,8 +49,8 @@ type CommandOverrideForm struct {
 	CommandsEnabled         bool
 	AutodeleteResponse      bool
 	AutodeleteTrigger       bool
-	AutodeleteResponseDelay int
-	AutodeleteTriggerDelay  int
+	AutodeleteResponseDelay int     `valid:"0,3600"`
+	AutodeleteTriggerDelay  int     `valid:"0,3600"`
 	RequireRoles            []int64 `valid:"role,true"`
 	IgnoreRoles             []int64 `valid:"role,true"`
 }

--- a/commands/plugin_web.go
+++ b/commands/plugin_web.go
@@ -38,8 +38,8 @@ type ChannelOverrideForm struct {
 	CommandsEnabled         bool
 	AutodeleteResponse      bool
 	AutodeleteTrigger       bool
-	AutodeleteResponseDelay int     `valid:"0,3600"`
-	AutodeleteTriggerDelay  int     `valid:"0,3600"`
+	AutodeleteResponseDelay int     `valid:"0,2678400"`
+	AutodeleteTriggerDelay  int     `valid:"0,2678400"`
 	RequireRoles            []int64 `valid:"role,true"`
 	IgnoreRoles             []int64 `valid:"role,true"`
 }
@@ -49,8 +49,8 @@ type CommandOverrideForm struct {
 	CommandsEnabled         bool
 	AutodeleteResponse      bool
 	AutodeleteTrigger       bool
-	AutodeleteResponseDelay int     `valid:"0,3600"`
-	AutodeleteTriggerDelay  int     `valid:"0,3600"`
+	AutodeleteResponseDelay int     `valid:"0,2678400"`
+	AutodeleteTriggerDelay  int     `valid:"0,2678400"`
 	RequireRoles            []int64 `valid:"role,true"`
 	IgnoreRoles             []int64 `valid:"role,true"`
 }


### PR DESCRIPTION
**YAGPDB Control Panel > Core > Command Settings**
User was able to add and save negative and very large values for "Autodelete Trigger after" and "Autodelete Response after".
This pull request adds range validation for these fields in both Channel and Command Override.