### PR TITLE
logs/plugin_bot: fix whois to work with animated avatars

### DIFF
--- a/logs/plugin_bot.go
+++ b/logs/plugin_bot.go
@@ -167,7 +167,7 @@ var cmdWhois = &commands.YAGCommand{
 				},
 				{
 					Name:   "Avatar",
-					Value:  "[Link](" + discordgo.EndpointUserAvatar(member.User.ID, member.User.Avatar) + ")",
+					Value:  "[Link](" + member.User.AvatarURL("256") + ")",
 					Inline: true,
 				},
 				{
@@ -197,7 +197,7 @@ var cmdWhois = &commands.YAGCommand{
 				},
 			},
 			Thumbnail: &discordgo.MessageEmbedThumbnail{
-				URL: discordgo.EndpointUserAvatar(member.User.ID, member.User.Avatar),
+				URL: member.User.AvatarURL("256"),
 			},
 		}
 


### PR DESCRIPTION
This PR removes the usage of the function, `discordgo.EndpointUserAvatar()` and replaces it with `user.AvatarURL()` in the `whois` command to deal correctly with animated avatars and return a GIF instead of a PNG, effectively changing the displayed thumbnail and a field.