### PR TITLE
Make user argument required in warnings list command

### DIFF
--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -664,7 +664,7 @@ var ModerationCommands = []*commands.YAGCommand{
 		Name:          "Warnings",
 		Description:   "Lists warning of a user.",
 		Aliases:       []string{"Warns"},
-		RequiredArgs:  0,
+		RequiredArgs:  1,
 		Arguments: []*dcmd.ArgDef{
 			{Name: "User", Type: dcmd.UserID, Default: 0},
 			{Name: "Page", Type: &dcmd.IntArg{Max: 10000}, Default: 0},


### PR DESCRIPTION
The user argument was not required in -warns or -warnings command, so it was taking 0 as default user id. This PR makes the user argument required for this command to run.