### PR TITLE
Fix gap between dropdown toggle button and options list

### DIFF
--- a/frontend/static/css/custom.css
+++ b/frontend/static/css/custom.css
@@ -212,10 +212,6 @@ html.sidebar-left-collapsed #nav-footer {
 	transform: translate3d(0px, 0px, 0px) !important;
 }
 
-.multiselect-container {
-	top: 125px !important;
-}
-
 /*Proper Design, Jonas is angry at bootstrap*/
 
 .card {

--- a/frontend/static/vendorr/bootstrap-multiselect/bootstrap-multiselect.js
+++ b/frontend/static/vendorr/bootstrap-multiselect/bootstrap-multiselect.js
@@ -403,7 +403,7 @@
             buttonClass: 'btn btn-default',
             inheritClass: false,
             buttonWidth: 'auto',
-            buttonContainer: '<div class="btn-group dropup" />',
+            buttonContainer: '<div class="btn-group dropdown" />',
             dropRight: false,
             dropUp: false,
             selectedClass: 'active',

--- a/frontend/templates/cp_main.html
+++ b/frontend/templates/cp_main.html
@@ -86,7 +86,7 @@
             </div>
         </section>
     </div>
-    <section class="body" style="margin-bottom: 150px;">
+    <section class="body">
         {{template "cp_nav_header" .}}
 
         <div class="inner-wrapper">


### PR DESCRIPTION
For every multiselect on the YAGPDB web app, there was bootstrap's dropup being used. In some cases when the options are less than three, there was a visible gap between the dropdown toggle button and the options list as can be seen in the following screenshot:
<img width="163" alt="Screenshot 2022-03-10 at 1 26 58 PM" src="https://user-images.githubusercontent.com/98815360/157646870-f623388d-8cad-41f4-9900-8f47cdb04eb5.png">

This PR fixes the issue by removing the extra 125px from top.
Also changing the dropup to dropdown to make the single select and multiselect consistent.
The new is shown in the following screenshot:
<img width="162" alt="Screenshot 2022-03-10 at 1 27 48 PM" src="https://user-images.githubusercontent.com/98815360/157647447-392b6392-6dca-4f36-b08d-992cb2089dd4.png">

