### PR TITLE
slashcommands: force NSFW to false if not present

### DIFF
--- a/commands/slashcommands.go
+++ b/commands/slashcommands.go
@@ -162,6 +162,12 @@ func (p *Plugin) yagCommandToSlashCommand(cmd *dcmd.RegisteredCommand) *discordg
 		// not enabled for slash commands
 		return nil
 	}
+
+	nsfw := cast.NSFW
+	if !cast.NSFW {
+		nsfw = false // force NSFW to false if not present
+	}
+
 	t := true
 
 	_, opts := cast.slashCommandOptions()
@@ -170,7 +176,7 @@ func (p *Plugin) yagCommandToSlashCommand(cmd *dcmd.RegisteredCommand) *discordg
 		Description:       common.CutStringShort(cast.Description, 100),
 		DefaultPermission: &t,
 		Options:           opts,
-		NSFW:              cast.NSFW,
+		NSFW:              nsfw,
 	}
 }
 


### PR DESCRIPTION
Currently, if a command has previously been set to NSFW when the bot is run, subsequently removing the NSFW flag does NOT update the slash command's NSFW status in Discord. This results in said command continually being restricted to NSFW channels exclusively by Discord.

I have tested this to the best of my ability, and I have personally concluded that removing `omitempty` from the `CreateApplicationCommandRequest` struct seems not to make a difference. I am open to being proven wrong. 

My tests involved setting a command to NSFW, running the bot and testing the command, then removing the NSFW from the command, running the bot, restarting Discord client, logging in and out of Discord client to be 100% certain, and running the command again. These tests concluded that removing `omitempty` did not affect Discord's limiting of the slash command to NSFW channels.

This commit simply forces the NSFW flag to be set to false during conversion to `CreateApplicationCommandRequest` if the command doesn't have the NSFW flag set. Similar testing has concluded this to be effective.