### PR TITLE
Link to moderation configuration page

### DIFF
--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -54,7 +54,7 @@ func MBaseCmdSecond(cmdData *dcmd.Data, reason string, reasonArgOptional bool, n
 	cmdName := cmdData.Cmd.Trigger.Names[0]
 	oreason = reason
 	if !enabled {
-		return oreason, commands.NewUserErrorf("The **%s** command is disabled on this server. Enable it in the control panel on the moderation page.", cmdName)
+		return oreason, commands.NewUserErrorf("The **%s** command is disabled on this server. It can be enabled at <https://yagpdb.xyz/manage/%d/moderation>", cmdName, cmdData.GuildData.GS.ID)
 	}
 
 	if strings.TrimSpace(reason) == "" {


### PR DESCRIPTION
Having users joining, not able to identify how to enable moderation commands, and the error response failing to effectively indicate how to do so, has bugged me for a while. So this adds a link to the page for the given server, to the response...