### PR TITLE
add a flag to delete optional amount of messages on kick

### DIFF
--- a/automod/effects.go
+++ b/automod/effects.go
@@ -272,7 +272,7 @@ func (kick *KickUserEffect) Apply(ctxData *TriggeredRuleData, settings interface
 		reason += ctxData.ConstructReason(true)
 	}
 
-	err := moderation.KickUser(nil, ctxData.GS.ID, ctxData.CS, ctxData.Message, common.BotUser, reason, &ctxData.MS.User)
+	err := moderation.KickUser(nil, ctxData.GS.ID, ctxData.CS, ctxData.Message, common.BotUser, reason, &ctxData.MS.User, -1)
 	return err
 }
 

--- a/automod_legacy/bot.go
+++ b/automod_legacy/bot.go
@@ -156,7 +156,7 @@ func CheckMessage(evt *eventsystem.EventData, m *discordgo.Message) bool {
 		case PunishMute:
 			err = moderation.MuteUnmuteUser(nil, true, cs.GuildID, cs, m, common.BotUser, "Automoderator: "+punishMsg, member, muteDuration)
 		case PunishKick:
-			err = moderation.KickUser(nil, cs.GuildID, cs, m, common.BotUser, "Automoderator: "+punishMsg, &member.User)
+			err = moderation.KickUser(nil, cs.GuildID, cs, m, common.BotUser, "Automoderator: "+punishMsg, &member.User, -1)
 		case PunishBan:
 			err = moderation.BanUser(nil, cs.GuildID, cs, m, common.BotUser, "Automoderator: "+punishMsg, &member.User)
 		}

--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -229,7 +229,7 @@ var ModerationCommands = []*commands.YAGCommand{
 			{Name: "Reason", Type: dcmd.String},
 		},
 		ArgSwitches: []*dcmd.ArgDef{
-			{Name: "cl", Help: "Messages to delete", Type: dcmd.Int},
+			{Name: "cl", Help: "Messages to delete", Type: &dcmd.IntArg{Min: 1, Max: 100}},
 		},
 		RequireBotPerms:     [][]int64{{discordgo.PermissionAdministrator}, {discordgo.PermissionManageServer}, {discordgo.PermissionKickMembers}},
 		SlashCommandEnabled: true,
@@ -253,12 +253,6 @@ var ModerationCommands = []*commands.YAGCommand{
 			toDel := -1
 			if parsed.Switches["cl"].Value != nil {
 				toDel = parsed.Switches["cl"].Int()
-
-				if toDel < 0 {
-					return "Error: Num is too small (has to be within 1 - 100)", nil
-				} else if toDel > 100 {
-					return "Error: Num is too big (has to be within 1 - 100)", nil
-				}
 			}
 
 			var msg *discordgo.Message

--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -228,6 +228,9 @@ var ModerationCommands = []*commands.YAGCommand{
 			{Name: "User", Type: dcmd.UserID},
 			{Name: "Reason", Type: dcmd.String},
 		},
+		ArgSwitches: []*dcmd.ArgDef{
+			{Name: "cl", Help: "Messages to delete", Type: dcmd.Int},
+		},
 		RequireBotPerms:     [][]int64{{discordgo.PermissionAdministrator}, {discordgo.PermissionManageServer}, {discordgo.PermissionKickMembers}},
 		SlashCommandEnabled: true,
 		DefaultEnabled:      false,
@@ -247,11 +250,23 @@ var ModerationCommands = []*commands.YAGCommand{
 				return "Error: Reason too long (can be max 470 characters).", nil
 			}
 
+			toDel := -1
+			if parsed.Switches["cl"].Value != nil {
+				toDel = parsed.Switches["cl"].Int()
+
+				if toDel < 0 {
+					return "Error: Num is too small (has to be within 1 - 100)", nil
+				} else if toDel > 100 {
+					return "Error: Num is too big (has to be within 1 - 100)", nil
+				}
+			}
+
 			var msg *discordgo.Message
 			if parsed.TraditionalTriggerData != nil {
 				msg = parsed.TraditionalTriggerData.Message
 			}
-			err = KickUser(config, parsed.GuildData.GS.ID, parsed.GuildData.CS, msg, parsed.Author, reason, target)
+
+			err = KickUser(config, parsed.GuildData.GS.ID, parsed.GuildData.CS, msg, parsed.Author, reason, target, toDel)
 			if err != nil {
 				return nil, err
 			}

--- a/moderation/punishments.go
+++ b/moderation/punishments.go
@@ -181,7 +181,7 @@ func sendPunishDM(config *Config, dmMsg string, action ModlogAction, gs *dstate.
 	}
 }
 
-func KickUser(config *Config, guildID int64, channel *dstate.ChannelState, message *discordgo.Message, author *discordgo.User, reason string, user *discordgo.User) error {
+func KickUser(config *Config, guildID int64, channel *dstate.ChannelState, message *discordgo.Message, author *discordgo.User, reason string, user *discordgo.User, del int) error {
 	config, err := getConfigIfNotSet(guildID, config)
 	if err != nil {
 		return common.ErrWithCaller(err)
@@ -192,13 +192,16 @@ func KickUser(config *Config, guildID int64, channel *dstate.ChannelState, messa
 		return err
 	}
 
-	if !config.DeleteMessagesOnKick {
+	if del == 0 {
 		return nil
+	} else if del == -1 && config.DeleteMessagesOnKick {
+		del = 100
 	}
 
 	if channel != nil {
-		_, err = DeleteMessages(guildID, channel.ID, user.ID, 100, 100)
+		_, err = DeleteMessages(guildID, channel.ID, user.ID, del, del)
 	}
+
 	return err
 }
 


### PR DESCRIPTION
This PR makes the following changes:
- change the `KickUser` func to accept number of messages to delete, as a parameter.
- change occurrences of the func to incorporate the new parameter.
- add a `cl` flag to the `kick` command to specify number of messages to delete (1-100).