### PR TITLE
Fix deleted roles not getting removed simultaneously from automod-v2 drop down

### DIFF
--- a/web/template.go
+++ b/web/template.go
@@ -138,7 +138,7 @@ OUTER:
 			}
 		}
 
-		builder.WriteString(fmt.Sprintf(`<option value="0" selected>Deleted role: %d</option>\n`, sr))
+		builder.WriteString(fmt.Sprintf(`<option value="%[1]d" selected>Deleted role: %[1]d</option>\n`, sr))
 	}
 
 	for k, role := range roles {


### PR DESCRIPTION
When roles selected in "Automod v2 conditions" are deleted, the menu shows "Deleted Role: 0" for each deleted role. When you try to uncheck all these roles and proceed to save, only one of the roles is removed at a time from the list.

The root cause of the issue was that all the deleted roles were assigned value="0" in the <option> tag. Due to this, the multiselector was behaving abnormally. This PR updates the value of such roles with their ID (which will be unique).