### PR TITLE
Update middleware validator to handle only min value, add min value validations in various forms

### DIFF
--- a/autorole/autorole.go
+++ b/autorole/autorole.go
@@ -37,7 +37,7 @@ func RegisterPlugin() {
 
 type GeneralConfig struct {
 	Role             int64 `json:",string" valid:"role,true"`
-	RequiredDuration int
+	RequiredDuration int   `valid:"0,"`
 
 	RequiredRoles []int64 `valid:"role,true"`
 	IgnoreRoles   []int64 `valid:"role,true"`

--- a/moderation/models.go
+++ b/moderation/models.go
@@ -42,7 +42,7 @@ type Config struct {
 	MuteIgnoreChannels      pq.Int64Array `gorm:"type:bigint[]" valid:"channel,true"`
 	MuteMessage             string        `valid:"template,5000"`
 	UnmuteMessage           string        `valid:"template,5000"`
-	DefaultMuteDuration     sql.NullInt64 `gorm:"default:10"`
+	DefaultMuteDuration     sql.NullInt64 `gorm:"default:10" valid:"0,"`
 
 	// Warn
 	WarnCommandsEnabled    bool

--- a/reddit/plugin_web.go
+++ b/reddit/plugin_web.go
@@ -38,7 +38,7 @@ type CreateForm struct {
 	ID         int64  `schema:"id"`
 	UseEmbeds  bool   `schema:"use_embeds"`
 	NSFWMode   int    `schema:"nsfw_filter"`
-	MinUpvotes int    `schema:"min_upvotes"`
+	MinUpvotes int    `schema:"min_upvotes" valid:"0,"`
 }
 
 type UpdateForm struct {
@@ -46,7 +46,7 @@ type UpdateForm struct {
 	ID         int64 `schema:"id"`
 	UseEmbeds  bool  `schema:"use_embeds"`
 	NSFWMode   int   `schema:"nsfw_filter"`
-	MinUpvotes int   `schema:"min_upvotes"`
+	MinUpvotes int   `schema:"min_upvotes" valid:"0,"`
 }
 
 var (

--- a/reputation/plugin_web.go
+++ b/reputation/plugin_web.go
@@ -29,10 +29,10 @@ var PageHTMLSettings string
 type PostConfigForm struct {
 	Enabled                 bool
 	EnableThanksDetection   bool
-	PointsName              string `valid:",50"`
-	Cooldown                int    `valid:"0,86401"` // One day
-	MaxGiveAmount           int64
-	MaxRemoveAmount         int64
+	PointsName              string  `valid:",50"`
+	Cooldown                int     `valid:"0,86401"` // One day
+	MaxGiveAmount           int64   `valid:"0,"`
+	MaxRemoveAmount         int64   `valid:"0,"`
 	RequiredGiveRoles       []int64 `valid:"role,true"`
 	RequiredReceiveRoles    []int64 `valid:"role,true"`
 	BlacklistedGiveRoles    []int64 `valid:"role,true"`

--- a/rolecommands/web.go
+++ b/rolecommands/web.go
@@ -56,8 +56,8 @@ type FormGroup struct {
 
 	Mode int
 
-	MultipleMax int
-	MultipleMin int
+	MultipleMax int `valid:"0,250"`
+	MultipleMin int `valid:"0,250"`
 
 	SingleAutoToggleOff   bool
 	SingleRequireOne      bool

--- a/verification/verification_web.go
+++ b/verification/verification_web.go
@@ -35,8 +35,8 @@ type FormData struct {
 	Enabled             bool
 	VerifiedRole        int64  `valid:"role"`
 	PageContent         string `valid:",10000"`
-	KickUnverifiedAfter int
-	WarnUnverifiedAfter int
+	KickUnverifiedAfter int    `valid:"0,"`
+	WarnUnverifiedAfter int    `valid:"0,"`
 	WarnMessage         string `valid:"template,10000"`
 	DMMessage           string `valid:"template,10000"`
 	LogChannel          int64  `valid:"channel,true"`

--- a/web/validation.go
+++ b/web/validation.go
@@ -114,8 +114,8 @@ func ValidateForm(guild *dstate.GuildSet, tmpl TemplateData, form interface{}) b
 		// Perform validation based on value type
 		switch cv := vField.Interface().(type) {
 		case int:
-			min, max := readMinMax(validationTag)
-			err = ValidateIntMinMaxField(int64(cv), int64(min), int64(max))
+			min, max, onlyMin := readMinMax(validationTag)
+			err = ValidateIntMinMaxField(int64(cv), int64(min), int64(max), onlyMin)
 		case int64:
 			var keep bool
 			keep, err = ValidateIntField(cv, validationTag, guild, false)
@@ -130,11 +130,11 @@ func ValidateForm(guild *dstate.GuildSet, tmpl TemplateData, form interface{}) b
 				vField.Set(reflect.ValueOf(newNullInt))
 			}
 		case float64:
-			min, max := readMinMax(validationTag)
-			err = ValidateFloatField(cv, min, max)
+			min, max, onlyMin := readMinMax(validationTag)
+			err = ValidateFloatField(cv, min, max, onlyMin)
 		case float32:
-			min, max := readMinMax(validationTag)
-			err = ValidateFloatField(float64(cv), min, max)
+			min, max, onlyMin := readMinMax(validationTag)
+			err = ValidateFloatField(float64(cv), min, max, onlyMin)
 		case string:
 			var newS string
 			newS, err = ValidateStringField(cv, validationTag, guild)
@@ -219,12 +219,15 @@ func ValidateForm(guild *dstate.GuildSet, tmpl TemplateData, form interface{}) b
 	return ok
 }
 
-func readMinMax(valid *ValidationTag) (float64, float64) {
-
+func readMinMax(valid *ValidationTag) (float64, float64, bool) {
+	onlyMin := false
 	min, _ := valid.Float(0)
 	max, _ := valid.Float(1)
+	if valid.values[1] == "" {
+		onlyMin = true
+	}
 
-	return min, max
+	return min, max, onlyMin
 }
 
 func ValidateIntSliceField(is []int64, tags *ValidationTag, guild *dstate.GuildSet) (filtered []int64, err error) {
@@ -248,8 +251,8 @@ func ValidateIntField(i int64, tags *ValidationTag, guild *dstate.GuildSet, forc
 
 	if kind != "role" && kind != "channel" {
 		// Treat as min max
-		min, max := readMinMax(tags)
-		return true, ValidateIntMinMaxField(i, int64(min), int64(max))
+		min, max, onlyMin := readMinMax(tags)
+		return true, ValidateIntMinMaxField(i, int64(min), int64(max), onlyMin)
 	}
 
 	if kind == "" {
@@ -284,7 +287,11 @@ func ValidateIntField(i int64, tags *ValidationTag, guild *dstate.GuildSet, forc
 
 }
 
-func ValidateIntMinMaxField(i int64, min, max int64) error {
+func ValidateIntMinMaxField(i int64, min, max int64, onlyMin bool) error {
+
+	if onlyMin && i < min {
+		return fmt.Errorf("should be at least %d", min)
+	}
 
 	if min != max && (i < min || i > max) {
 		return fmt.Errorf("out of range (%d - %d)", min, max)
@@ -293,7 +300,11 @@ func ValidateIntMinMaxField(i int64, min, max int64) error {
 	return nil
 }
 
-func ValidateFloatField(f float64, min, max float64) error {
+func ValidateFloatField(f float64, min, max float64, onlyMin bool) error {
+
+	if onlyMin && f < min {
+		return fmt.Errorf("should be at least %f", min)
+	}
 
 	if min != max && (f < min || f > max) {
 		return fmt.Errorf("out of range (%f - %f)", min, max)

--- a/web/validation.go
+++ b/web/validation.go
@@ -220,14 +220,11 @@ func ValidateForm(guild *dstate.GuildSet, tmpl TemplateData, form interface{}) b
 }
 
 func readMinMax(valid *ValidationTag) (float64, float64, bool) {
-	onlyMin := false
+
 	min, _ := valid.Float(0)
 	max, _ := valid.Float(1)
-	if valid.values[1] == "" {
-		onlyMin = true
-	}
 
-	return min, max, onlyMin
+	return min, max, valid.values[1] == "" // Last value is a flag which represents that only min value is provided
 }
 
 func ValidateIntSliceField(is []int64, tags *ValidationTag, guild *dstate.GuildSet) (filtered []int64, err error) {


### PR DESCRIPTION
1. Updated the readMinMax function to handle empty max value so that only min value can be provided (for example: a field that requires positive number, hence min=0 and no max value). For this field the validation will be described as:
```
type Example struct {
    PositiveField int `valid:"0,"`
}
```
Here only min value (0) will be validated, and if negative value is entered, it will show an error:
```
Positive Field: should be at least 0
```

2. Several forms on the control panel didn't have proper validations on the backend, this PR adds those validations.