### PR TITLE
moderation: disconnect member from VC upon mute

### DIFF
--- a/lib/discordgo/restapi.go
+++ b/lib/discordgo/restapi.go
@@ -952,14 +952,14 @@ func (s *Session) GuildMemberEdit(guildID, userID int64, roles []string) (err er
 // GuildMemberMove moves a guild member from one voice channel to another/none
 //  guildID   : The ID of a Guild.
 //  userID    : The ID of a User.
-//  channelID : The ID of a channel to move user to, or null?
+//  channelID : The ID of a channel to move user to. Use 0 to disconnect the member.
 // NOTE : I am not entirely set on the name of this function and it may change
 // prior to the final 1.0.0 release of Discordgo
 func (s *Session) GuildMemberMove(guildID, userID, channelID int64) (err error) {
 
 	data := struct {
-		ChannelID int64 `json:"channel_id,string"`
-	}{channelID}
+		ChannelID NullableID `json:"channel_id,string"`
+	}{NullableID(channelID)}
 
 	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, 0))
 	if err != nil {

--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -322,6 +322,7 @@ var ModerationCommands = []*commands.YAGCommand{
 				return nil, err
 			}
 
+			common.BotSession.GuildMemberMove(parsed.GuildData.GS.ID, target.ID, 0)
 			return GenericCmdResp(MAMute, target, d, true, false), nil
 		},
 	},


### PR DESCRIPTION
By default, the mute role removes the permission to speak in VCs from the member. However, if a member is in VC at the time at which they are muted, they will still be able to speak. To prevent this, many other moderation bots disconnect the target member from VC upon mute, something that has been suggested for YAGPDB as well.

This PR implements support for disconnecting members from voice in package `discordgo` (code loosely based on an old PR from Satty; see https://github.com/botlabs-gg/discordgo/pull/10) and then uses it to implement the desired change in the mute command.