### PR TITLE
bot/paginatedinteraction: change next and prev emoji arrows to remove discrepancy

### DIFF
--- a/bot/paginatedmessages/paginatedinteractions.go
+++ b/bot/paginatedmessages/paginatedinteractions.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	EmojiNext = "⮕"
-	EmojiPrev = "⬅"
+	EmojiNext = "▶"
+	EmojiPrev = "◀"
 )
 
 var (


### PR DESCRIPTION
Discord mobile on android seems to display the current next and previous buttons in an odd fashion wherein one looks different from the other. 

- Discord on PC
![image](https://user-images.githubusercontent.com/67655446/178037272-72bb38dd-4bee-4288-af1d-3824bb35ecdb.png)

- Discord on Android
![image](https://user-images.githubusercontent.com/67655446/178037543-3ab516c7-3af0-4285-a50a-2a3d98913853.png)

This PR changes the emojis used for next and previous buttons to avoid such a problem.
- Discord on Android after changes
![image](https://user-images.githubusercontent.com/67655446/178038816-36a172d7-e27b-4fc3-b331-a65ba2fe6b08.png)
