### PR TITLE
customcommands: handle threads for `sendTemplate`

### DIFF
--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -102,6 +102,12 @@ func (c *Context) baseChannelArg(v interface{}) *dstate.ChannelState {
 						return &v
 					}
 				}
+				// Do the same for thread names
+				for _, v := range c.GS.Threads {
+					if strings.EqualFold(t, v.Name) && v.Type == discordgo.ChannelTypeGuildPublicThread || v.Type == discordgo.ChannelTypeGuildPrivateThread {
+						return &v
+					}
+				}
 			}
 		}
 	}
@@ -177,7 +183,7 @@ func (c *Context) sendNestedTemplate(channel interface{}, dm bool, name string, 
 				return "", errors.New("unknown channel")
 			}
 
-			cs = c.GS.GetChannel(cID)
+			cs = c.GS.GetChannelOrThread(cID)
 			if cs == nil {
 				return "", errors.New("unknown channel")
 			}


### PR DESCRIPTION
Previously, the `sendTemplate` function failed for threads with "unknown
channel". This commit modifies the tmplSendTemplate function as well as
the baseChannelArg function to also include threads.

Related suggestion:
https://canary.discord.com/channels/166207328570441728/356486960417734666/994956087142924438

Signed-off-by: Luca Zeuch <l-zeuch@email.de>