### PR TITLE
cardsagainstdiscord: provide error for all response-only packs

### DIFF
--- a/lib/cardsagainstdiscord/cad.go
+++ b/lib/cardsagainstdiscord/cad.go
@@ -91,6 +91,7 @@ var (
 	ErrNotGM                = errors.New("You're not the game master")
 	ErrStoppedAlready       = errors.New("Game already stopped")
 	ErrPlayerNotInGame      = errors.New("Player not in your game")
+	ErrAllPacksResponseOnly = errors.New("The set of packs specified are all response-only; at least one pack that has prompts is needed to start a game")
 )
 
 type ErrUnknownPack struct {
@@ -104,7 +105,7 @@ func (e *ErrUnknownPack) Error() string {
 func HumanizeError(err error) string {
 	err = errors.Cause(err)
 
-	if err == ErrGameAlreadyInChannel || err == ErrPlayerAlreadyInGame || err == ErrGameNotFound || err == ErrGameFull || err == ErrNoPacks || err == ErrNotGM || err == ErrStoppedAlready || err == ErrPlayerNotInGame {
+	if err == ErrGameAlreadyInChannel || err == ErrPlayerAlreadyInGame || err == ErrGameNotFound || err == ErrGameFull || err == ErrNoPacks || err == ErrNotGM || err == ErrStoppedAlready || err == ErrPlayerNotInGame || err == ErrAllPacksResponseOnly {
 		return err.Error()
 	}
 

--- a/lib/cardsagainstdiscord/manager.go
+++ b/lib/cardsagainstdiscord/manager.go
@@ -22,22 +22,30 @@ func NewGameManager(sessionProvider SessionProvider) *GameManager {
 
 func (gm *GameManager) CreateGame(guildID int64, channelID int64, userID int64, username string, voteMode bool, packs ...string) (*Game, error) {
 	allPacks := false
+	allResponseOnly := true
 	for _, v := range packs {
 		if v == "*" {
 			allPacks = true
+			allResponseOnly = false
 			break
 		}
 
-		_, ok := Packs[v]
+		p, ok := Packs[v]
 		if !ok {
 			return nil, &ErrUnknownPack{
 				PassedPack: v,
 			}
 		}
+		if len(p.Prompts) > 0 {
+			allResponseOnly = false
+		}
 	}
 
 	if len(packs) < 1 && !allPacks {
 		return nil, ErrNoPacks
+	}
+	if allResponseOnly {
+		return nil, ErrAllPacksResponseOnly
 	}
 
 	if allPacks {


### PR DESCRIPTION
When creating a CAH game with a set of response-only packs such as the AI and blank packs, starting the game results in a cryptic error message:
> The running game almost caused a crash! The game has been terminated as a result. Contact the bot owner.

The stack trace points to this function, particularly the call to `Intn`:
https://github.com/botlabs-gg/yagpdb/blob/4b71c707b1247d323898d6cde8c13c20b665c214/lib/cardsagainstdiscord/game.go#L557-L567

Looking at this, it's fairly clear what the issue is: if all the cards are response-only (i.e., have no prompts), then `g.availablePrompts` will be an empty slice even after reloading. Hence, `rand.Intn(len(g.availablePrompts))` is equivalent to `rand.Intn(0)`, and `0` is an invalid argument to `rand.Intn`.

This PR fixes the issue by providing an informative error up-front when a CAH game is creating with a set of response-only packs.