### PR TITLE
Using Long Date/Time for Event Time to display day

### DIFF
--- a/rsvp/plugin_bot.go
+++ b/rsvp/plugin_bot.go
@@ -370,7 +370,7 @@ func UpdateEventEmbed(m *models.RSVPSession) error {
 
 	embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
 		Name:  "Time",
-		Value: fmt.Sprintf("<t:%d> (UTC: `%s`)", m.StartsAt.Unix(), UTCTime.Format(timeFormat)),
+		Value: fmt.Sprintf("<t:%d:F> (UTC: `%s`)", m.StartsAt.Unix(), UTCTime.Format(timeFormat)),
 	}, &discordgo.MessageEmbedField{
 		Name:  "Reactions usage",
 		Value: "React to mark you as a participant, undecided, or not joining",


### PR DESCRIPTION
Would like to see what day the event is created for when creating events in the future.

Proposing to display the day of the event in the event details.




Style | Input | Output (12-hour clock) | Output (24-hour clock)
-- | -- | -- | --
Long Date/Time | <t:1543392060:F> | Wednesday, November 28, 2018 9:01 AM | Wednesday, 28 November 2018 09:01




Sauce: https://gist.github.com/LeviSnoot/d9147767abeef2f770e9ddcd91eb85aa

