### PR TITLE
cc: fix panic in tmplJSONToSDict

### DIFF
--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -1086,7 +1086,7 @@ func tmplJson(v interface{}) (string, error) {
 
 func tmplJSONToSDict(v interface{}) (SDict, error) {
 	var toSDict SDict
-	err := json.Unmarshal([]byte(v.(string)), &toSDict)
+	err := json.Unmarshal([]byte(ToString(v)), &toSDict)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`tmplJSONToSDict` would panic if the argument given to it was not a string.
This PR makes the func use the ToString function for the conversion of v instead of a type assertion.