### PR TITLE
Improve automod spam link checking 

### DIFF
--- a/antiphishing/antiphishing.go
+++ b/antiphishing/antiphishing.go
@@ -79,7 +79,19 @@ func getAllPhishingDomains() ([]string, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	domains := make([]string, 0)
+
+	req2, _ := http.NewRequest("GET", "https://api.heptagrambotproject.com/locked/all/scam/links", nil)
+	req2.Header.Add("Content-Type", "application/json")
+	req2.Header.Add("Accept", "*/*")
+	req2.Header.Add("X-identify", "YAGPDB")
+	resp2, err := client.Do(req2)
+	if err != nil {
+		return nil, err
+	}
+	defer resp2.Body.Close()
+
+	// get both responses and merge them in an single array
+	var domains []string
 	err = json.NewDecoder(resp.Body).Decode(&domains)
 	if err != nil {
 		return nil, err

--- a/antiphishing/antiphishing.go
+++ b/antiphishing/antiphishing.go
@@ -18,6 +18,10 @@ type Plugin struct {
 	stopWorkers chan *sync.WaitGroup
 }
 
+type HeptagramAntiFishResponse struct {
+	scamDetected bool `json:"scamDetected"`
+}
+
 type BitFlowAntiFishResponse struct {
 	Match   bool `json:"match"`
 	Matches []struct {


### PR DESCRIPTION
Hey! I figured it'd be fun to contribute to this project, and I happen to be the core maintainer of an API that has a scam link endpoint. 

However, this bot is incredibly complex, and I am having trouble making this contribution. I figured I would open this as a draft, and ask for help. 

I'm struggling to find how to adapt the code to call both my API and the sinking yacht API. Does anyone have any thoughts on this?