### PR TITLE
customcommands: improve editor ui

### DIFF
--- a/customcommands/assets/customcommands-editcmd.html
+++ b/customcommands/assets/customcommands-editcmd.html
@@ -114,9 +114,6 @@
                                             <b>Command Trigger</b>: Works the same way as normal commands by using the
                                             command
                                             prefix or bot mention followed by the trigger.<br />
-                                            For example: If you set the trigger to <code>hello</code> then you can type
-                                            <code>-hello</code> or <code>@yagpdb hello</code> to trigger it (assuming
-                                            default settings)
                                         </p>
                                         <p id="trigger-desc-prefix">
                                             Any message that starts with the trigger will run the command.

--- a/customcommands/assets/customcommands-editcmd.html
+++ b/customcommands/assets/customcommands-editcmd.html
@@ -147,8 +147,13 @@
                                     <div class="col-sm-12">
                                         <div class="form-group">
                                             <label>Trigger</label>
-                                            <input type="text" class="form-control" name="trigger" placeholder="fun"
-                                                value="{{.CC.TextTrigger}}">
+                                            <div class="input-group mb-2">
+                                                <div class="input-group-prepend" id="command-trigger-prepended-prefix">
+                                                    <div class="input-group-text">{{.CommandPrefix}}</div>
+                                                </div>
+                                                <input type="text" class="form-control" name="trigger" placeholder="fun"
+                                                    value="{{.CC.TextTrigger}}">
+                                            </div>
 
                                             {{checkbox "case_sensitive" "case_sensitive" "Case Sensitive?" .CC.TextTriggerCaseSensitive}}
 
@@ -499,6 +504,8 @@
             $("#time-trigger-no-channel-warning").addClass("hidden");
         };
 
+        if (dropdown.val() === "cmd") $("#command-trigger-prepended-prefix").show();
+        else $("#command-trigger-prepended-prefix").hide();
 
         $("#trigger-help").children().each(function (i, v) {
             $(v).attr("hidden", true);

--- a/customcommands/assets/customcommands-editcmd.html
+++ b/customcommands/assets/customcommands-editcmd.html
@@ -143,12 +143,12 @@
                                 <div class="row">
                                     <div class="col-sm-12">
                                         <div class="form-group">
-                                            <label>Trigger</label>
+                                            <label>Trigger (<span id="trigger-length">{{len .CC.TextTrigger}}</span>/1000)</label>
                                             <div class="input-group mb-2">
                                                 <div class="input-group-prepend" id="command-trigger-prepended-prefix">
                                                     <div class="input-group-text">{{.CommandPrefix}}</div>
                                                 </div>
-                                                <input type="text" class="form-control" name="trigger" placeholder="fun"
+                                                <input id="trigger" type="text" class="form-control" name="trigger" placeholder="fun"
                                                     value="{{.CC.TextTrigger}}">
                                             </div>
 
@@ -522,6 +522,13 @@
         handleRestrictionChange($("#require-role-mode").prop("checked"), $("#command-roles"), "require-no-roles-warning", requireNoRolesWarning);
         handleRestrictionChange($("#require-channel-mode").prop("checked"), $("#command-channels"), "require-no-channels-warning", requireNoChannelsWarning);
     })
+
+    $("#trigger").keyup(function() {
+        const trigger = $(this).val();
+        $("#trigger-length")
+            .text(trigger.length)
+            .toggleClass("text-danger", trigger.length > 1000);
+    });
 
     function onCCChanged(textArea) {
         var textAreas = textArea.parentElement.parentElement.querySelectorAll("textarea")

--- a/customcommands/assets/customcommands-editcmd.html
+++ b/customcommands/assets/customcommands-editcmd.html
@@ -429,6 +429,11 @@
 
 <script src="/static/vendorr/tln/tln.min.js"></script>
 <link rel="stylesheet" href="/static/vendorr/tln/tln.min.css">
+<style>
+    html.dark .input-group-prepend > .input-group-text {
+        background: #191c21;
+    }
+</style>
 
 <script type="text/javascript">
     function isTextTrigger(t) {

--- a/customcommands/assets/customcommands-editcmd.html
+++ b/customcommands/assets/customcommands-editcmd.html
@@ -308,8 +308,16 @@
                                 <p>{{if .CC.LastError}}<b>{{formatTime .CC.LastErrorTime.Time.UTC}}</b> - <code>
                                     {{.CC.LastError}}</code>{{else}}None{{end}}</p>
 
-                                <h4>Run count</h4>
-                                <p><code>{{.CC.RunCount}}</code></p>
+                                <div class="row">
+                                    <div class="col-md-4">
+                                        <h4>Run count</h4>
+                                        <p><code>{{.CC.RunCount}}</code></p>
+                                    </div>
+                                    <div class="col-auto">
+                                        <h4>Last run</h4>
+                                        <p>{{if .CC.LastRun.Valid}}{{formatTime .CC.LastRun.Time.UTC}}{{else}}None{{end}}</p>
+                                    </div>
+                                </div>
 
                                 <h4>Output errors as command response</h4>
                                 {{checkbox "show_errors" "show_errors" "" .CC.ShowErrors}}

--- a/customcommands/assets/customcommands-editcmd.html
+++ b/customcommands/assets/customcommands-editcmd.html
@@ -370,7 +370,8 @@
                             <div class="col">
                                 <button type="submit" class="btn btn-success btn-block"
                                     formaction="/manage/{{$guild}}/customcommands/commands/{{.CC.LocalID}}/update"
-                                    data-async-form-alertsonly>Save</button>
+                                    data-async-form-alertsonly
+                                    accesskey="s">Save</button>
                             </div>
                             <div class="col">
                                 <button type="submit" class="btn btn-danger btn-block"

--- a/customcommands/web.go
+++ b/customcommands/web.go
@@ -14,6 +14,7 @@ import (
 	"github.com/botlabs-gg/yagpdb/v2/common"
 	"github.com/botlabs-gg/yagpdb/v2/common/cplogs"
 	"github.com/botlabs-gg/yagpdb/v2/common/featureflags"
+	prfx "github.com/botlabs-gg/yagpdb/v2/common/prefix"
 	"github.com/botlabs-gg/yagpdb/v2/common/pubsub"
 	yagtemplate "github.com/botlabs-gg/yagpdb/v2/common/templates"
 	"github.com/botlabs-gg/yagpdb/v2/customcommands/models"
@@ -74,12 +75,13 @@ func (p *Plugin) InitWeb() {
 
 	subMux.Use(func(inner http.Handler) http.Handler {
 		h := func(w http.ResponseWriter, r *http.Request) {
-			_, templateData := web.GetBaseCPContextData(r.Context())
+			g, templateData := web.GetBaseCPContextData(r.Context())
 			strTriggerTypes := map[int]string{}
 			for k, v := range triggerStrings {
 				strTriggerTypes[int(k)] = v
 			}
 			templateData["CCTriggerTypes"] = strTriggerTypes
+			templateData["CommandPrefix"], _ = prfx.GetCommandPrefixRedis(g.ID)
 
 			inner.ServeHTTP(w, r)
 		}


### PR DESCRIPTION
-  For command triggers, display the prefix to the left of the actual trigger. The prefix will be hidden for all other trigger types. Inspiration for this change comes from a fairly popular suggestion (18 upvotes, 1 downvote) on the server from a while back.
- Show the last run time and the trigger length.
- Add <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>S</kbd> as a shortcut to save the command.

Before:
![Screenshot of editor before changes](https://user-images.githubusercontent.com/56809242/167344451-0262f3fd-0e01-4b82-8473-0a8749aae6ce.png)

After:
![Screenshot of editor after changes](https://user-images.githubusercontent.com/56809242/167344324-60b9f3de-b9c9-4e94-8fe3-8cbef0d04319.png)