### PR TITLE
Allow Send message effect to send message in different channel

### DIFF
--- a/automod/assets/automod.html
+++ b/automod/assets/automod.html
@@ -329,6 +329,9 @@ table{
     <select id="automod-channel-multi-template" class="multiselect form-control" multiple="multiple" data-plugin-multiselect>
         {{textChannelOptionsMulti .ActiveGuild.Channels nil}}
     </select>
+    <select id="automod-channel-single-template" class="form-control">
+        {{textChannelOptions .ActiveGuild.Channels nil true "None"}}
+    </select>
     <select id="automod-list-selection-template" class="form-control">
         {{range .AutomodLists}}
         <option value="{{.ID}}">{{.Name}}</option>
@@ -539,6 +542,9 @@ $(function(){
         case "role":
             cloneDropdown(column, "#automod-roledropdown-single-template", key, true);
             break;
+        case "channel":
+            cloneDropdown(column, "#automod-channel-single-template", key, true);
+            break;
         case "multi_channel":
             cloneDropdown(column, "#automod-channel-multi-template", key, true);
             break;
@@ -612,6 +618,10 @@ $(function(){
                     {{else if eq .Kind "role"}}
                     <select name="{{$name}}" class="form-control" >
                         {{roleOptions $dot.dot.ActiveGuild.Roles nil (index $dot.settings .Key)}}
+                    </select>
+                    {{else if eq .Kind "channel"}}
+                    <select name="{{$name}}" class="form-control">
+                        {{textChannelOptions $dot.dot.ActiveGuild.Channels (index $dot.settings .Key) true "None"}}
                     </select>
                     {{else if eq .Kind "multi_channel"}}
                     <select name="{{$name}}" class="multiselect form-control" multiple="multiple" data-plugin-multiselect>

--- a/automod/effects.go
+++ b/automod/effects.go
@@ -774,6 +774,7 @@ type SendChannelMessageEffectData struct {
 	CustomReason string `valid:",0,280,trimspace"`
 	Duration     int    `valid:",0,3600,trimspace"`
 	PingUser     bool
+	LogChannel   int64
 }
 
 type SendChannelMessageEffect struct{}
@@ -817,6 +818,12 @@ func (send *SendChannelMessageEffect) UserSettings() []*SettingDef {
 			Kind:    SettingTypeBool,
 			Default: false,
 		},
+		{
+			Name:    "Channel to send message in (Leave None to send message in same channel)",
+			Key:     "LogChannel",
+			Kind:    SettingTypeChannel,
+			Default: nil,
+		},
 	}
 }
 
@@ -826,12 +833,13 @@ func (send *SendChannelMessageEffect) Apply(ctxData *TriggeredRuleData, settings
 		return nil
 	}
 
+	settingsCast := settings.(*SendChannelMessageEffectData)
+
 	// If we dont have any channel data, we can't send a message
-	if ctxData.CS == nil {
+	if ctxData.CS == nil && settingsCast.LogChannel == 0 {
 		return nil
 	}
 
-	settingsCast := settings.(*SendChannelMessageEffectData)
 	msgSend := &discordgo.MessageSend{}
 
 	if settingsCast.PingUser {
@@ -848,7 +856,14 @@ func (send *SendChannelMessageEffect) Apply(ctxData *TriggeredRuleData, settings
 		msgSend.Content += ctxData.ConstructReason(true)
 	}
 
-	message, err := common.BotSession.ChannelMessageSendComplex(ctxData.CS.ID, msgSend)
+	var logChannel int64
+	if settingsCast.LogChannel != 0 {
+		logChannel = settingsCast.LogChannel
+	} else {
+		logChannel = ctxData.CS.ID
+	}
+
+	message, err := common.BotSession.ChannelMessageSendComplex(logChannel, msgSend)
 	if err != nil {
 		logger.WithError(err).Error("Failed to send message for AutomodV2")
 		return err


### PR DESCRIPTION
Added a channel dropdown to allow Send Message effect to send the message in separate channel if required.
<img width="1080" alt="Screenshot 2022-08-02 at 3 56 30 PM" src="https://user-images.githubusercontent.com/98815360/182353308-f7402182-cc9c-47c6-a0bf-e7929bb7ed93.png">

