### PR TITLE
common/util: remove optional protocol from link regex

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -23,7 +23,7 @@ import (
 func KeyGuild(guildID int64) string         { return "guild:" + discordgo.StrID(guildID) }
 func KeyGuildChannels(guildID int64) string { return "channels:" + discordgo.StrID(guildID) }
 
-var LinkRegex = regexp.MustCompile(`(?i)([a-z\d]+://)?((\w+:\w+@)?([a-z\d.-]+\.[a-z]{2,64})(:\d+)?(/.*)?)`)
+var LinkRegex = regexp.MustCompile(`(?i)([a-z\d]+://)((\w+:\w+@)?([a-z\d.-]+\.[a-z]{2,64})(:\d+)?(/.*)?)`)
 var DomainFinderRegex = regexp.MustCompile(`(?i)(?:[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?\.)+[a-z\d][a-z\d-]{0,61}[a-z\d]`)
 
 type GuildWithConnected struct {


### PR DESCRIPTION
The current implementation of link validation is, although technically
correct, too sensitive; e.g. it considers an ellipsis (`...`) a valid
link.

This commit modifies the link validator regexp to only consider URLs
with a leading protocol. This should cut down on the reported
false-positives.

The change is justified by the fact that URLs with no leading protocol
aren't "clickable" in Discord either, and as such having it optional is
an anti-pattern, despite the technically correct implemementation.