### PR TITLE
templates: support threads in `"channel"` carg

### DIFF
--- a/customcommands/tmplextensions.go
+++ b/customcommands/tmplextensions.go
@@ -77,7 +77,7 @@ func tmplCArg(typ string, name string, opts ...interface{}) (*dcmd.ArgDef, error
 	case "userid":
 		def.Type = dcmd.UserID
 	case "channel":
-		def.Type = dcmd.Channel
+		def.Type = dcmd.ChannelOrThread
 	case "member":
 		def.Type = &commands.MemberArg{}
 	case "role":


### PR DESCRIPTION
This was brought up on the support server, where a user tried to give a
thread as channel argument using `parseArgs` in their custom command.

Arguably, the current behaviour can be considered intended, however I
personally believe that adding another (if not two more) variations like
`"thread"` and `"channel-or-thread"` are undesirable and add more
complication than necessary.

The normal user would expect `parseArgs` to accept also threads as a
`"channel"` carg, and this commit implements exactly that behaviour.