### PR TITLE
amod_legacy: rewrite cached invites logic

### DIFF
--- a/automod_legacy/rules_test.go
+++ b/automod_legacy/rules_test.go
@@ -1,0 +1,20 @@
+package automod_legacy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCachedInvites(t *testing.T) {
+	invitesCache.set("foo", 123)
+	i, ok := invitesCache.get("foo")
+	assert.True(t, ok)
+	assert.EqualValues(t, 123, i.guildID)
+
+	time.Sleep(50 * time.Millisecond)
+	invitesCache.tick(time.Millisecond)
+	_, ok = invitesCache.get("foo")
+	assert.False(t, ok)
+}


### PR DESCRIPTION
This PR aims to rewrite the logic of the cached invites in the automod_legacy package.
The old logic was messy, I find this new one much cleaner.

Other than that, this logic is orders of magnitude faster.


---- Edit
Removed the benchmarks because of the discussion in the community server, see here: https://discord.com/channels/166207328570441728/920615133993107467/1004781523557429349