### PR TITLE
help: Increased description clarity around maintenance commands

### DIFF
--- a/autorole/bot.go
+++ b/autorole/bot.go
@@ -51,7 +51,7 @@ var roleCommands = []*commands.YAGCommand{
 	{
 		CmdCategory: commands.CategoryDebug,
 		Name:        "Roledbg",
-		Description: "Debug debug debug autorole assignment",
+		Description: "Returns count of autorole assignments currently being processed",
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 			var processing int
 			err := common.RedisPool.Do(radix.Cmd(&processing, "GET", KeyProcessing(parsed.GuildData.GS.ID)))

--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -1037,7 +1037,7 @@ func BotCachedGetCommandsWithMessageTriggers(guildID int64, ctx context.Context)
 var cmdFixCommands = &commands.YAGCommand{
 	CmdCategory:          commands.CategoryTool,
 	Name:                 "fixscheduledccs",
-	Description:          "???",
+	Description:          "Corrects the next run time of interval CCs globally, fixes issues arising from missed executions due to downtime. Bot Admin Only",
 	HideFromCommandsPage: true,
 	HideFromHelp:         true,
 	RunFunc: util.RequireBotAdmin(func(data *dcmd.Data) (interface{}, error) {

--- a/premium/codepremiumsource.go
+++ b/premium/codepremiumsource.go
@@ -155,7 +155,7 @@ var cmdGenerateCode = &commands.YAGCommand{
 	HideFromCommandsPage: true,
 	Name:                 "generatepremiumcode",
 	Aliases:              []string{"gpc"},
-	Description:          "Generates premium codes",
+	Description:          "Generates premium codes. Bot Owner Only",
 	HideFromHelp:         true,
 	RequiredArgs:         3,
 	RunInDM:              true,

--- a/reddit/bot.go
+++ b/reddit/bot.go
@@ -31,7 +31,7 @@ func (p *Plugin) AddCommands() {
 		CmdCategory:          commands.CategoryDebug,
 		HideFromCommandsPage: true,
 		Name:                 "testreddit",
-		Description:          "Tests the reddit feeds in this server by checking the specified post",
+		Description:          "Tests the reddit feeds in this server by checking the specified post. Bot Owner Only",
 		HideFromHelp:         true,
 		RequiredArgs:         1,
 		Arguments: []*dcmd.ArgDef{

--- a/stdcommands/allocstat/measure_allocs.go
+++ b/stdcommands/allocstat/measure_allocs.go
@@ -15,7 +15,7 @@ var Command = &commands.YAGCommand{
 	CmdCategory:          commands.CategoryDebug,
 	HideFromCommandsPage: true,
 	Name:                 "allocstat",
-	Description:          "Memory statistics.",
+	Description:          "Memory statistics. Bot Admin Only",
 	HideFromHelp:         true,
 	RunFunc: util.RequireBotAdmin(func(data *dcmd.Data) (interface{}, error) {
 		common.BotSession.ChannelTyping(data.ChannelID)

--- a/stdcommands/banserver/banserver.go
+++ b/stdcommands/banserver/banserver.go
@@ -13,7 +13,7 @@ var Command = &commands.YAGCommand{
 	CmdCategory:          commands.CategoryDebug,
 	HideFromCommandsPage: true,
 	Name:                 "banserver",
-	Description:          ";))",
+	Description:          "Bans the specified server from using the bot. YAGPDB will leave the server, and leave whenever invited back. Bot Owner Only",
 	HideFromHelp:         true,
 	RequiredArgs:         1,
 	Arguments: []*dcmd.ArgDef{

--- a/stdcommands/ccreqs/ccreqs.go
+++ b/stdcommands/ccreqs/ccreqs.go
@@ -13,7 +13,7 @@ var Command = &commands.YAGCommand{
 	CmdCategory:          commands.CategoryDebug,
 	HideFromCommandsPage: true,
 	Name:                 "ccreqs",
-	Description:          "Returns the number of concurrent requests currently going on",
+	Description:          "Returns the number of concurrent requests currently going on. Bot Admin Only",
 	HideFromHelp:         true,
 	RunFunc: util.RequireBotAdmin(func(data *dcmd.Data) (interface{}, error) {
 		return fmt.Sprintf("`%d`", common.BotSession.Ratelimiter.CurrentConcurrentLocks()), nil

--- a/stdcommands/createinvite/createinvite.go
+++ b/stdcommands/createinvite/createinvite.go
@@ -14,7 +14,7 @@ var Command = &commands.YAGCommand{
 	CmdCategory:          commands.CategoryDebug,
 	HideFromCommandsPage: true,
 	Name:                 "createinvite",
-	Description:          "Maintenance command, creates a invite for the specified server",
+	Description:          "Maintenance command, creates an invite for the specified server. Bot Admin Only",
 	HideFromHelp:         true,
 	RequiredArgs:         1,
 	Arguments: []*dcmd.ArgDef{

--- a/stdcommands/dcallvoice/dcallvoice.go
+++ b/stdcommands/dcallvoice/dcallvoice.go
@@ -15,7 +15,7 @@ var Command = &commands.YAGCommand{
 	CmdCategory:          commands.CategoryDebug,
 	HideFromCommandsPage: true,
 	Name:                 "dcallvoice",
-	Description:          "Disconnects from all the voice channels the bot is in",
+	Description:          "Disconnects from all the voice channels the bot is in. Bot Admin Only",
 	HideFromHelp:         true,
 	RunFunc: util.RequireBotAdmin(func(data *dcmd.Data) (interface{}, error) {
 

--- a/stdcommands/findserver/findserver.go
+++ b/stdcommands/findserver/findserver.go
@@ -28,7 +28,7 @@ var Command = &commands.YAGCommand{
 	HideFromCommandsPage: true,
 	Name:                 "findserver",
 	Aliases:              []string{"findservers"},
-	Description:          "Looks for a server by server name or the servers a user owns",
+	Description:          "Looks for a server by server name or the servers a user owns. Bot Admin Only",
 	HideFromHelp:         true,
 	ArgSwitches: []*dcmd.ArgDef{
 		{Name: "name", Type: dcmd.String, Default: ""},

--- a/stdcommands/globalrl/globalrl.go
+++ b/stdcommands/globalrl/globalrl.go
@@ -12,7 +12,7 @@ var Command = &commands.YAGCommand{
 	Cooldown:             2,
 	CmdCategory:          commands.CategoryDebug,
 	Name:                 "globalrl",
-	Description:          "Tests the global ratelimit functionality",
+	Description:          "Tests the global ratelimit functionality. Bot Owner Only",
 	RequiredArgs:         1,
 	HideFromHelp:         true,
 	HideFromCommandsPage: true,

--- a/stdcommands/leaveserver/leaveserver.go
+++ b/stdcommands/leaveserver/leaveserver.go
@@ -12,7 +12,7 @@ var Command = &commands.YAGCommand{
 	CmdCategory:          commands.CategoryDebug,
 	HideFromCommandsPage: true,
 	Name:                 "leaveserver",
-	Description:          ";))",
+	Description:          "Causes YAGPDB to leave the specified server. The bot may still be invited back with full functionality restored. Bot Owner Only",
 	HideFromHelp:         true,
 	RequiredArgs:         1,
 	Arguments: []*dcmd.ArgDef{

--- a/stdcommands/listflags/listflags.go
+++ b/stdcommands/listflags/listflags.go
@@ -14,7 +14,7 @@ var Command = &commands.YAGCommand{
 	CmdCategory:          commands.CategoryDebug,
 	HideFromCommandsPage: true,
 	Name:                 "listflags",
-	Description:          ";))",
+	Description:          "Lists feature flags for the current, or optional provided guild. Bot Owner Only",
 	HideFromHelp:         true,
 	RequiredArgs:         0,
 	Arguments: []*dcmd.ArgDef{

--- a/stdcommands/memstats/memstats.go
+++ b/stdcommands/memstats/memstats.go
@@ -17,7 +17,7 @@ var Command = &commands.YAGCommand{
 	CmdCategory:          commands.CategoryDebug,
 	HideFromCommandsPage: true,
 	Name:                 "memstats",
-	Description:          ";))",
+	Description:          "Full memory statistics. Bot Owner Only",
 	HideFromHelp:         true,
 	RunFunc: util.RequireOwner(func(data *dcmd.Data) (interface{}, error) {
 		var m runtime.MemStats

--- a/stdcommands/setstatus/setstatus.go
+++ b/stdcommands/setstatus/setstatus.go
@@ -12,7 +12,7 @@ var Command = &commands.YAGCommand{
 	CmdCategory:          commands.CategoryDebug,
 	HideFromCommandsPage: true,
 	Name:                 "setstatus",
-	Description:          "Sets the bot's status and streaming url",
+	Description:          "Sets the bot's status and optional streaming url. Bot Admin Only",
 	HideFromHelp:         true,
 	Arguments: []*dcmd.ArgDef{
 		{Name: "status", Type: dcmd.String, Default: ""},

--- a/stdcommands/sleep/sleep.go
+++ b/stdcommands/sleep/sleep.go
@@ -12,7 +12,7 @@ var Command = &commands.YAGCommand{
 	CmdCategory:          commands.CategoryDebug,
 	HideFromCommandsPage: true,
 	Name:                 "sleep",
-	Description:          "Maintenance command, used to test command queueing",
+	Description:          "Maintenance command, used to test command queueing. Bot Admin Only",
 	HideFromHelp:         true,
 	RunFunc: util.RequireBotAdmin(func(data *dcmd.Data) (interface{}, error) {
 		time.Sleep(time.Second * 5)

--- a/stdcommands/statedbg/statedbg.go
+++ b/stdcommands/statedbg/statedbg.go
@@ -15,7 +15,7 @@ import (
 
 func Commands() *dcmd.Container {
 	container, _ := commands.CommandSystem.Root.Sub("state")
-	container.Description = "utilities for debugging state stuff"
+	container.Description = "utilities for debugging state stuff. Bot Admin Only"
 	container.AddMidlewares(util.RequireBotAdmin)
 	container.AddCommand(getGuild, getGuild.GetTrigger())
 	container.AddCommand(getMember, getMember.GetTrigger())
@@ -27,7 +27,7 @@ func Commands() *dcmd.Container {
 var getGuild = &commands.YAGCommand{
 	CmdCategory:  commands.CategoryDebug,
 	Name:         "guild",
-	Description:  "Responds with state debug info",
+	Description:  "Responds with state debug info. Bot Admin Only",
 	HideFromHelp: true,
 	RunFunc:      cmdFuncGetGuild,
 }
@@ -52,7 +52,7 @@ func cmdFuncGetGuild(data *dcmd.Data) (interface{}, error) {
 var getMember = &commands.YAGCommand{
 	CmdCategory: commands.CategoryDebug,
 	Name:        "member",
-	Description: "Responds with state debug info",
+	Description: "Responds with state debug info. Bot Admin Only",
 	Arguments: []*dcmd.ArgDef{
 		{Name: "Target", Type: dcmd.BigInt},
 	},
@@ -93,7 +93,7 @@ func cmdFuncGetMember(data *dcmd.Data) (interface{}, error) {
 var botMember = &commands.YAGCommand{
 	CmdCategory:  commands.CategoryDebug,
 	Name:         "botmember",
-	Description:  "Responds with state debug info",
+	Description:  "Responds with state debug info. Bot Admin Only",
 	HideFromHelp: true,
 	RunFunc:      cmdFuncBotMember,
 }

--- a/stdcommands/toggledbg/toggledbg.go
+++ b/stdcommands/toggledbg/toggledbg.go
@@ -13,7 +13,7 @@ var Command = &commands.YAGCommand{
 	CmdCategory:          commands.CategoryDebug,
 	HideFromCommandsPage: true,
 	Name:                 "toggledbg",
-	Description:          "Toggles Debug Logging",
+	Description:          "Toggles Debug Logging. Restarting the bot will always reset debug logging. Bot Owner Only",
 	HideFromHelp:         true,
 	RunFunc: util.RequireOwner(func(data *dcmd.Data) (interface{}, error) {
 		if logrus.IsLevelEnabled(logrus.DebugLevel) {

--- a/stdcommands/unbanserver/unbanserver.go
+++ b/stdcommands/unbanserver/unbanserver.go
@@ -13,7 +13,7 @@ var Command = &commands.YAGCommand{
 	CmdCategory:          commands.CategoryDebug,
 	HideFromCommandsPage: true,
 	Name:                 "unbanserver",
-	Description:          ";))",
+	Description:          "Removes the bot ban from the specified server. Bot Owner Only",
 	HideFromHelp:         true,
 	RequiredArgs:         1,
 	Arguments: []*dcmd.ArgDef{


### PR DESCRIPTION
In an effort to clarify maintenance commands for regular users of the public instance, and provide more details for self-hosters, this pull request increases the clarity of descriptions for maintenance commands.

Bot Owner Only and Bot Admin Only have been appended to their corresponding commands' descriptions, and the ;)) descriptions have been updated with full descriptions.

This pull request is mirrored in the yagpdb-docs, the descriptions for each command are synched between both of my pull requests.