### PR TITLE
templates: make callVariadic indirect inputs

### DIFF
--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -1126,7 +1126,8 @@ func callVariadic(f variadicFunc, skipNil bool, values ...reflect.Value) (reflec
 			}
 		case v.Kind() == reflect.Array || v.Kind() == reflect.Slice:
 			for i := 0; i < v.Len(); i++ {
-				vs = append(vs, v.Index(i))
+				irv, _ := indirect(v.Index(i))
+				vs = append(vs, irv)
 			}
 		default:
 			vs = append(vs, v)


### PR DESCRIPTION
The following code doesn't work currently:
```
{{addReactions (cslice "👋")}}
```

Instead, it displays an unintuitive error:
```
Failed executing CC #10, line 1, row 2: executing "CC #10" at <addReactions (cslice "👋")>: error calling addReactions: HTTP 400 Bad Request, {"message": "Unknown Emoji", "code": 10014}
```

The fix is simple, as shown, but why it makes a difference at all is a more complex matter. Below is a brief explanation for the benefit of reviewers and future readers of this code.
- `tmplAddReactions` defines a helper function `f`, which performs the actual API calls.
- `f` takes in a slice of `reflect.Value`s and calls `MessageReactionAdd(v.String())` for each value `v`.
- `reflect.Value.String` [returns a string of the form "\<T value\>" where T is v's type](https://pkg.go.dev/reflect#Value.String) when the value is not of type `string`.
- Thus, if we encounter an emoji that isn't of type `string`, the reaction that we add will not be in the correct format. For example, this would be the case if the emoji is an interface value holding a string as its concrete value.

Now onto `callVariadic` and its role in this. If `callVariadic` receives a slice type, like `cslice "👋"`, it will process each element of that slice as is. In this case, since `cslice` is backed by a `[]interface{}`, the element type is `interface{}` and so we run into the problem mentioned previously. The reasoning behind the fix is, hopefully, now obvious; we just arrange for `callVariadic` to dig down to the concrete interface value using `indirect` so the emoji that `addReactions` sees has type `string` instead of `interface{}`.