### PR TITLE
templates: don't deref null ptr in getMessage

### DIFF
--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -1101,8 +1101,10 @@ func (c *Context) tmplGetMessage(channel, msgID interface{}) (*discordgo.Message
 	mID := ToInt64(msgID)
 
 	message, _ := common.BotSession.ChannelMessage(cID, mID)
-	// get message endpoint doesn't return guild ID, so just patch it in to make message.Link work
-	message.GuildID = c.GS.ID
+	if message != nil {
+		// get message endpoint doesn't return guild ID, so just patch it in to make message.Link work
+		message.GuildID = c.GS.ID
+	}
 	return message, nil
 }
 


### PR DESCRIPTION
Fix regression caused by #1209.
Thanks to Mr. T for pointing this out.
