### PR TITLE
Add count and limit on CC control panel, prevent creating new CC if limit is exhausted

### DIFF
--- a/customcommands/assets/customcommands.html
+++ b/customcommands/assets/customcommands.html
@@ -62,7 +62,7 @@
                     <form class="form-horizontal" method="post"
                         action="/manage/{{.ActiveGuild.ID}}/customcommands/groups/{{.CurrentCommandGroup.ID}}/update"
                         data-async-form>
-                        <div class="row">
+                        <div class="row" style="margin-bottom: 20px;">
                             <div class="col-6">
                                 <div class="form-group">
                                     <label>Name </label>
@@ -113,10 +113,11 @@
                         </div>
                     </form>
                     {{end}}
+                    <p>You have created <code>{{.CCCount}}</code> custom commands against the total limit of <code>{{.CCLimit}}</code> {{.AdditionalMessage}}</p>
                     <form method="post" action="/manage/{{.ActiveGuild.ID}}/customcommands/commands/new">
                         <input type="text" name="GroupID" hidden
                             value="{{if .CurrentCommandGroup}}{{.CurrentCommandGroup.ID}}{{end}}">
-                        <button type="submit" class="btn btn-success">Create
+                        <button type="submit" class="btn btn-success" {{if ge .CCCount .CCLimit}}disabled{{end}}>Create
                             a new Custom Command</button>
                     </form>
                 </div>


### PR DESCRIPTION
This PR adds a text message before the `Create a new Custom Command` button to show how many commands are created, and disables the button if the limit is exhausted.
See the screenshots below:
<img width="430" alt="Screenshot 2022-05-13 at 3 45 35 PM" src="https://user-images.githubusercontent.com/98815360/168263483-8c4435ce-07f2-4277-9523-36e416fef341.png">
<img width="815" alt="Screenshot 2022-05-13 at 3 46 14 PM" src="https://user-images.githubusercontent.com/98815360/168263527-803892a7-378b-4d3d-9c4f-f685c1993d9a.png">

