### PR TITLE
dcmd: optimize arg parsing

### DIFF
--- a/lib/dcmd/parse_test.go
+++ b/lib/dcmd/parse_test.go
@@ -50,6 +50,35 @@ func TestParseArgDefs(t *testing.T) {
 	}
 }
 
+var Sink int
+
+func BenchmarkSplitArgs(b *testing.B) {
+	benchmarks := []struct {
+		name string
+		in   string
+	}{
+		{"very short input", "-xkcd"},
+		{"short input", "-send bar baz"},
+		{"medium-length input", "-simpleembed -title abc -desc xyz -color ff0000"},
+		{"medium-length input with quoted text", `-simpleembed -title "foo bar baz" -desc "hello world"`},
+		{"long input", `-ce {
+			"title": "example title",
+			"color" 1234,
+			"description": "very interesting test case\n",
+			"timestamp": "",
+			"author": {},
+			"image": { "url": "" }
+		}`},
+	}
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				Sink += len(SplitArgs(bm.in))
+			}
+		})
+	}
+}
+
 func TestParseSwitches(t *testing.T) {
 	cases := []struct {
 		name         string


### PR DESCRIPTION
Argument parsing is a hot path given that it occurs on every command run. Thus, it makes sense to investigate possible performance improvements in this area.

This PR optimizes the `SplitArgs` function in two ways:

- Use a `strings.Builder` instead of string concatenation.
- Instead of looping through `ArgContainers` to check if the input is an argument container, use a function instead, which provides more optimization opportunities to the compiler.

Additionally, to verify that the changes do help performance-wise, add a couple of benchmarks with representative inputs. Results are below (before/after.)

```
name                                              old time/op    new time/op    delta
SplitArgs/very_short_input-4                         329ns ± 4%     132ns ± 5%  -59.71%  (p=0.008 n=5+5)
SplitArgs/short_input-4                              846ns ± 2%     450ns ± 4%  -46.74%  (p=0.008 n=5+5)
SplitArgs/medium-length_input-4                     2.76µs ± 1%    1.09µs ± 1%  -60.46%  (p=0.016 n=4+5)
SplitArgs/medium-length_input_with_quoted_text-4    2.99µs ± 6%    1.07µs ±12%  -64.25%  (p=0.008 n=5+5)
SplitArgs/long_input-4                              9.85µs ± 4%    3.05µs ±18%  -69.07%  (p=0.008 n=5+5)

name                                              old alloc/op   new alloc/op   delta
SplitArgs/very_short_input-4                         72.0B ± 0%     40.0B ± 0%  -44.44%  (p=0.008 n=5+5)
SplitArgs/short_input-4                               208B ± 0%      152B ± 0%  -26.92%  (p=0.008 n=5+5)
SplitArgs/medium-length_input-4                       704B ± 0%      360B ± 0%  -48.86%  (p=0.008 n=5+5)
SplitArgs/medium-length_input_with_quoted_text-4      752B ± 0%      328B ± 0%  -56.38%  (p=0.008 n=5+5)
SplitArgs/long_input-4                              2.88kB ± 0%    0.94kB ± 0%  -67.50%  (p=0.008 n=5+5)

name                                              old allocs/op  new allocs/op  delta
SplitArgs/very_short_input-4                          11.0 ± 0%       3.0 ± 0%  -72.73%  (p=0.008 n=5+5)
SplitArgs/short_input-4                               25.0 ± 0%       9.0 ± 0%  -64.00%  (p=0.008 n=5+5)
SplitArgs/medium-length_input-4                       86.0 ± 0%      19.0 ± 0%  -77.91%  (p=0.008 n=5+5)
SplitArgs/medium-length_input_with_quoted_text-4      91.0 ± 0%      17.0 ± 0%  -81.32%  (p=0.008 n=5+5)
SplitArgs/long_input-4                                 298 ± 0%        44 ± 0%  -85.23%  (p=0.008 n=5+5)
```