### PR TITLE
Added functions to reply to a message using custom command

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -565,10 +565,6 @@ func baseContextFuncs(c *Context) {
 	c.addContextFunc("editMessageNoEscape", c.tmplEditMessage(false))
 	c.addContextFunc("pinMessage", c.tmplPinMessage(false))
 	c.addContextFunc("unpinMessage", c.tmplPinMessage(true))
-	c.addContextFunc("sendMessageReply", c.tmplSendMessageReply(true, false))
-	c.addContextFunc("sendMessageReplyRetID", c.tmplSendMessageReply(true, true))
-	c.addContextFunc("sendMessageReplyNoEscape", c.tmplSendMessageReply(false, false))
-	c.addContextFunc("sendMessageReplyNoEscapeRetID", c.tmplSendMessageReply(false, true))
 
 	// Mentions
 	c.addContextFunc("mentionEveryone", c.tmplMentionEveryone)

--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -565,6 +565,10 @@ func baseContextFuncs(c *Context) {
 	c.addContextFunc("editMessageNoEscape", c.tmplEditMessage(false))
 	c.addContextFunc("pinMessage", c.tmplPinMessage(false))
 	c.addContextFunc("unpinMessage", c.tmplPinMessage(true))
+	c.addContextFunc("sendMessageReply", c.tmplSendMessageReply(true, false))
+	c.addContextFunc("sendMessageReplyRetID", c.tmplSendMessageReply(true, true))
+	c.addContextFunc("sendMessageReplyNoEscape", c.tmplSendMessageReply(false, false))
+	c.addContextFunc("sendMessageReplyNoEscapeRetID", c.tmplSendMessageReply(false, true))
 
 	// Mentions
 	c.addContextFunc("mentionEveryone", c.tmplMentionEveryone)

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -401,6 +401,92 @@ func (c *Context) tmplSendMessage(filterSpecialMentions bool, returnID bool) fun
 	}
 }
 
+func (c *Context) tmplSendMessageReply(filterSpecialMentions bool, returnID bool) func(channel interface{}, msgID interface{}, msg interface{}) interface{} {
+	parseMentions := []discordgo.AllowedMentionType{discordgo.AllowedMentionTypeUsers}
+	if !filterSpecialMentions {
+		parseMentions = append(parseMentions, discordgo.AllowedMentionTypeRoles, discordgo.AllowedMentionTypeEveryone)
+	}
+
+	return func(channel interface{}, msgID interface{}, msg interface{}) interface{} {
+		if c.IncreaseCheckGenericAPICall() {
+			return ""
+		}
+
+		cID := c.ChannelArg(channel)
+		if cID == 0 {
+			return ""
+		}
+
+		isDM := cID != c.ChannelArgNoDM(channel)
+		gName := c.GS.Name
+		info := fmt.Sprintf("Custom Command DM from the server **%s**", gName)
+		embedInfo := fmt.Sprintf("Custom Command DM from the server %s", gName)
+		icon := discordgo.EndpointGuildIcon(c.GS.ID, c.GS.Icon)
+		mID := ToInt64(msgID)
+
+		var m *discordgo.Message
+		msgSend := &discordgo.MessageSend{
+			AllowedMentions: discordgo.AllowedMentions{
+				Parse: parseMentions,
+			},
+			Reference: &discordgo.MessageReference{
+				MessageID: mID,
+				ChannelID: cID,
+			},
+		}
+		var err error
+
+		switch typedMsg := msg.(type) {
+		case *discordgo.MessageEmbed:
+			if isDM {
+				typedMsg.Footer = &discordgo.MessageEmbedFooter{
+					Text:    embedInfo,
+					IconURL: icon,
+				}
+			}
+			msgSend.Embeds = []*discordgo.MessageEmbed{typedMsg}
+		case []*discordgo.MessageEmbed:
+			if isDM {
+				for _, e := range typedMsg {
+					e.Footer = &discordgo.MessageEmbedFooter{
+						Text:    embedInfo,
+						IconURL: icon,
+					}
+				}
+			}
+		case *discordgo.MessageSend:
+			msgSend = typedMsg
+			msgSend.AllowedMentions = discordgo.AllowedMentions{Parse: parseMentions}
+			if isDM {
+				if len(typedMsg.Embeds) > 0 {
+					for _, e := range msgSend.Embeds {
+						e.Footer = &discordgo.MessageEmbedFooter{
+							Text:    embedInfo,
+							IconURL: icon,
+						}
+					}
+				} else {
+					typedMsg.Content = info + "\n" + typedMsg.Content
+				}
+			}
+		default:
+			if isDM {
+				msgSend.Content = info + "\n" + ToString(msg)
+			} else {
+				msgSend.Content = ToString(msg)
+			}
+		}
+
+		m, err = common.BotSession.ChannelMessageSendComplex(cID, msgSend)
+
+		if err == nil && returnID {
+			return m.ID
+		}
+
+		return ""
+	}
+}
+
 func (c *Context) tmplEditMessage(filterSpecialMentions bool) func(channel interface{}, msgID interface{}, msg interface{}) (interface{}, error) {
 	parseMentions := []discordgo.AllowedMentionType{discordgo.AllowedMentionTypeUsers}
 	if !filterSpecialMentions {

--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -259,8 +259,12 @@ func CreateMessageSend(values ...interface{}) (*discordgo.MessageSend, error) {
 			// Cut the filename to a reasonable length if it's too long
 			filename = common.CutStringShort(ToString(val), 64)
 		case "reply":
+			msgID := ToInt64(val)
+			if msgID <= 0 {
+				return nil, errors.New(fmt.Sprintf("invalid message id '%s' provided to reply.", ToString(val)))
+			}
 			msg.Reference = &discordgo.MessageReference{
-				MessageID: val.(int64),
+				MessageID: msgID,
 			}
 		default:
 			return nil, errors.New(`invalid key "` + key + `" passed to send message builder`)

--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -258,6 +258,10 @@ func CreateMessageSend(values ...interface{}) (*discordgo.MessageSend, error) {
 		case "filename":
 			// Cut the filename to a reasonable length if it's too long
 			filename = common.CutStringShort(ToString(val), 64)
+		case "reply":
+			msg.Reference = &discordgo.MessageReference{
+				MessageID: val.(int64),
+			}
 		default:
 			return nil, errors.New(`invalid key "` + key + `" passed to send message builder`)
 		}


### PR DESCRIPTION
Added key `reply` in `complexMessage` which can be used to reply to a message by providing its message id.
Example:
`{{ sendMessage nil (complexMessage "content" "This is a reply" "reply" .Message.ID) }}`