### PR TITLE
refactor(moderation): Remove if from default DM

### DIFF
--- a/moderation/punishments.go
+++ b/moderation/punishments.go
@@ -32,11 +32,7 @@ const (
 const MaxTimeOutDuration = 40320 * time.Minute
 const MinTimeOutDuration = time.Minute
 const DefaultTimeoutDuration = 10 * time.Minute
-
-const (
-	DefaultDMMessage = `You have been {{.ModAction}}
-{{if .Reason}}**Reason:** {{.Reason}}{{end}}`
-)
+const DefaultDMMessage = "You have been {{.ModAction}}\n**Reason:** {{.Reason}}"
 
 func getMemberWithFallback(gs *dstate.GuildSet, user *discordgo.User) (ms *dstate.MemberState, notFound bool) {
 	ms, err := bot.GetMember(gs.ID, user.ID)


### PR DESCRIPTION
The Template Script previosuly featured the check, `if .Reason`. But, `.Reason` returns the string, `"(No reason specified)"` if a reason wasn't provided when the moderation action was triggered, making this check redundant.

Additionally, the declaration of the constant used a multi-variable declaration style, for no dicernable reason, so this has been changed to a single variable declaration, and with the simplification of the Template Script, this commit also switches to using a single-line string, using the newline character.