### PR TITLE
stdcommands/wouldyourather: remove author and footer icon from embed

### DIFF
--- a/stdcommands/wouldyourather/wouldyourather.go
+++ b/stdcommands/wouldyourather/wouldyourather.go
@@ -30,7 +30,6 @@ var Command = &commands.YAGCommand{
 			Author: &discordgo.MessageEmbedAuthor{
 				Name:    "Would you rather...",
 				URL:     "https://either.io/",
-				IconURL: "https://yagpdb.xyz/static/icons/favicon-32x32.png",
 			},
 			Footer: &discordgo.MessageEmbedFooter{
 				Text:    fmt.Sprintf("Requested by: %s#%s", data.Author.Username, data.Author.Discriminator),

--- a/stdcommands/wouldyourather/wouldyourather.go
+++ b/stdcommands/wouldyourather/wouldyourather.go
@@ -33,7 +33,6 @@ var Command = &commands.YAGCommand{
 			},
 			Footer: &discordgo.MessageEmbedFooter{
 				Text:    fmt.Sprintf("Requested by: %s#%s", data.Author.Username, data.Author.Discriminator),
-				IconURL: discordgo.EndpointUserAvatar(data.Author.ID, data.Author.Avatar),
 			},
 			Color: rand.Intn(16777215),
 		}


### PR DESCRIPTION
The author icon in the `wouldyourather` command is a low-quality icon of YAG's avatar, which doesn't look right. Since it doesn't make much sense to display the avatar in the embed anyway, since users can already see who the message is from, removing it altogether seems like a better option than using an image/icon with a better resolution. To balance the changes out in the author icon, the footer icon with the user avatar is also removed in this PR.

Current Embed:
![image](https://user-images.githubusercontent.com/67655446/169686713-a76fddfa-09bd-4100-9333-75343bb5f77a.png)

Embed after the changes:
![image](https://user-images.githubusercontent.com/67655446/169686733-5d566b41-c821-4ed2-9f84-9997ef74b462.png)
