### PR TITLE
dcmd: refactor combo selection algorithm

### DIFF
--- a/lib/dcmd/arg.go
+++ b/lib/dcmd/arg.go
@@ -2,6 +2,7 @@ package dcmd
 
 import (
 	"bytes"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -392,8 +393,8 @@ func (sopts *SlashCommandsParseOptions) ExpectChannelOpt(name string) (*discordg
 
 // ArgType is the interface argument types has to implement,
 type ArgType interface {
-	// Return true if this argument part matches this type
-	Matches(def *ArgDef, part string) bool
+	// CheckCompatibility reports the degree to which the input matches the type.
+	CheckCompatibility(def *ArgDef, part string) CompatibilityResult
 
 	// Attempt to parse it, returning any error if one occured.
 	ParseFromMessage(def *ArgDef, part string, data *Data) (val interface{}, err error)
@@ -403,6 +404,59 @@ type ArgType interface {
 	HelpName() string
 
 	SlashCommandOptions(def *ArgDef) []*discordgo.ApplicationCommandOption
+}
+
+// CompatibilityResult indicates the degree to which a value matches a type.
+type CompatibilityResult int
+
+const (
+	// Incompatible indicates that the value does not match the type at all. For example,
+	// the string "abc" would be incompatible with an integer type.
+	Incompatible CompatibilityResult = iota
+
+	// CompatibilityPoor indicates that the value superficially matches the
+	// type, but violates some required constraint or property. For example, 11
+	// would have poor compatibility with an integer type with range limited to
+	// [0, 10].
+	CompatibilityPoor
+
+	// CompatibilityGood indicates that the value matches the type well. For
+	// example, 204255221017214977 would have good compatibility with a user
+	// type as it has the correct length for a Discord snowflake though the ID
+	// may not correspond to a valid user. Similarly, 10 would have good compatibility
+	// with an unbounded integer type.
+	CompatibilityGood
+)
+
+func (c CompatibilityResult) String() string {
+	switch c {
+	case Incompatible:
+		return "incompatible"
+	case CompatibilityPoor:
+		return "poor compatibility"
+	case CompatibilityGood:
+		return "good compatibility"
+	default:
+		return fmt.Sprintf("CompatibilityResult(%d)", c)
+	}
+}
+
+// DetermineSnowflakeCompatibility returns CompatibilityGood if s could represent
+// a Discord snowflake ID and Incompatible otherwise.
+func DetermineSnowflakeCompatibility(s string) CompatibilityResult {
+	_, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return Incompatible
+	}
+
+	const (
+		minSnowflakeLength = 17
+		maxSnowflakeLength = 19
+	)
+	if len(s) < minSnowflakeLength || len(s) > maxSnowflakeLength {
+		return CompatibilityPoor
+	}
+	return CompatibilityGood
 }
 
 var (
@@ -430,10 +484,17 @@ type IntArg struct {
 
 var _ ArgType = (*IntArg)(nil)
 
-func (i *IntArg) Matches(def *ArgDef, part string) bool {
-	_, err := strconv.ParseInt(part, 10, 64)
-	return err == nil
+func (i *IntArg) CheckCompatibility(def *ArgDef, part string) CompatibilityResult {
+	v, err := strconv.ParseInt(part, 10, 64)
+	if err != nil {
+		return Incompatible
+	}
+	if i.Min == i.Max || i.Min <= v && v <= i.Max {
+		return CompatibilityGood
+	}
+	return CompatibilityPoor
 }
+
 func (i *IntArg) ParseFromMessage(def *ArgDef, part string, data *Data) (interface{}, error) {
 	v, err := strconv.ParseInt(part, 10, 64)
 	if err != nil {
@@ -498,10 +559,17 @@ type FloatArg struct {
 
 var _ ArgType = (*FloatArg)(nil)
 
-func (f *FloatArg) Matches(def *ArgDef, part string) bool {
-	_, err := strconv.ParseFloat(part, 64)
-	return err == nil
+func (f *FloatArg) CheckCompatibility(def *ArgDef, part string) CompatibilityResult {
+	v, err := strconv.ParseFloat(part, 64)
+	if err != nil {
+		return Incompatible
+	}
+	if f.Min == f.Max || f.Min <= v && v <= f.Max {
+		return CompatibilityGood
+	}
+	return CompatibilityPoor
 }
+
 func (f *FloatArg) ParseFromMessage(def *ArgDef, part string, data *Data) (interface{}, error) {
 	v, err := strconv.ParseFloat(part, 64)
 	if err != nil {
@@ -552,7 +620,10 @@ type StringArg struct{}
 
 var _ ArgType = (*StringArg)(nil)
 
-func (s *StringArg) Matches(def *ArgDef, part string) bool { return true }
+func (s *StringArg) CheckCompatibility(def *ArgDef, part string) CompatibilityResult {
+	return CompatibilityGood
+}
+
 func (s *StringArg) ParseFromMessage(def *ArgDef, part string, data *Data) (interface{}, error) {
 	return part, nil
 }
@@ -575,9 +646,9 @@ type UserArg struct{}
 
 var _ ArgType = (*UserArg)(nil)
 
-func (u *UserArg) Matches(def *ArgDef, part string) bool {
+func (u *UserArg) CheckCompatibility(def *ArgDef, part string) CompatibilityResult {
 	// Username/ID searches are enabled, any string can be used
-	return true
+	return CompatibilityGood
 }
 
 func (u *UserArg) ParseFromMessage(def *ArgDef, part string, data *Data) (interface{}, error) {
@@ -710,15 +781,14 @@ type UserIDArg struct{}
 
 var _ ArgType = (*UserIDArg)(nil)
 
-func (u *UserIDArg) Matches(def *ArgDef, part string) bool {
+func (u *UserIDArg) CheckCompatibility(def *ArgDef, part string) CompatibilityResult {
 	// Check for mention
 	if strings.HasPrefix(part, "<@") && strings.HasSuffix(part, ">") {
-		return true
+		return DetermineSnowflakeCompatibility(strings.TrimPrefix(part[2:len(part)-1], "!"))
 	}
 
 	// Check for ID
-	_, err := strconv.ParseInt(part, 10, 64)
-	return err == nil
+	return DetermineSnowflakeCompatibility(part)
 }
 
 func (u *UserIDArg) ParseFromMessage(def *ArgDef, part string, data *Data) (interface{}, error) {
@@ -780,15 +850,14 @@ type ChannelArg struct {
 
 var _ ArgType = (*ChannelArg)(nil)
 
-func (ca *ChannelArg) Matches(def *ArgDef, part string) bool {
+func (ca *ChannelArg) CheckCompatibility(def *ArgDef, part string) CompatibilityResult {
 	// Check for mention
 	if strings.HasPrefix(part, "<#") && strings.HasSuffix(part, ">") {
-		return true
+		return DetermineSnowflakeCompatibility(part[2 : len(part)-1])
 	}
 
 	// Check for ID
-	_, err := strconv.ParseInt(part, 10, 64)
-	return err == nil
+	return DetermineSnowflakeCompatibility(part)
 }
 
 func (ca *ChannelArg) ParseFromMessage(def *ArgDef, part string, data *Data) (interface{}, error) {
@@ -886,24 +955,23 @@ type AdvUserArg struct {
 
 var _ ArgType = (*AdvUserArg)(nil)
 
-func (u *AdvUserArg) Matches(def *ArgDef, part string) bool {
+func (u *AdvUserArg) CheckCompatibility(def *ArgDef, part string) CompatibilityResult {
 	if strings.HasPrefix(part, "<@") && strings.HasSuffix(part, ">") {
-		return true
+		return DetermineSnowflakeCompatibility(strings.TrimPrefix(part[2:len(part)-1], "!"))
 	}
 
 	if u.EnableUserID {
-		_, err := strconv.ParseInt(part, 10, 64)
-		if err == nil {
-			return true
+		if DetermineSnowflakeCompatibility(part[2:len(part)-1]) == CompatibilityGood {
+			return CompatibilityGood
 		}
 	}
 
 	if u.EnableUsernameSearch {
 		// username search
-		return true
+		return CompatibilityGood
 	}
 
-	return false
+	return Incompatible
 }
 
 func (u *AdvUserArg) ParseFromMessage(def *ArgDef, part string, data *Data) (interface{}, error) {

--- a/lib/dcmd/arg_test.go
+++ b/lib/dcmd/arg_test.go
@@ -11,26 +11,26 @@ func TestIntArg(t *testing.T) {
 	part := "123"
 	expected := int64(123)
 
-	assert.True(t, Int.Matches(nil, part), "Should match")
+	assert.Equal(t, CompatibilityGood, Int.CheckCompatibility(nil, part), "Should have excellent compatibility")
 
 	v, err := Int.ParseFromMessage(nil, part, nil)
 	assert.NoError(t, err, "Should parse sucessfully")
 	assert.Equal(t, v, expected, "Should be equal")
 
-	assert.False(t, Int.Matches(nil, "12hello21"), "Should not match")
+	assert.Equal(t, Incompatible, Int.CheckCompatibility(nil, "12hello21"), "Should be incompatible")
 }
 
 func TestFloatArg(t *testing.T) {
 	part := "12.3"
 	expected := float64(12.3)
 
-	assert.True(t, Float.Matches(nil, part), "Should match")
+	assert.Equal(t, CompatibilityGood, Float.CheckCompatibility(nil, part), "Should have excellent compatibility")
 
 	v, err := Float.ParseFromMessage(nil, part, nil)
 	assert.NoError(t, err, "Should parse sucessfully")
 	assert.Equal(t, v, expected, "Should be equal")
 
-	assert.False(t, Float.Matches(nil, "1.2hello21"), "Should not match")
+	assert.Equal(t, Incompatible, Float.CheckCompatibility(nil, "1.2hello21"), "Should be incompatible")
 }
 
 func TestUserIDArg(t *testing.T) {
@@ -44,20 +44,20 @@ func TestUserIDArg(t *testing.T) {
 
 	cases := []struct {
 		part   string
-		match  bool
+		compat CompatibilityResult
 		result int64
 	}{
-		{"123", true, 123},
-		{"hello", false, 321},
-		{"<@105487308693757952>", true, 105487308693757952},
+		{"123", CompatibilityGood, 123},
+		{"hello", Incompatible, 321},
+		{"<@105487308693757952>", CompatibilityGood, 105487308693757952},
 	}
 
 	for _, c := range cases {
 		t.Run("case_"+c.part, func(t *testing.T) {
 			arg := &UserIDArg{}
-			matches := arg.Matches(nil, c.part)
-			assert.Equal(t, c.match, matches, "Incorrect match")
-			if matches {
+			compat := arg.CheckCompatibility(nil, c.part)
+			assert.Equal(t, c.compat, compat, "Compitability result doesn't match")
+			if compat != Incompatible {
 				parsed, err := arg.ParseFromMessage(nil, c.part, d)
 				assert.NoError(t, err, "Should parse sucessfully")
 				assert.Equal(t, c.result, parsed)

--- a/lib/dcmd/cmd.go
+++ b/lib/dcmd/cmd.go
@@ -79,22 +79,7 @@ type CmdWithArgDefs interface {
 		```
 		As you can see, the integers are indexes in the argument definitions returned. The above combos will allow any combination or arguments, even none.
 
-		Important: Argument combos can only allow multiple orders or arguments with different types. It cannot for example detect the difference between 2 text arguments passed.
-		Here's some notes on different types and how well they differentiate:
-
-		user to number:
-			user to number can always be differentiated between, unless a username is provided instead of a mention,
-			if a username consists of only numbers then it would think that that user is a number, if you use this you need to set the
-			RequireMention flag.
-
-		user to string:
-			this is also pretty reliable, but the RequireMention flag is pretty much required here.
-
-		string to number:
-			this can work if you know the string will never itself be a number.
-
-		Note: you can force arguments to become strings by putting them in quotes or code blocks.
-
+		Argument combos generally work as expected in non-ambiguous cases, but it cannot for example detect the difference between two text arguments.
 	*/
 	ArgDefs(data *Data) (args []*ArgDef, required int, combos [][]int)
 }

--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -453,7 +453,7 @@ var ModerationCommands = []*commands.YAGCommand{
 		CustomEnabled:   true,
 		CmdCategory:     commands.CategoryModeration,
 		Name:            "Clean",
-		Description:     "Delete the last number of messages from chat, optionally filtering by user, max age and regex or ignoring pinned messages.\n⚠️ **Warning:** Using `clean <userId> <amount>` does not work. This is because the user ID is interpreted as the amount. As it is over the limit of 100, it is treated as invalid. You can use `clean <amount> <userId>` instead or mention the user.",
+		Description:     "Delete the last number of messages from chat, optionally filtering by user, max age and regex or ignoring pinned messages.",
 		LongDescription: "Specify a regex with \"-r regex_here\" and max age with \"-ma 1h10m\"\nYou can invert the regex match (i.e. only clear messages that do not match the given regex) by supplying the `-im` flag\nNote: Will only look in the last 1k messages",
 		Aliases:         []string{"clear", "cl"},
 		RequiredArgs:    1,

--- a/reputation/plugin_bot.go
+++ b/reputation/plugin_bot.go
@@ -212,13 +212,13 @@ var cmds = []*commands.YAGCommand{
 		Name:                "RepLog",
 		Aliases:             []string{"replogs"},
 		Description:         "Shows the rep log for the specified user.",
-		RequiredArgs:        1,
 		SlashCommandEnabled: true,
 		DefaultEnabled:      false,
 		Arguments: []*dcmd.ArgDef{
 			{Name: "User", Type: dcmd.UserID},
 			{Name: "Page", Type: dcmd.Int, Default: 1},
 		},
+		ArgumentCombos: [][]int{{}, {0}, {1}, {0, 1}},
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 			conf, err := GetConfig(parsed.Context(), parsed.GuildData.GS.ID)
 			if err != nil {
@@ -230,6 +230,9 @@ var cmds = []*commands.YAGCommand{
 			}
 
 			targetID := parsed.Args[0].Int64()
+			if targetID == 0 {
+				targetID = parsed.Author.ID
+			}
 
 			const entriesPerPage = 20
 			offset := (parsed.Args[1].Int() - 1) * entriesPerPage


### PR DESCRIPTION
Presently, `-clean user_id n` (e.g., `-clean 204255221017214977 1`) fails with 
> Invalid arguments provided: Num is too big (has to be within 1 - 100)

The issue is that the user ID argument is erroneously interpreted as the number of arguments to be deleted. That is, the argument combo with the user argument first and the number second is selected, while it should be the other way around.

This PR fixes the issue with the `clean` command and additionally supercedes #1196 through using argument combos in a way that was not previously possible.

## Implementation details and discussion

The underlying cause of the issue is that the integer argument type does not take its range into account when matching (the float argument type has a similar issue.) In other words, given an integer type bounded to the range `[1, 10]`, the value `11` would match but fail during parsing. The obvious fix then seems to be to make matching for integer types take range into account, so `11` does not match an integer type with range `[1, 10]`.

Unfortunately, though this fix addresses the original issue with the clean command, it introduces a regression; when the number of messages to delete is greater than 100, e.g., `-clean 204255221017214977 101`, the cryptic error
> Invalid arguments provided: No matching combo found

is produced, replacing the original, more helpful message
>  Invalid arguments provided: Num is too big (has to be within 1 - 100)

In order to avoid this regression, this PR takes a different, more involved approach. Instead of having input matching returning a binary result (either the input matches or it doesn't), it may now return three types of results: the input can be incompatible with the type; it can have poor compatibility with the type; and the input can have good compatibility with the type. (Some examples: "abc" is incompatible with an integer type; 10 has poor compatibility with an integer type with range `[0, 5]`; 100 has good compatibility with an unbounded integer type.) 

Accordingly, the argument combo selection algorithm is modified such that it prefers argument combos with better overall compatibility as opposed to just length. Argument combos with incompatible components will be rejected, but combos having components with poor compatibility will be accepted if there is no better alternative. This retains the helpful error message in cases like out-of-range integers.
