### PR TITLE
commands: impose proper limits on embed fields

### DIFF
--- a/commands/plugin_bot.go
+++ b/commands/plugin_bot.go
@@ -363,7 +363,7 @@ func ensureEmbedLimits(embed *discordgo.MessageEmbed) {
 
 	currentField := firstField
 	for _, v := range lines {
-		if utf8.RuneCountInString(currentField.Value)+utf8.RuneCountInString(v) >= 2000 {
+		if utf8.RuneCountInString(currentField.Value)+utf8.RuneCountInString(v) >= 1024 {
 			currentField = &discordgo.MessageEmbedField{
 				Name:  "...",
 				Value: v + "\n",


### PR DESCRIPTION
The function `ensureEmbedLimits` probably used outdated
information for enforcing embed limitations put in place.

This commit limits fields to 1024 characters in size, as that is the
current limit.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>