### PR TITLE
customcommands: handle responses over 2000 chars

### DIFF
--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -176,7 +176,8 @@ var cmdListCommands = &commands.YAGCommand{
 		var ccFile *discordgo.File
 		var msg *discordgo.MessageSend
 
-		if data.Switches["file"].Value != nil {
+		responses := fmt.Sprintf("```\n%s\n```", strings.Join(cc.Responses, "```\n```"))
+		if data.Switches["file"].Value != nil || len(responses) >= 2000 {
 			var buf bytes.Buffer
 			buf.WriteString(strings.Join(cc.Responses, "\nAdditional response:\n"))
 
@@ -213,6 +214,7 @@ var cmdListCommands = &commands.YAGCommand{
 			return msg, nil
 
 		}
+
 		return fmt.Sprintf("#%d - %s - Group: `%s`\n```%s\n%s\n```",
 			cc.LocalID, CommandTriggerType(cc.TriggerType), groupMap[cc.GroupID.Int64],
 			highlight, strings.Join(cc.Responses, "```\n```")), nil


### PR DESCRIPTION
This commit updates the `customcommands` command to handle responses
over 2000 characters in the way to instead send them to a file.

This was a suggestion on the support server, the relevant link follows:
https://discord.com/channels/166207328570441728/356486960417734666/927246757501480990

I've tested my changes for single responses over and under 2000
characters, as well as multiple responses, over and under 2000 together
respectively.

![image](https://user-images.githubusercontent.com/71897876/176870373-4c75e7bd-c235-46ec-81f8-2de3bf19507d.png)

Signed-off-by: Luca Zeuch <l-zeuch@email.de>