### PR TITLE
Handle unknown guild chunk events and cancel through redis for autorole full scan

### DIFF
--- a/autorole/assets/autorole.html
+++ b/autorole/assets/autorole.html
@@ -70,7 +70,7 @@
                     <p>YAGPDB already performs a scan of your server every minute, but this only includes online/cached
                         members, it would take up too many resources to keep absolutely all members in the state.</p>
                     <p>Therefore you can use this to perform a full scan of your server.</p>
-                    <p>You will have to wait a couple minutes in-between each completed scan.{{if .FullScanActive}} To cancel active full scan, use the button shown below (Cancelling full scan may take upto 10 seconds).{{end}}</p>
+                    <p>You will have to wait a couple minutes in-between each completed scan.{{if .FullScanActive}} To cancel active full scan, use the button shown below (Cancelling full scan may take upto 2 minutes).{{end}}</p>
                     {{if .FullScanActive}}
                         <div class="text-danger"><b>Already performing a full scan</b></div>
                         <p>

--- a/autorole/assets/autorole.html
+++ b/autorole/assets/autorole.html
@@ -47,11 +47,7 @@
                         <div class="form-group">
                             {{checkbox "AssignRoleAfterScreening" "AssignRoleAfterScreening" `Only assign the role after a member has completed Discord's Membership Screening` .Autorole.AssignRoleAfterScreening}}
                         </div>
-
-                        <p>Currently assigning role to <code>{{.Processing}}</code> members. ETA:
-                            <code>{{.ProcessingETA}}</code> minutes (May take up to a minute before the bot starts assigning
-                            roles).<br>
-                            <b>To stop, set the role to "None".</b></p>
+                        <br/>
                         <button type="submit" class="btn btn-success btn-lg btn-block">Save</button>
                     </div>
                 </div>
@@ -74,13 +70,13 @@
                     <p>YAGPDB already performs a scan of your server every minute, but this only includes online/cached
                         members, it would take up too many resources to keep absolutely all members in the state.</p>
                     <p>Therefore you can use this to perform a full scan of your server.</p>
-                    <p>You will have to wait a couple minutes in-between each completed scan. To cancel active full scan, use the button shown below (Cancelling full scan may take some seconds).</p>
+                    <p>You will have to wait a couple minutes in-between each completed scan.{{if .FullScanActive}} To cancel active full scan, use the button shown below (Cancelling full scan may take upto 10 seconds).{{end}}</p>
                     {{if .FullScanActive}}
                         <div class="text-danger"><b>Already performing a full scan</b></div>
                         <p>
                             <span>Current Status: {{.FullScanStatus}}</span>
                             {{if .AssignedRoles}}
-                                <span style="margin-left: 1rem;">Assigned roles to {{.AssignedRoles}} members</span>
+                                <span style="margin-left: 1rem;">Assigned roles to <code>{{.AssignedRoles}} members</code></span>
                             {{end}}
                         </p>
                         {{if ne .FullScanStatus "Cancelled"}}

--- a/autorole/autorole.go
+++ b/autorole/autorole.go
@@ -53,8 +53,6 @@ const (
 	FullScanCancelled
 )
 
-var cancelFullScan = make(chan bool)
-
 func GetGeneralConfig(guildID int64) (*GeneralConfig, error) {
 	conf := &GeneralConfig{}
 	err := common.GetRedisJson(KeyGeneral(guildID), conf)

--- a/autorole/plugin_botrest.go
+++ b/autorole/plugin_botrest.go
@@ -8,6 +8,7 @@ import (
 	"github.com/botlabs-gg/yagpdb/bot"
 	"github.com/botlabs-gg/yagpdb/common"
 	"github.com/botlabs-gg/yagpdb/common/internalapi"
+	"github.com/jonas747/discordgo/v2"
 	"github.com/mediocregopher/radix/v3"
 	"goji.io"
 	"goji.io/pat"
@@ -31,7 +32,13 @@ func botRestHandleScanFullServer(w http.ResponseWriter, r *http.Request) {
 
 	logger.WithField("guild", parsedGID).Info("autorole doing a full scan")
 	session := bot.ShardManager.SessionForGuild(parsedGID)
-	session.GatewayManager.RequestGuildMembers(parsedGID, "", 0)
+	query := ""
+	session.GatewayManager.RequestGuildMembersComplex(&discordgo.RequestGuildMembersData{
+		GuildID: parsedGID,
+		Nonce:   strconv.Itoa(int(parsedGID)),
+		Limit:   0,
+		Query:   &query,
+	})
 
 	internalapi.ServeJson(w, r, "ok")
 }

--- a/autorole/web.go
+++ b/autorole/web.go
@@ -116,7 +116,7 @@ func handleGetAutoroleMainPage(w http.ResponseWriter, r *http.Request) interface
 	tmpl["ProcessingETA"] = int(proc / 60)
 
 	// If any goroutine is running according to previous flow
-	workingOnFullScan := WorkingOnFullScan(activeGuild.ID)
+	workingOnFullScan := WorkingOnFullScanLegacy(activeGuild.ID)
 	if workingOnFullScan {
 		tmpl["FullScanActive"] = workingOnFullScan
 	}
@@ -157,12 +157,11 @@ func handleCancelFullScan(w http.ResponseWriter, r *http.Request) (web.TemplateD
 		return tmpl.AddAlerts(web.ErrorAlert("Full scan is not active. Please refresh the page.")), nil
 	}
 
-	err := common.RedisPool.Do(radix.Cmd(nil, "SETEX", RedisKeyFullScanStatus(activeGuild.ID), "100", strconv.Itoa(FullScanCancelled)))
+	err := common.RedisPool.Do(radix.Cmd(nil, "SETEX", RedisKeyFullScanStatus(activeGuild.ID), "10", strconv.Itoa(FullScanCancelled)))
 	if err != nil {
 		logger.WithError(err).Error("Failed marking Full scan as cancelled")
 	}
 
-	cancelFullScan <- true
 	return tmpl, nil
 }
 


### PR DESCRIPTION
1. Check from guild chunk nonce before starting the full scan iteration.
2. Handle cancel event using redis.
3. Remove unused lines from Autorole config webpage, highlight assigned members count.