### PR TITLE
feat(moderation): Update missing mute role error

### DIFF
--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -305,7 +305,7 @@ var ModerationCommands = []*commands.YAGCommand{
 			}
 
 			if config.MuteRole == "" {
-				return "No mute role set up, assign a mute role in the control panel", nil
+				return fmt.Sprintf("No mute role selected. Select one at <%s/manage/%d/moderation>", web.BaseURL(), parsed.GuildData.GS.ID), nil
 			}
 
 			reason := parsed.Args[2].Str()


### PR DESCRIPTION
Updates the error message when attempting to run `/mute`/`-mute` without having a mute role selected, to direct users to the relevant configuration page.