### PR TITLE
reputation: default to command author if no arguments are provided to the replog command

### DIFF
--- a/reputation/plugin_bot.go
+++ b/reputation/plugin_bot.go
@@ -194,7 +194,7 @@ var cmds = []*commands.YAGCommand{
 		Name:                "RepLog",
 		Aliases:             []string{"replogs"},
 		Description:         "Shows the rep log for the specified user.",
-		RequiredArgs:        1,
+		RequiredArgs:        0,
 		SlashCommandEnabled: true,
 		DefaultEnabled:      false,
 		Arguments: []*dcmd.ArgDef{
@@ -212,6 +212,9 @@ var cmds = []*commands.YAGCommand{
 			}
 
 			targetID := parsed.Args[0].Int64()
+			if (targetID == 0) {
+				targetID = parsed.Author.ID
+			}
 
 			const entriesPerPage = 20
 			offset := (parsed.Args[1].Int() - 1) * entriesPerPage


### PR DESCRIPTION
This PR allows using the `replog` command without having to provide the user argument by making it optional, in which case, it defaults to the user using the command.