### PR TITLE
paginatedmessages: switch to MessageSend

### DIFF
--- a/automod/commands.go
+++ b/automod/commands.go
@@ -100,7 +100,7 @@ func (p *Plugin) AddCommands() {
 			{Name: "user", Type: dcmd.UserID},
 		},
 		RequireDiscordPerms: []int64{discordgo.PermissionManageServer, discordgo.PermissionAdministrator, discordgo.PermissionBanMembers},
-		RunFunc: paginatedmessages.PaginatedCommand(0, func(data *dcmd.Data, p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
+		RunFunc: paginatedmessages.PaginatedCommand(0, func(data *dcmd.Data, p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageSend, error) {
 			skip := (page - 1) * 15
 			userID := data.Switch("user").Int64()
 
@@ -135,10 +135,11 @@ func (p *Plugin) AddCommands() {
 			}
 			out.WriteString("``` **RS** = ruleset, **R** = rule, **TR** = trigger")
 
-			return &discordgo.MessageEmbed{
+			embed := &discordgo.MessageEmbed{
 				Title:       "Automod logs",
 				Description: out.String(),
-			}, nil
+			}
+			return &discordgo.MessageSend{Embeds: []*discordgo.MessageEmbed{embed}}, nil
 		}),
 	}
 
@@ -228,7 +229,7 @@ func (p *Plugin) AddCommands() {
 			{Name: "old", Help: "Oldest First"},
 		},
 		RequireDiscordPerms: []int64{discordgo.PermissionManageServer, discordgo.PermissionAdministrator, discordgo.PermissionBanMembers, discordgo.PermissionKickMembers, discordgo.PermissionManageMessages},
-		RunFunc: paginatedmessages.PaginatedCommand(1, func(parsed *dcmd.Data, p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
+		RunFunc: paginatedmessages.PaginatedCommand(1, func(parsed *dcmd.Data, p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageSend, error) {
 			skip := (page - 1) * 15
 			userID := parsed.Args[0].Int64()
 			limit := 15
@@ -261,10 +262,11 @@ func (p *Plugin) AddCommands() {
 				out = "No violations"
 			}
 
-			return &discordgo.MessageEmbed{
+			embed := &discordgo.MessageEmbed{
 				Title:       "Violation Logs",
 				Description: out,
-			}, nil
+			}
+			return &discordgo.MessageSend{Embeds: []*discordgo.MessageEmbed{embed}}, nil
 		}),
 	}
 

--- a/bot/paginatedmessages/pageinatedmessage.go
+++ b/bot/paginatedmessages/pageinatedmessage.go
@@ -63,8 +63,8 @@ type PaginatedMessage struct {
 	// mutable fields
 	CurrentPage  int
 	MaxPage      int
-	LastResponse *discordgo.MessageEmbed
-	Navigate     func(p *PaginatedMessage, newPage int) (*discordgo.MessageEmbed, error)
+	LastResponse *discordgo.MessageSend
+	Navigate     func(p *PaginatedMessage, newPage int) (*discordgo.MessageSend, error)
 	Broken       bool
 
 	stopped        bool
@@ -73,7 +73,7 @@ type PaginatedMessage struct {
 	mu             sync.Mutex
 }
 
-type PagerFunc func(p *PaginatedMessage, page int) (*discordgo.MessageEmbed, error)
+type PagerFunc func(p *PaginatedMessage, page int) (*discordgo.MessageSend, error)
 
 func (p *PaginatedMessage) Stop() {
 	p.mu.Lock()

--- a/bot/paginatedmessages/paginatedcommand.go
+++ b/bot/paginatedmessages/paginatedcommand.go
@@ -9,7 +9,7 @@ type CtxKey int
 
 const CtxKeyNoPagination CtxKey = 1
 
-type PaginatedCommandFunc func(data *dcmd.Data, p *PaginatedMessage, page int) (*discordgo.MessageEmbed, error)
+type PaginatedCommandFunc func(data *dcmd.Data, p *PaginatedMessage, page int) (*discordgo.MessageSend, error)
 
 func PaginatedCommand(pageArgIndex int, cb PaginatedCommandFunc) dcmd.RunFunc {
 	return func(data *dcmd.Data) (interface{}, error) {
@@ -26,7 +26,7 @@ func PaginatedCommand(pageArgIndex int, cb PaginatedCommandFunc) dcmd.RunFunc {
 			return cb(data, nil, page)
 		}
 
-		_, err := CreatePaginatedMessage(data.GuildData.GS.ID, data.GuildData.CS.ID, page, 0, func(p *PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
+		_, err := CreatePaginatedMessage(data.GuildData.GS.ID, data.GuildData.CS.ID, page, 0, func(p *PaginatedMessage, page int) (*discordgo.MessageSend, error) {
 			return cb(data, p, page)
 		})
 

--- a/bot/paginatedmessages/paginatedinteractions.go
+++ b/bot/paginatedmessages/paginatedinteractions.go
@@ -256,8 +256,6 @@ OUTER:
 				Text: footer,
 			}
 			lastMessage.Embeds[len(lastMessage.Embeds)-1].Timestamp = time.Now().Format(time.RFC3339)
-		} else {
-			lastMessage.Content = fmt.Sprintf("%s\n`%s`", lastMessage.Content, footer)
 		}
 
 		_, err := common.BotSession.ChannelMessageEditComplex(&discordgo.MessageEdit{

--- a/commands/help.go
+++ b/commands/help.go
@@ -120,9 +120,9 @@ For more in depth help and information you should visit https://docs.yagpdb.xyz/
 
 	helpEmbeds = append([]*discordgo.MessageEmbed{firstPage}, helpEmbeds...)
 
-	_, err = paginatedmessages.CreatePaginatedMessage(0, channel.ID, 1, len(helpEmbeds), func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
+	_, err = paginatedmessages.CreatePaginatedMessage(0, channel.ID, 1, len(helpEmbeds), func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageSend, error) {
 		embed := helpEmbeds[page-1]
-		return embed, nil
+		return &discordgo.MessageSend{Embeds: []*discordgo.MessageEmbed{embed}}, nil
 	})
 	if err != nil {
 		return "Something went wrong, make sure you don't have the bot blocked or your DMs closed!", err

--- a/logs/plugin_bot.go
+++ b/logs/plugin_bot.go
@@ -280,7 +280,7 @@ var cmdUsernames = &commands.YAGCommand{
 			gID = parsed.GuildData.GS.ID
 		}
 
-		_, err := paginatedmessages.CreatePaginatedMessage(gID, parsed.ChannelID, 1, 0, func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
+		_, err := paginatedmessages.CreatePaginatedMessage(gID, parsed.ChannelID, 1, 0, func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageSend, error) {
 			target := parsed.Author
 			if parsed.Args[0].Value != nil {
 				target = parsed.Args[0].Value.(*discordgo.User)
@@ -312,7 +312,7 @@ var cmdUsernames = &commands.YAGCommand{
 				Description: out,
 			}
 
-			return embed, nil
+			return &discordgo.MessageSend{Embeds: []*discordgo.MessageEmbed{embed}}, nil
 		})
 
 		return nil, err
@@ -343,7 +343,7 @@ var cmdNicknames = &commands.YAGCommand{
 			return "Nickname logging is disabled on this server", nil
 		}
 
-		_, err = paginatedmessages.CreatePaginatedMessage(parsed.GuildData.GS.ID, parsed.ChannelID, 1, 0, func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
+		_, err = paginatedmessages.CreatePaginatedMessage(parsed.GuildData.GS.ID, parsed.ChannelID, 1, 0, func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageSend, error) {
 
 			offset := (page - 1) * 15
 
@@ -372,7 +372,7 @@ var cmdNicknames = &commands.YAGCommand{
 				Description: out,
 			}
 
-			return embed, nil
+			return &discordgo.MessageSend{Embeds: []*discordgo.MessageEmbed{embed}}, nil
 		})
 
 		return nil, err

--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -980,7 +980,7 @@ var ModerationCommands = []*commands.YAGCommand{
 		RequiredDiscordPermsHelp: "ManageMessages or ManageServer",
 		SlashCommandEnabled:      true,
 		DefaultEnabled:           false,
-		RunFunc: paginatedmessages.PaginatedCommand(0, func(parsed *dcmd.Data, p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
+		RunFunc: paginatedmessages.PaginatedCommand(0, func(parsed *dcmd.Data, p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageSend, error) {
 
 			showUserIDs := false
 			config, _, err := MBaseCmd(parsed, 0)
@@ -1030,7 +1030,7 @@ var ModerationCommands = []*commands.YAGCommand{
 
 			embed.Description = out
 
-			return embed, nil
+			return &discordgo.MessageSend{Embeds: []*discordgo.MessageEmbed{embed}}, nil
 
 		}),
 	},
@@ -1297,9 +1297,9 @@ func FindRole(gs *dstate.GuildSet, roleS string) *discordgo.Role {
 	return nil
 }
 
-func PaginateWarnings(parsed *dcmd.Data) func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
+func PaginateWarnings(parsed *dcmd.Data) func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageSend, error) {
 
-	return func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
+	return func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageSend, error) {
 
 		var err error
 		skip := (page - 1) * 6
@@ -1356,10 +1356,11 @@ func PaginateWarnings(parsed *dcmd.Data) func(p *paginatedmessages.PaginatedMess
 			currentField.Value = "No Warnings"
 		}
 
-		return &discordgo.MessageEmbed{
+		embed := &discordgo.MessageEmbed{
 			Title:       fmt.Sprintf("Warnings - User : %d", userID),
 			Description: desc,
 			Fields:      fields,
-		}, nil
+		}
+		return &discordgo.MessageSend{Embeds: []*discordgo.MessageEmbed{embed}}, nil
 	}
 }

--- a/reputation/plugin_bot.go
+++ b/reputation/plugin_bot.go
@@ -409,7 +409,7 @@ var cmds = []*commands.YAGCommand{
 				return topRepPager(parsed.GuildData.GS.ID, nil, page)
 			}
 
-			_, err := paginatedmessages.CreatePaginatedMessage(parsed.GuildData.GS.ID, parsed.ChannelID, page, 0, func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
+			_, err := paginatedmessages.CreatePaginatedMessage(parsed.GuildData.GS.ID, parsed.ChannelID, page, 0, func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageSend, error) {
 				return topRepPager(parsed.GuildData.GS.ID, p, page)
 			})
 
@@ -418,7 +418,7 @@ var cmds = []*commands.YAGCommand{
 	},
 }
 
-func topRepPager(guildID int64, p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
+func topRepPager(guildID int64, p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageSend, error) {
 	offset := (page - 1) * 15
 	entries, err := TopUsers(guildID, offset, 15)
 	if err != nil {
@@ -451,7 +451,7 @@ func topRepPager(guildID int64, p *paginatedmessages.PaginatedMessage, page int)
 
 	embed.Description = out
 
-	return embed, nil
+	return &discordgo.MessageSend{Embeds: []*discordgo.MessageEmbed{embed}}, nil
 
 }
 

--- a/stdcommands/define/define.go
+++ b/stdcommands/define/define.go
@@ -46,11 +46,11 @@ var Command = &commands.YAGCommand{
 
 		if paginatedView {
 			_, err := paginatedmessages.CreatePaginatedMessage(
-				data.GuildData.GS.ID, data.ChannelID, 1, len(qResp.Results), func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
+				data.GuildData.GS.ID, data.ChannelID, 1, len(qResp.Results), func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageSend, error) {
 					i := page - 1
 
 					paginatedEmbed := embedCreator(qResp.Results, i)
-					return paginatedEmbed, nil
+					return &discordgo.MessageSend{Embeds: []*discordgo.MessageEmbed{paginatedEmbed}}, nil
 				})
 			if err != nil {
 				return "Something went wrong", nil

--- a/stdcommands/howlongtobeat/howlongtobeat.go
+++ b/stdcommands/howlongtobeat/howlongtobeat.go
@@ -92,13 +92,13 @@ var Command = &commands.YAGCommand{
 
 		if paginatedView {
 			_, err := paginatedmessages.CreatePaginatedMessage(
-				data.GuildData.GS.ID, data.ChannelID, 1, len(games), func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
+				data.GuildData.GS.ID, data.ChannelID, 1, len(games), func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageSend, error) {
 					i := page - 1
 					sort.SliceStable(games, func(i, j int) bool {
 						return games[i].JaroWinklerSimilarity > games[j].JaroWinklerSimilarity
 					})
 					paginatedEmbed := embedCreator(games, i, paginatedView)
-					return paginatedEmbed, nil
+					return &discordgo.MessageSend{Embeds: []*discordgo.MessageEmbed{paginatedEmbed}}, nil
 				})
 			if err != nil {
 				return "Something went wrong", nil

--- a/stdcommands/inspire/inspire.go
+++ b/stdcommands/inspire/inspire.go
@@ -42,7 +42,7 @@ var Command = &commands.YAGCommand{
 			}
 			inspireArray = arrayMaker(inspireArray, result)
 			_, err = paginatedmessages.CreatePaginatedMessage(
-				data.GuildData.GS.ID, data.ChannelID, 1, 15, func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
+				data.GuildData.GS.ID, data.ChannelID, 1, 15, func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageSend, error) {
 					if page-1 == len(inspireArray) {
 						result, err := inspireFromAPI(true)
 						if err != nil {
@@ -50,7 +50,7 @@ var Command = &commands.YAGCommand{
 						}
 						inspireArray = arrayMaker(inspireArray, result)
 					}
-					return createInspireEmbed(inspireArray[page-1], true), nil
+					return &discordgo.MessageSend{Embeds: []*discordgo.MessageEmbed{createInspireEmbed(inspireArray[page-1], true)}}, nil
 				})
 			if err != nil {
 				return nil, err

--- a/stdcommands/owldictionary/owldictionary.go
+++ b/stdcommands/owldictionary/owldictionary.go
@@ -73,12 +73,12 @@ var Command = &commands.YAGCommand{
 			return createOwlbotDefinitionEmbed(&res, res.Definitions[0]), nil
 		}
 
-		_, err = paginatedmessages.CreatePaginatedMessage(data.GuildData.GS.ID, data.ChannelID, 1, len(res.Definitions), func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
+		_, err = paginatedmessages.CreatePaginatedMessage(data.GuildData.GS.ID, data.ChannelID, 1, len(res.Definitions), func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageSend, error) {
 			if page > len(res.Definitions) {
 				return nil, paginatedmessages.ErrNoResults
 			}
 
-			return createOwlbotDefinitionEmbed(&res, res.Definitions[page-1]), nil
+			return &discordgo.MessageSend{Embeds: []*discordgo.MessageEmbed{createOwlbotDefinitionEmbed(&res, res.Definitions[page-1])}}, nil
 		})
 
 		return nil, err

--- a/timezonecompanion/plugin_bot.go
+++ b/timezonecompanion/plugin_bot.go
@@ -244,8 +244,8 @@ func StrZone(zone string) string {
 	return fmt.Sprintf("`%s`: %s", zone, name)
 }
 
-func paginatedTimezones(timezones []string) func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
-	return func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
+func paginatedTimezones(timezones []string) func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageSend, error) {
+	return func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageSend, error) {
 		numSkip := (page - 1) * 10
 
 		out := ""
@@ -260,9 +260,10 @@ func paginatedTimezones(timezones []string) func(p *paginatedmessages.PaginatedM
 			}
 		}
 
-		return &discordgo.MessageEmbed{
+		embed := &discordgo.MessageEmbed{
 			Description: "Please redo the command with one of the following:\n" + out,
-		}, nil
+		}
+		return &discordgo.MessageSend{Embeds: []*discordgo.MessageEmbed{embed}}, nil
 	}
 }
 


### PR DESCRIPTION
Previous paginated messages were limited to message embeds only. This pr switches them over to MessageSend struct, allowing full customization.

If the paginated message contains embeds, the page number and timecode are added to the final embed. If the message contains no embeds, the page number is appended to the message content.

The paginate test command is added to demonstrate this functionality, with an optional arg to control page count, and a switch for demonstrating messages without embeds.

Previous paginated commands are also updated to use MessageSend instead.

![Screenshot 2022-11-28 at 01 18 59](https://user-images.githubusercontent.com/110698921/204240593-4df125b5-5fcc-4cb4-a624-faf6acd39777.png)