### PR TITLE
customcommands: use CSOrThread() instead

### DIFF
--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -431,7 +431,7 @@ func handleMessageReactions(evt *eventsystem.EventData) {
 		return
 	}
 
-	cState := evt.CS()
+	cState := evt.CSOrThread()
 	if cState == nil {
 		return
 	}


### PR DESCRIPTION
This commit modifies `customcommands/bot.go` to use the `CSOrThread()`
method introduced with support for threads.

Previously, reaction-based custom commands were not triggering inside
threads, as the `EventData.CS()` method only works for true channels,
unlike `EventData.CSOrThread()`, which also supports threads.

This regression was most likely an oversight when introducing thread
support in YAGPDB.