### PR TITLE
moderation/commands: make report command's response ephemeral

### DIFF
--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -503,6 +503,7 @@ var ModerationCommands = []*commands.YAGCommand{
 		},
 		SlashCommandEnabled: true,
 		DefaultEnabled:      false,
+		IsResponseEphemeral: true,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 			config, _, err := MBaseCmd(parsed, 0)
 			if err != nil {


### PR DESCRIPTION
As described by the title, this PR makes the report command's response ephemeral.
![image](https://user-images.githubusercontent.com/67655446/176406363-dc2f794b-50b1-4b5d-8b28-70f7f857dd48.png)
