### PR TITLE
templates: remove IncreaseCheckStateLock

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -477,10 +477,6 @@ func (c *Context) IncreaseCheckGenericAPICall() bool {
 	return c.IncreaseCheckCallCounter("api_call", 100)
 }
 
-func (c *Context) IncreaseCheckStateLock() bool {
-	return c.IncreaseCheckCallCounter("state_lock", 500)
-}
-
 func (c *Context) LogEntry() *logrus.Entry {
 	f := logger.WithFields(logrus.Fields{
 		"guild": c.GS.ID,


### PR DESCRIPTION
`IncreaseCheckStateLock` is a relic of the older state tracker, which required locking the state before, e.g., iterating through roles, in order to avoid data races. The new state tracker introduced about a year ago does not impose this requirement, so `IncreaseCheckStateLock` is no longer necessary. This PR removes it and switches existing references to different call counters.