### PR TITLE
autorole: add notice about Discord's protections

### DIFF
--- a/autorole/assets/autorole.html
+++ b/autorole/assets/autorole.html
@@ -42,6 +42,12 @@
                             </select>
                         </div>
                         <div class="form-group">
+                            <h4>Notice:</h4>
+                            <p>
+                            Automatically adding any role on join bypasses Discord's protections such as
+                            <a href="https://support.discord.com/hc/en-us/articles/216679607-What-are-Verification-levels-"><b>Verification Levels</b></a>
+                            and <a href="https://support.discord.com/hc/en-us/articles/1500000466882-Rules-Screening-FAQ"><b>Rule Screening</b></a>.
+                            </p>
                             {{checkbox "OnlyOnJoin" "OnlyOnJoin" `Only assign the role when they join, do not give it back if it's removed from them afterwards. (<b>Note:</b> Above mentioned conditions will be checked before assigning the role)` .Autorole.OnlyOnJoin `onchange="toggleOnlyOnJoin(this)"`}}
                         </div>
                         <div class="form-group">


### PR DESCRIPTION
Seeing as Discord's protective means like Verification Levels and Rule
Screening do not apply to members with a role present, adding a role
automatically on join bypasses these means.

This commit adds a notice to the autorole page pointing this exact thing
out.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>