### PR TITLE
Mention method for dstate.ChannelState

### DIFF
--- a/lib/dstate/interface.go
+++ b/lib/dstate/interface.go
@@ -1,6 +1,7 @@
 package dstate
 
 import (
+	"errors"
 	"strconv"
 	"strings"
 	"time"
@@ -223,6 +224,13 @@ func (c *ChannelState) IsPrivate() bool {
 	}
 
 	return false
+}
+
+func (c *ChannelState) Mention() (string, error) {
+	if c == nil {
+		return "", errors.New("channel not found")
+	}
+	return "<#" + discordgo.StrID(c.ID) + ">", nil
 }
 
 // A fully cached member


### PR DESCRIPTION
Because templates.CtxChannel aka .Channel has .Mention available, for consistency sake make it available also for dstate.ChannelState channels indexed from .Guild.Channels.