### PR TITLE
customcommands: limit execCC call chains

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -165,6 +165,8 @@ type Context struct {
 
 	CurrentFrame *ContextFrame
 
+	// See DelayedRunCCData.CallChain.
+	ExecCallChain          []time.Time
 	IsExecedByLeaveMessage bool
 
 	contextFuncsAdded bool


### PR DESCRIPTION
**This change is as of yet completely untested; it exists to facilitate discussion regarding whether the approach taken is viable. If we agree that this is the right way to proceed, I will conduct the appropriate tests prior to undrafting this.**

---

`execCC` abuse has ran rampant ever since the function's introduction, with current limits proving futile. In certain causes, commands (mis)using `execCC` have caused whole shards to be impacted. This PR attempts to prevent such issues while minimally impacting reasonable usage. 

The key idea is to track relevant parts of `execCC` call chains (herein "chains") and limit calls based on that. A chain is created when a custom command executes another via `execCC`. If the executed command calls `execCC` again, then the chain is extended. Since chains can get very long without necessarily being abusive (e.g., consider a chain of `execCC`s with a 24h delay, which shouldn't be an issue), we only remember calls that occurred less than 5 minutes ago. If, at any time, the number of elements in the chain exceeds 20, we issue an error.

Put differently, this change limits `execCC` chains to not exceed a depth of 20 in a span of less than 5 minutes.

Feedback is appreciated and encouraged. This has the potential to be a major breaking change, and we want to get it right the first time, so there's no rush.