### PR TITLE
Update TimeTriggerInterval to 5 in interval test cases

### DIFF
--- a/customcommands/interval_test.go
+++ b/customcommands/interval_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNextRunTimeBasic(t *testing.T) {
 	cc := &models.CustomCommand{
-		TimeTriggerInterval: 1,
+		TimeTriggerInterval: 5,
 	}
 
 	tim := time.Now().UTC()
@@ -25,8 +25,9 @@ func TestNextRunTimeBasic(t *testing.T) {
 	cc.LastRun = null.TimeFrom(tim)
 
 	next := CalcNextRunTime(cc, tim)
-	if next != tim.UTC().Add(time.Minute) {
-		t.Error("incorrect next run, should be: ", tim.UTC().Add(time.Minute), ", got: ", next)
+	expected := tim.UTC().Add(time.Minute * 5)
+	if next != expected {
+		t.Error("incorrect next run, should be: ", expected, ", got: ", next)
 	}
 }
 
@@ -52,14 +53,14 @@ func TestNextRunTimeImpossible(t *testing.T) {
 
 func TestNextRunTimeExcludingHours(t *testing.T) {
 	cc := &models.CustomCommand{
-		TimeTriggerInterval:       1,
+		TimeTriggerInterval:       5,
 		TimeTriggerExcludingHours: []int64{0, 1},
 	}
 
 	tim := time.Time{}
 
 	nextRun := CalcNextRunTime(cc, tim)
-	expected := tim.Add((time.Hour * 2) + time.Minute)
+	expected := tim.Add((time.Hour * 2) + (time.Minute * 5))
 
 	if nextRun != expected {
 		t.Error("next run should be now: ", expected, ", got: ", nextRun)
@@ -68,7 +69,7 @@ func TestNextRunTimeExcludingHours(t *testing.T) {
 
 func TestNextRunTimeExcludingDays(t *testing.T) {
 	cc := &models.CustomCommand{
-		TimeTriggerInterval:      1,
+		TimeTriggerInterval:      5,
 		TimeTriggerExcludingDays: []int64{0, 1},
 	}
 
@@ -84,7 +85,7 @@ func TestNextRunTimeExcludingDays(t *testing.T) {
 
 func TestNextRunTimeExcludingDaysHours(t *testing.T) {
 	cc := &models.CustomCommand{
-		TimeTriggerInterval:       1,
+		TimeTriggerInterval:       5,
 		TimeTriggerExcludingDays:  []int64{2},
 		TimeTriggerExcludingHours: []int64{0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23},
 	}

--- a/customcommands/interval_test.go
+++ b/customcommands/interval_test.go
@@ -49,6 +49,18 @@ func TestNextRunTimeImpossible(t *testing.T) {
 	if !next.IsZero() {
 		t.Error("next time is not zero: ", next)
 	}
+
+	cc.TimeTriggerExcludingDays = nil
+	next = CalcNextRunTime(cc, time.Now())
+	if !next.IsZero() {
+		t.Error("next time is not zero: ", next)
+	}
+
+	cc.TimeTriggerInterval = 44641
+	next = CalcNextRunTime(cc, time.Now())
+	if !next.IsZero() {
+		t.Error("next time is not zero: ", next)
+	}
 }
 
 func TestNextRunTimeExcludingHours(t *testing.T) {


### PR DESCRIPTION
Some test cases were failing after the condition for validating `TimeTriggerInterval` was added. This PR updates the interval in those settings to be in the new range.