### PR TITLE
Removed `CREATE INDEX` statement from automod_violations rule_id 

### DIFF
--- a/automod/db_schema.go
+++ b/automod/db_schema.go
@@ -76,9 +76,6 @@ CREATE INDEX IF NOT EXISTS automod_violations_guild_idx ON automod_violations(gu
 CREATE INDEX IF NOT EXISTS automod_violations_user_idx ON automod_violations(user_id);
 
 `, `
-CREATE INDEX IF NOT EXISTS automod_violations_rule_idx ON automod_violations(rule_id);
-
-`, `
 CREATE TABLE IF NOT EXISTS automod_lists (
 	id BIGSERIAL PRIMARY KEY,
 	guild_id BIGINT NOT NULL,


### PR DESCRIPTION
removed CREATE INDEX from automod_violations rule_id as deleting a rule has a cascade effect on update automod_violations rule_id column and causes CPU spike on db. 