### PR TITLE
customcommands: add `raw` switch

### DIFF
--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -132,6 +132,7 @@ var cmdListCommands = &commands.YAGCommand{
 	ArgSwitches: []*dcmd.ArgDef{
 		{Name: "file", Help: "Send responses in file"},
 		{Name: "color", Help: "Use syntax highlighting (Go)"},
+		{Name: "raw", Help: "Force raw output"},
 	},
 	RunFunc: func(data *dcmd.Data) (interface{}, error) {
 		ccs, err := models.CustomCommands(qm.Where("guild_id = ?", data.GuildData.GS.ID), qm.OrderBy("local_id")).AllG(data.Context())
@@ -178,7 +179,7 @@ var cmdListCommands = &commands.YAGCommand{
 		var msg *discordgo.MessageSend
 
 		responses := fmt.Sprintf("```\n%s\n```", strings.Join(cc.Responses, "```\n```"))
-		if data.Switches["file"].Value != nil || len(responses) >= 2000 {
+		if data.Switches["file"].Value != nil || len(responses) >= 2000 && data.Switches["raw"].Value == nil {
 			var buf bytes.Buffer
 			buf.WriteString(strings.Join(cc.Responses, "\nAdditional response:\n"))
 


### PR DESCRIPTION
Commit 3054fe9 (customcommands: handle responses over 2000 chars) via
PR #1294 introduced a regression with its automagic handling of responses
over 2000 characters, breaking custom commands reliant on the original
behaviour of dumping the code.

This commit attempts to fix that regression by adding a `-raw` switch so
that users relying on the original behaviour can force that for their
custom command """backend""", whilst we still keep a nice user-facing
experience.

Closes #1312

Signed-off-by: Luca Zeuch <l-zeuch@email.de>