### PR TITLE
Link to Role Commands page

### DIFF
--- a/rolecommands/menu.go
+++ b/rolecommands/menu.go
@@ -31,10 +31,11 @@ var recentMenusTracker = NewRecentMenusTracker(time.Minute * 10)
 
 func cmdFuncRoleMenuCreate(parsed *dcmd.Data) (interface{}, error) {
 	name := parsed.Args[0].Str()
+	panelURL := fmt.Sprintf("https://yagpdb.xyz/manage/%d/rolecommands/", parsed.GuildData.GS.ID)
 	group, err := models.RoleGroups(qm.Where("guild_id=?", parsed.GuildData.GS.ID), qm.Where("name ILIKE ?", name), qm.Load("RoleCommands")).OneG(parsed.Context())
 	if err != nil {
 		if errors.Cause(err) == sql.ErrNoRows {
-			const genericHelpMessage = "Did not find the role command group specified, make sure you typed it right, if you haven't set one up yet you can do so in the control panel."
+			const genericHelpMessage = fmt.Sprintf("Did not find the role command group specified. Make sure it's spelled correctly, or set one up at <%s>.", panelURL)
 
 			groups, err := models.RoleGroups(models.RoleGroupWhere.GuildID.EQ(parsed.GuildData.GS.ID), qm.Select(models.RoleGroupColumns.Name)).AllG(parsed.Context())
 			if err != nil {
@@ -61,7 +62,7 @@ func cmdFuncRoleMenuCreate(parsed *dcmd.Data) (interface{}, error) {
 
 	cmdsLen := len(group.R.RoleCommands)
 	if cmdsLen < 1 {
-		return "No commands in this group, set them up in the control panel.", nil
+		return fmt.Sprintf("No commands in this group. Set them up at <%s/group/%d>.", panelURL, group.ID), nil
 	}
 
 	model := &models.RoleMenu{

--- a/rolecommands/menu.go
+++ b/rolecommands/menu.go
@@ -35,7 +35,7 @@ func cmdFuncRoleMenuCreate(parsed *dcmd.Data) (interface{}, error) {
 	group, err := models.RoleGroups(qm.Where("guild_id=?", parsed.GuildData.GS.ID), qm.Where("name ILIKE ?", name), qm.Load("RoleCommands")).OneG(parsed.Context())
 	if err != nil {
 		if errors.Cause(err) == sql.ErrNoRows {
-			const genericHelpMessage = fmt.Sprintf("Did not find the role command group specified. Make sure it's spelled correctly, or set one up at <%s>.", panelURL)
+			genericHelpMessage = fmt.Sprintf("Did not find the role command group specified. Make sure it's spelled correctly, or set one up at <%s>.", panelURL)
 
 			groups, err := models.RoleGroups(models.RoleGroupWhere.GuildID.EQ(parsed.GuildData.GS.ID), qm.Select(models.RoleGroupColumns.Name)).AllG(parsed.Context())
 			if err != nil {

--- a/rolecommands/menu.go
+++ b/rolecommands/menu.go
@@ -35,7 +35,7 @@ func cmdFuncRoleMenuCreate(parsed *dcmd.Data) (interface{}, error) {
 	group, err := models.RoleGroups(qm.Where("guild_id=?", parsed.GuildData.GS.ID), qm.Where("name ILIKE ?", name), qm.Load("RoleCommands")).OneG(parsed.Context())
 	if err != nil {
 		if errors.Cause(err) == sql.ErrNoRows {
-			genericHelpMessage = fmt.Sprintf("Did not find the role command group specified. Make sure it's spelled correctly, or set one up at <%s>.", panelURL)
+			genericHelpMessage := fmt.Sprintf("Did not find the role command group specified. Make sure it's spelled correctly, or set one up at <%s>.", panelURL)
 
 			groups, err := models.RoleGroups(models.RoleGroupWhere.GuildID.EQ(parsed.GuildData.GS.ID), qm.Select(models.RoleGroupColumns.Name)).AllG(parsed.Context())
 			if err != nil {


### PR DESCRIPTION
Similarly to linking to the moderation page when moderation commands are disabled, this adds a link to the Role Commands page, when there's a configuration issue, such as YAGPDB being unable to find a specified Role Group, or the Role Group having no Role Commands.