### PR TITLE
Update redis requirements in readme, update autorole full scan text description, update breaking_changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ docker-compose -f yagpdb/yagpdb_docker/docker-compose.dev.yml up
 
 * Golang 1.16 or above
 * PostgreSQL 9.6 or later
-* Redis version 3.x or later
+* Redis version 5.x or later
 
 #### Setting Up
 

--- a/autorole/assets/autorole.html
+++ b/autorole/assets/autorole.html
@@ -67,10 +67,9 @@
                     <h4 class="card-title">Perform a retro-active full scan</h4>
                 </header>
                 <div class="card-body">
-                    <p>YAGPDB already performs a scan of your server every minute, but this only includes online/cached
-                        members, it would take up too many resources to keep absolutely all members in the state.</p>
-                    <p>Therefore you can use this to perform a full scan of your server.</p>
-                    <p>You will have to wait a couple minutes in-between each completed scan.{{if .FullScanActive}} To cancel active full scan, use the button shown below (Cancelling full scan may take upto 2 minutes).{{end}}</p>
+                    <p>This feature scans the server completely, and assigns the autorole to the eligible members (if they don't have the role already).</p>
+                    <p>This is a resource intensive process, and the time taken is directly proportional to the number of members in the server.</p>
+                    <p>The form above to update the Autorole configuration will be disabled when the full scan is active.{{if .FullScanActive}} To cancel active full scan, use the button shown below (Cancelling full scan may take upto 2 minutes).{{end}}</p>
                     {{if .FullScanActive}}
                         <div class="text-danger"><b>Already performing a full scan</b></div>
                         <p>

--- a/breaking_changes.md
+++ b/breaking_changes.md
@@ -1,5 +1,10 @@
 This file will be updated with breaking changes, before you update you should check this file for steps on updating your database schema and migration processes, and be notified of other breaking changes elsewhere.
 
+**18th Apr 2022 (1.32.0-dev)**
+
+ - Autorole Full scan feature is now paid premium only, and the configuration form is disabled when full scan is active.
+ - Minimum required redis version is 5.x.
+
 **27th Jul 2019 (1.19.12-dev)**
 
  - You can't access old message logs unless you migrate them from the old format using the `migratelogs` owner only command. Be careful and only run this once as otherwise you'll have duplicate log entries.


### PR DESCRIPTION
1. Add redis minimum required version as 5.x in README.md
2. Update breaking_changes.md
3. Update autorole full scan description on the configuration page.