### PR TITLE
Check for command override for gr/tr commands with negative values

### DIFF
--- a/commands/plugin_bot.go
+++ b/commands/plugin_bot.go
@@ -184,7 +184,7 @@ func YAGCommandMiddleware(inner dcmd.RunFunc) dcmd.RunFunc {
 		defer removeRunningCommand(guildID, data.ChannelID, data.Author.ID, yc)
 
 		// Check if the user can execute the command
-		canExecute, resp, settings, err := yc.checkCanExecuteCommand(data)
+		canExecute, resp, settings, err := yc.CheckCanExecuteCommand(data)
 		if err != nil {
 			yc.Logger(data).WithError(err).Error("An error occured while checking if we could run command")
 		}

--- a/commands/yagcommmand.go
+++ b/commands/yagcommmand.go
@@ -397,7 +397,7 @@ type CanExecuteError struct {
 }
 
 // checks if the specified user can execute the command, and if so returns the settings for said command
-func (yc *YAGCommand) checkCanExecuteCommand(data *dcmd.Data) (canExecute bool, resp *CanExecuteError, settings *CommandSettings, err error) {
+func (yc *YAGCommand) CheckCanExecuteCommand(data *dcmd.Data) (canExecute bool, resp *CanExecuteError, settings *CommandSettings, err error) {
 	// Check guild specific settings if not triggered from a DM
 	if data.GuildData != nil {
 		guild := data.GuildData.GS


### PR DESCRIPTION
If the user runs giverep/takerep command by giving negative value, it should check that the opposite command's overridden settings if any.

For example, if takerep command is overridden for some whitelist roles only, then following error will be raised if the user running the command is not in whitelist roles.
<img width="794" alt="Screenshot 2022-05-20 at 12 09 32 PM" src="https://user-images.githubusercontent.com/98815360/169469112-9583f770-e840-4beb-a2df-c1f37656679c.png">
 