### PR TITLE
feat(moderation): Update moderation widget with Timeout status

### DIFF
--- a/moderation/plugin_web.go
+++ b/moderation/plugin_web.go
@@ -131,7 +131,7 @@ func (p *Plugin) LoadServerHomeWidget(w http.ResponseWriter, r *http.Request) (w
 </ul>`
 
 	if config.ReportEnabled || config.CleanEnabled || config.GiveRoleCmdEnabled || config.ActionChannel != "" ||
-		config.MuteEnabled || config.KickEnabled || config.BanEnabled || config.WarnCommandsEnabled {
+		config.MuteEnabled || config.KickEnabled || config.BanEnabled || config.WarnCommandsEnabled || config.TimeoutEnabled {
 		templateData["WidgetEnabled"] = true
 	} else {
 		templateData["WidgetDisabled"] = true

--- a/moderation/plugin_web.go
+++ b/moderation/plugin_web.go
@@ -127,6 +127,7 @@ func (p *Plugin) LoadServerHomeWidget(w http.ResponseWriter, r *http.Request) (w
 	<li>Kick command: %s</li>
 	<li>Ban command: %s</li>
 	<li>Mute/Unmute commands: %s</li>
+	<li>Timeout/Untimeout commands: %s</li>
 	<li>Warning commands: %s</li>
 </ul>`
 
@@ -140,7 +141,8 @@ func (p *Plugin) LoadServerHomeWidget(w http.ResponseWriter, r *http.Request) (w
 	templateData["WidgetBody"] = template.HTML(fmt.Sprintf(format, web.EnabledDisabledSpanStatus(config.ReportEnabled),
 		web.EnabledDisabledSpanStatus(config.CleanEnabled), web.EnabledDisabledSpanStatus(config.GiveRoleCmdEnabled),
 		web.EnabledDisabledSpanStatus(config.KickEnabled), web.EnabledDisabledSpanStatus(config.BanEnabled),
-		web.EnabledDisabledSpanStatus(config.MuteEnabled), web.EnabledDisabledSpanStatus(config.WarnCommandsEnabled)))
+		web.EnabledDisabledSpanStatus(config.MuteEnabled), web.EnabledDisabledSpanStatus(config.TimeoutEnabled),
+		web.EnabledDisabledSpanStatus(config.WarnCommandsEnabled)))
 
 	return templateData, nil
 }


### PR DESCRIPTION
I noticed the status of the **Timeout** section, wasn't listed in the **Moderation** widget on the home page in the control panel, so this should add the status to that list, as well as including it in the overall display for whether the widget is enabled or not.
