### PR TITLE
Improve autorole assignment through Retroactive Full Scan

### DIFF
--- a/autorole/assets/autorole.html
+++ b/autorole/assets/autorole.html
@@ -10,49 +10,52 @@
 <form method="post" action="/manage/{{.ActiveGuild.ID}}/autorole" data-async-form>
     <div class="row">
         <div class="col-lg-12">
-            <div class="card {{if ne .Autorole.Role 0}} card-featured card-featured-success{{end}}">
-                <div class="card-body">
-                    <p><b>Changes may take up to a minute before they have any effect</b></p>
-                    <div class="form-group">
-                        <label for="autorole-role">Automatically assign members this role</label>
-                        <select id="autorole-role" class="form-control" name="Role">
-                            {{roleOptions .ActiveGuild.Roles .HighestRole .Autorole.Role "None (disabled)"}}
-                        </select>
-                    </div>
-                    <div class="form-group">
-                        <label for="autorole-duration">Minutes of membership required for role (<b>Disclaimer:</b> Will
-                            not work if you have it set to only give roles on join)</label>
-                        <input type="number" min="0" class="form-control" id="autorole-duration" name="RequiredDuration"
-                            placeholder="" value="{{if .Autorole.OnlyOnJoin}}0{{else}}{{.Autorole.RequiredDuration}}{{end}}" {{if .Autorole.OnlyOnJoin}}disabled{{end}}>
-                    </div>
-                    <div class="form-group">
-                        <label>Require one of these roles to be present on the member</label><br />
-                        <select name="RequiredRoles" class="multiselect form-control" multiple="multiple"
-                            id="require-roles" data-plugin-multiselect>
-                            {{roleOptionsMulti .ActiveGuild.Roles nil .Autorole.RequiredRoles}}
-                        </select>
-                    </div>
-                    <div class="form-group">
-                        <label>Ignore people with the following roles</label><br />
-                        <select name="IgnoreRoles" class="multiselect form-control" multiple="multiple"
-                            id="ignore-roles" data-plugin-multiselect>
-                            {{roleOptionsMulti .ActiveGuild.Roles nil .Autorole.IgnoreRoles}}
-                        </select>
-                    </div>
-                    <div class="form-group">
-                        {{checkbox "OnlyOnJoin" "OnlyOnJoin" `Only assign the role when they join, do not give it back if it's removed from them afterwards. (<b>Note:</b> Above mentioned conditions will be checked before assigning the role)` .Autorole.OnlyOnJoin `onchange="toggleOnlyOnJoin(this)"`}}
-                    </div>
-                    <div class="form-group">
-                        {{checkbox "AssignRoleAfterScreening" "AssignRoleAfterScreening" `Only assign the role after a member has completed Discord's Membership Screening` .Autorole.AssignRoleAfterScreening}}
-                    </div>
+            <fieldset {{if .FullScanActive}}disabled{{end}}>
+                <div class="card {{if ne .Autorole.Role 0}} card-featured card-featured-success{{end}}">
+                    <div class="card-body">
+                        {{if .FullScanActive}}<p class="text-danger">Form is disabled because full scan is running. To update the Autorole config, cancel the Full scan.</p>{{end}}
+                        <p><b>Changes may take up to a minute before they have any effect</b></p>
+                        <div class="form-group">
+                            <label for="autorole-role">Automatically assign members this role</label>
+                            <select id="autorole-role" class="form-control" name="Role">
+                                {{roleOptions .ActiveGuild.Roles .HighestRole .Autorole.Role "None (disabled)"}}
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="autorole-duration">Minutes of membership required for role (<b>Disclaimer:</b> Will
+                                not work if you have it set to only give roles on join)</label>
+                            <input type="number" min="0" class="form-control" id="autorole-duration" name="RequiredDuration"
+                                placeholder="" value="{{if .Autorole.OnlyOnJoin}}0{{else}}{{.Autorole.RequiredDuration}}{{end}}" {{if .Autorole.OnlyOnJoin}}disabled{{end}}>
+                        </div>
+                        <div class="form-group">
+                            <label>Require one of these roles to be present on the member</label><br />
+                            <select name="RequiredRoles" class="multiselect form-control" multiple="multiple"
+                                id="require-roles" data-plugin-multiselect>
+                                {{roleOptionsMulti .ActiveGuild.Roles nil .Autorole.RequiredRoles}}
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label>Ignore people with the following roles</label><br />
+                            <select name="IgnoreRoles" class="multiselect form-control" multiple="multiple"
+                                id="ignore-roles" data-plugin-multiselect>
+                                {{roleOptionsMulti .ActiveGuild.Roles nil .Autorole.IgnoreRoles}}
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            {{checkbox "OnlyOnJoin" "OnlyOnJoin" `Only assign the role when they join, do not give it back if it's removed from them afterwards. (<b>Note:</b> Above mentioned conditions will be checked before assigning the role)` .Autorole.OnlyOnJoin `onchange="toggleOnlyOnJoin(this)"`}}
+                        </div>
+                        <div class="form-group">
+                            {{checkbox "AssignRoleAfterScreening" "AssignRoleAfterScreening" `Only assign the role after a member has completed Discord's Membership Screening` .Autorole.AssignRoleAfterScreening}}
+                        </div>
 
-                    <p>Currently assigning role to <code>{{.Processing}}</code> members. ETA:
-                        <code>{{.ProcessingETA}}</code> minutes (May take up to a minute before the bot starts assigning
-                        roles).<br>
-                        <b>To stop, set the role to "None".</b></p>
-                    <button type="submit" class="btn btn-success btn-lg btn-block">Save</button>
+                        <p>Currently assigning role to <code>{{.Processing}}</code> members. ETA:
+                            <code>{{.ProcessingETA}}</code> minutes (May take up to a minute before the bot starts assigning
+                            roles).<br>
+                            <b>To stop, set the role to "None".</b></p>
+                        <button type="submit" class="btn btn-success btn-lg btn-block">Save</button>
+                    </div>
                 </div>
-            </div>
+            </fieldset>
             <!-- /.panel -->
         </div>
         <!-- /.col-lg-12 -->
@@ -70,14 +73,25 @@
                 <div class="card-body">
                     <p>YAGPDB already performs a scan of your server every minute, but this only includes online/cached
                         members, it would take up too many resources to keep absolutely all members in the state.</p>
-                    <p>Therefore you can use this to perform a full scan of your server, this may become an automatic
-                        premium option at some point.</p>
-                    <p>You will have to wait a couple minutes in-between each completed scan, to cancel this you can set
-                        the role to "None" and it should stop within a minute.</p>
-                    {{if .FullScanActive}}<p class="text-danger">Already performing a full scan</p>
+                    <p>Therefore you can use this to perform a full scan of your server.</p>
+                    <p>You will have to wait a couple minutes in-between each completed scan. To cancel active full scan, use the button shown below (Cancelling full scan may take some seconds).</p>
+                    {{if .FullScanActive}}
+                        <div class="text-danger"><b>Already performing a full scan</b></div>
+                        <p>
+                            <span>Current Status: {{.FullScanStatus}}</span>
+                            {{if .AssignedRoles}}
+                                <span style="margin-left: 1rem;">Assigned roles to {{.AssignedRoles}} members</span>
+                            {{end}}
+                        </p>
+                        {{if ne .FullScanStatus "Cancelled"}}
+                            <button type="submit" class="btn btn-danger btn-lg btn-block"
+                                formaction="/manage/{{.ActiveGuild.ID}}/autorole/fullscan/cancel">Cancel currently active full scan</button>
+                        {{end}}
                     {{else if eq .Autorole.Role 0}}<p class="text-danger">No active autorole role set</p>
-                    {{else}}<button type="submit" class="btn btn-warning btn-lg btn-block"
-                        data-async-form-alertsonly>Perform full scan.</button>{{end}}
+                    {{else}}
+                        <button type="submit" class="btn btn-warning btn-lg btn-block"
+                            data-async-form-alertsonly>Perform full scan</button>
+                    {{end}}
                 </div>
             </div>
             <!-- /.panel -->

--- a/autorole/autorole.go
+++ b/autorole/autorole.go
@@ -45,6 +45,16 @@ type GeneralConfig struct {
 	AssignRoleAfterScreening bool
 }
 
+const (
+	FullScanStarted int = iota + 1
+	FullScanIterating
+	FullScanIterationDone
+	FullScanAssigningRole
+	FullScanCancelled
+)
+
+var cancelFullScan = make(chan bool)
+
 func GetGeneralConfig(guildID int64) (*GeneralConfig, error) {
 	conf := &GeneralConfig{}
 	err := common.GetRedisJson(KeyGeneral(guildID), conf)

--- a/autorole/plugin_botrest.go
+++ b/autorole/plugin_botrest.go
@@ -38,7 +38,7 @@ func botRestHandleScanFullServer(w http.ResponseWriter, r *http.Request) {
 
 func botRestPostFullScan(guildID int64) error {
 	var resp string
-	err := common.RedisPool.Do(radix.Cmd(&resp, "SET", RedisKeyGuildChunkProecssing(guildID), "1", "EX", "10", "NX"))
+	err := common.RedisPool.Do(radix.Cmd(&resp, "SET", RedisKeyFullScanStatus(guildID), strconv.Itoa(FullScanStarted), "EX", "10", "NX"))
 	if err != nil {
 		return errors.WithMessage(err, "r.SET")
 	}

--- a/autorole/web.go
+++ b/autorole/web.go
@@ -6,6 +6,7 @@ import (
 	"html"
 	"html/template"
 	"net/http"
+	"strconv"
 
 	"emperror.dev/errors"
 	"github.com/botlabs-gg/yagpdb/common"
@@ -70,6 +71,7 @@ func (p *Plugin) InitWeb() {
 	muxer.Handle(pat.Get("/"), getHandler)
 
 	muxer.Handle(pat.Post("/fullscan"), web.ControllerPostHandler(handlePostFullScan, getHandler, nil))
+	muxer.Handle(pat.Post("/fullscan/cancel"), web.ControllerPostHandler(handleCancelFullScan, getHandler, nil))
 
 	muxer.Handle(pat.Post(""), web.SimpleConfigSaverHandler(Form{}, getHandler, panelLogKeyUpdatedSettings))
 	muxer.Handle(pat.Post("/"), web.SimpleConfigSaverHandler(Form{}, getHandler, panelLogKeyUpdatedSettings))
@@ -83,13 +85,41 @@ func handleGetAutoroleMainPage(w http.ResponseWriter, r *http.Request) interface
 	web.CheckErr(tmpl, err, "Failed retrieving general config (contact support)", web.CtxLogger(r.Context()).Error)
 	tmpl["Autorole"] = general
 
+	var status int
+	fullScanActive := false
+	common.RedisPool.Do(radix.Cmd(&status, "GET", RedisKeyFullScanStatus(activeGuild.ID)))
+	if status > 0 {
+		fullScanActive = true
+		var fullScanStatus string
+		switch status {
+		case FullScanStarted:
+			fullScanStatus = "Started"
+		case FullScanIterating:
+			fullScanStatus = "Iterating through the members"
+		case FullScanIterationDone:
+			fullScanStatus = "Iteration completed"
+		case FullScanAssigningRole:
+			fullScanStatus = "Assigning roles"
+			var assignedRoles string
+			common.RedisPool.Do(radix.Cmd(&assignedRoles, "GET", RedisKeyFullScanAssignedRoles(activeGuild.ID)))
+			tmpl["AssignedRoles"] = assignedRoles
+		case FullScanCancelled:
+			fullScanStatus = "Cancelled"
+		}
+		tmpl["FullScanStatus"] = fullScanStatus
+	}
+	tmpl["FullScanActive"] = fullScanActive
+
 	var proc int
 	common.RedisPool.Do(radix.Cmd(&proc, "GET", KeyProcessing(activeGuild.ID)))
 	tmpl["Processing"] = proc
 	tmpl["ProcessingETA"] = int(proc / 60)
 
-	fullScanActive := WorkingOnFullScan(activeGuild.ID)
-	tmpl["FullScanActive"] = fullScanActive
+	// If any goroutine is running according to previous flow
+	workingOnFullScan := WorkingOnFullScan(activeGuild.ID)
+	if workingOnFullScan {
+		tmpl["FullScanActive"] = workingOnFullScan
+	}
 
 	return tmpl
 
@@ -114,6 +144,25 @@ func handlePostFullScan(w http.ResponseWriter, r *http.Request) (web.TemplateDat
 
 	go cplogs.RetryAddEntry(web.NewLogEntryFromContext(r.Context(), panelLogKeyStartedFullScan))
 
+	return tmpl, nil
+}
+
+func handleCancelFullScan(w http.ResponseWriter, r *http.Request) (web.TemplateData, error) {
+	ctx := r.Context()
+	activeGuild, tmpl := web.GetBaseCPContextData(ctx)
+
+	var status int64
+	common.RedisPool.Do(radix.Cmd(&status, "GET", RedisKeyFullScanStatus(activeGuild.ID)))
+	if status == 0 {
+		return tmpl.AddAlerts(web.ErrorAlert("Full scan is not active. Please refresh the page.")), nil
+	}
+
+	err := common.RedisPool.Do(radix.Cmd(nil, "SETEX", RedisKeyFullScanStatus(activeGuild.ID), "100", strconv.Itoa(FullScanCancelled)))
+	if err != nil {
+		logger.WithError(err).Error("Failed marking Full scan as cancelled")
+	}
+
+	cancelFullScan <- true
 	return tmpl, nil
 }
 


### PR DESCRIPTION
This PR includes following changes:
1. Disable Autorole config form while the full scan is running.
2. Iterate through members to find members eligible for autorole, and keep them in a sorted set.
3. After all the members are iterated, launch a go routine to assign role to the members in the given set.
4. Add button to allow cancelling the full scan while it is running.
5. Add full scan status along with number of members to which the role was assigned on the Autorole config dashboard.