### PR TITLE
templates: patch getMessage result to incl guild ID

### DIFF
--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -1113,6 +1113,8 @@ func (c *Context) tmplGetMessage(channel, msgID interface{}) (*discordgo.Message
 	mID := ToInt64(msgID)
 
 	message, _ := common.BotSession.ChannelMessage(cID, mID)
+	// get message endpoint doesn't return guild ID, so just patch it in to make message.Link work
+	message.GuildID = c.GS.ID
 	return message, nil
 }
 


### PR DESCRIPTION
Currently, calling `Link` on the Message struct returned from `getMessage` in a custom command results in an invalid link where the guild ID is 0. Interesting enough, the issue is not on our end -- Discord simply does not return the guild ID when calling the get message endpoint.

Ideally, we would patch the resulting struct in the `ChannelMessage` call itself, but that would mean that all callers would have to pass in an additional guild ID, even if they don't really need the returned structure to have one. Thus, given that the sole use of `message.Link` is in the context of custom commands, this PR opts to patch the result in the `getMessage` function directly.