### PR TITLE
Show logs only to selected roles or remove the roles selector if everyone is selected

### DIFF
--- a/logs/assets/logs_control_panel.html
+++ b/logs/assets/logs_control_panel.html
@@ -84,18 +84,20 @@
                                 <p><b>Access control</b></p>
                                 <label>Mode</label><br>
                                 <select name="AccessMode" class="multiselect form-control"
-                                    id="blacklisted-roles-receive">
+                                    id="message-logs-access-mode" onchange="toggleAccessMode(this)">
                                     <option value="0" {{if eq .Config.AccessMode 0}} selected{{end}}>Members can view
                                         message logs</option>
                                     <option value="1" {{if eq .Config.AccessMode 1}} selected{{end}}>Everyone can view
                                         message logs</option>
                                 </select>
-                                <label>Roles</label><br>
-                                <select name="MessageLogsAllowedRoles" class="multiselect form-control"
-                                    multiple="multiple" id="blacklisted-roles-receive" data-plugin-multiselect
-                                    data-placeholder="Everyone">
-                                    {{roleOptionsMulti .ActiveGuild.Roles nil .Config.MessageLogsAllowedRoles}}
-                                </select>
+                                <div id="roles-selector" {{if eq .Config.AccessMode 1}}hidden{{end}} style="margin: 1em 0;">
+                                    <label>Roles</label><br>
+                                    <select name="MessageLogsAllowedRoles" class="multiselect form-control"
+                                        multiple="multiple" id="message-logs-allowed-roles" data-plugin-multiselect
+                                        data-placeholder="None selected">
+                                        {{roleOptionsMulti .ActiveGuild.Roles nil .Config.MessageLogsAllowedRoles}}
+                                    </select>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -168,5 +170,16 @@
 <!-- /.row -->
 
 {{template "cp_footer" .}}
+
+<script>
+    function toggleAccessMode(accessMode) {
+        const rolesSelector = document.getElementById("roles-selector")
+        if (accessMode.value === "1") {
+            rolesSelector.setAttribute("hidden", "")
+        } else {
+            rolesSelector.removeAttribute("hidden")
+        }
+    }
+</script>
 
 {{end}}

--- a/logs/web.go
+++ b/logs/web.go
@@ -224,29 +224,30 @@ func HandleLogsCPDeleteAll(w http.ResponseWriter, r *http.Request) (web.Template
 }
 
 func CheckCanAccessLogs(w http.ResponseWriter, r *http.Request, config *models.GuildLoggingConfig) bool {
-	_, tmpl := web.GetBaseCPContextData(r.Context())
+	ctx := r.Context()
+	_, tmpl := web.GetBaseCPContextData(ctx)
 
-	isAdmin, _ := web.IsAdminRequest(r.Context(), r)
-
-	// check if were allowed access to logs on this server
-	if isAdmin || config.AccessMode == AccessModeEveryone {
-		return true
-	}
-
-	member := web.ContextMember(r.Context())
+	member := web.ContextMember(ctx)
 	if member == nil {
 		tmpl.AddAlerts(web.ErrorAlert("This server has restricted log access to members only."))
 		return false
 	}
 
-	if len(config.MessageLogsAllowedRoles) > 0 {
-		if !common.ContainsInt64SliceOneOf(member.Roles, config.MessageLogsAllowedRoles) {
-			tmpl.AddAlerts(web.ErrorAlert("This server has restricted log access to certain roles, you don't have any of them."))
-			return false
-		}
+	memberPermissions := web.ContextMemberPerms(ctx)
+	guild := web.ContextGuild(ctx)
+
+	// if access mode is everyone or the user is the owner or they have administrator/manage server perms, then they can access the logs
+	if (config.AccessMode == 1) || (member.User.ID == guild.OwnerID) || (memberPermissions&discordgo.PermissionAdministrator == discordgo.PermissionAdministrator) || (memberPermissions&discordgo.PermissionManageServer == discordgo.PermissionManageServer) {
+		return true
 	}
 
-	return true
+	// If the user has one of the allowed roles
+	if len(config.MessageLogsAllowedRoles) > 0 && common.ContainsInt64SliceOneOf(member.Roles, config.MessageLogsAllowedRoles) {
+		return true
+	}
+
+	tmpl.AddAlerts(web.ErrorAlert("This server has restricted log access to certain roles, you don't have any of them."))
+	return false
 }
 
 type ctxKey int


### PR DESCRIPTION
1. The dropdown to handle roles for logs access will be removed if access for everyone is selected.
2. Allow only selected members or owner/admins/members with manage server permission to view logs.