### PR TITLE
template: make execTemplate error when too many args

### DIFF
--- a/lib/template/funcs.go
+++ b/lib/template/funcs.go
@@ -257,7 +257,7 @@ func length(item interface{}) (int, error) {
 
 // execTemplate executes the associated template with the given name and data
 // and returns its return value.
-func execTemplate(name string, data ...reflect.Value) reflect.Value {
+func execTemplate(name string, data ...interface{}) reflect.Value {
 	panic("unreachable") // implemented as a special case in evalCall
 }
 


### PR DESCRIPTION
Presently, the following program
```
{{define "f"}}
	{{.}}
{{end}}
{{execTemplate "f" 1 2 3}}
```
runs without error, when it really should not; the arguments `2` and `3` to `execTemplate` are silently ignored. Fix this by making `execTemplate` error when there's more than two arguments, and while we're at it, simplify the implementation slightly.