### PR TITLE
redirect to support server instead of repository issues to make suggestions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 Are you planning on contributing or suggesting something for the bot? Go ahead, just make sure you know what you are doing, we don't want to have to fix the bot if someone breaks it!
 
-In order to make a suggestion, head to the [issues page](https://github.com/botlabs-gg/yagpdb/issues) and make an issue titled "Suggestion: (name)" and fill out a little description. Please please please, check that this hasn't already been suggested or requested as a PR.
+In order to make a suggestion, head to the [support server](https://discord.gg/4udtcA5). Before creating a new suggestion, check that it hasn't already been suggested or requested as a PR.
 
 If you want to make a contribution, create a fork, cut a branch from master, make the necessary changes and then make a PR to the dev branch (botlabs-gg/yagpdb/dev). This is key for larger commits and edits to important / complicated parts of the bot so it can be tested safely without breaking everything.
 


### PR DESCRIPTION
This PR updates CONTRIBUTING.md to ask suggestions to be made on the support server instead of issues on the repository.