### PR TITLE
Add API to handle update and run now for interval custom commands

### DIFF
--- a/customcommands/assets/customcommands-editcmd.html
+++ b/customcommands/assets/customcommands-editcmd.html
@@ -370,7 +370,7 @@
                         <div class="row mt-4" id="interval-cc-run-now">
                             <div class="col">
                                 <button type="submit" class="btn btn-secondary btn-block" title="This will trigger this custom command immediately"
-                                    formaction="/manage/{{$guild}}/customcommands/commands/{{.CC.LocalID}}/run_now">Run now</button>
+                                    formaction="/manage/{{$guild}}/customcommands/commands/{{.CC.LocalID}}/update_and_run">Run now</button>
                             </div>
                         </div>
                     </form>

--- a/customcommands/web.go
+++ b/customcommands/web.go
@@ -99,6 +99,7 @@ func (p *Plugin) InitWeb() {
 	subMux.Handle(pat.Post("/commands/:cmd/update"), web.ControllerPostHandler(handleUpdateCommand, getCmdHandler, CustomCommand{}))
 	subMux.Handle(pat.Post("/commands/:cmd/delete"), web.ControllerPostHandler(handleDeleteCommand, getHandler, nil))
 	subMux.Handle(pat.Post("/commands/:cmd/run_now"), web.ControllerPostHandler(handleRunCommandNow, getCmdHandler, nil))
+	subMux.Handle(pat.Post("/commands/:cmd/update_and_run"), web.ControllerPostHandler(handleUpdateAndRunNow, getCmdHandler, CustomCommand{}))
 
 	subMux.Handle(pat.Post("/creategroup"), web.ControllerPostHandler(handleNewGroup, getHandler, GroupForm{}))
 	subMux.Handle(pat.Post("/groups/:group/update"), web.ControllerPostHandler(handleUpdateGroup, getGroupHandler, GroupForm{}))
@@ -399,6 +400,14 @@ func handleRunCommandNow(w http.ResponseWriter, r *http.Request) (web.TemplateDa
 	go pubsub.Publish("custom_commands_run_now", activeGuild.ID, cmd)
 
 	return templateData, nil
+}
+
+func handleUpdateAndRunNow(w http.ResponseWriter, r *http.Request) (web.TemplateData, error) {
+	updateData, err := handleUpdateCommand(w, r)
+	if err != nil {
+		return updateData, err
+	}
+	return handleRunCommandNow(w, r)
 }
 
 // allow for max 5 triggers with intervals of less than 10 minutes


### PR DESCRIPTION
On Edit Custom Command page, if the type of command is interval based, then a button Run Now is shown along with Save and Delete buttons. The button when clicked just ran the custom command without updating it (if there were any changes).
This PR adds an API `/manage/{{$guild}}/customcommands/commands/{{.CC.LocalID}}/update_and_run` which is triggered from that button, and updates and then runs the custom command.