### PR TITLE
refactor: Move config page URL formatting to `web.ManageServerURL`

### DIFF
--- a/cah/commands.go
+++ b/cah/commands.go
@@ -107,7 +107,7 @@ func (p *Plugin) AddCommands() {
 
 	container, _ := commands.CommandSystem.Root.Sub("cah")
 	container.NotFound = commands.CommonContainerNotFoundHandler(container, "")
-	container.Description = "Playt cards against humanity!"
+	container.Description = "Play cards against humanity!"
 
 	container.AddCommand(cmdCreate, cmdCreate.GetTrigger())
 	container.AddCommand(cmdEnd, cmdEnd.GetTrigger())

--- a/commands/yagcommmand.go
+++ b/commands/yagcommmand.go
@@ -420,8 +420,16 @@ func (yc *YAGCommand) checkCanExecuteCommand(data *dcmd.Data) (canExecute bool, 
 				return false, nil, nil, nil
 			}
 		}
+		channel_id := data.GuildData.CS.ID
+		parent_id := data.GuildData.CS.ParentID
+		// in case the channel is a thread, get the parent channel from parent id and check for the overrides
+		if data.GuildData.CS.Type.IsThread() {
+			channel := data.GuildData.GS.GetChannel(parent_id)
+			channel_id = channel.ID
+			parent_id = channel.ParentID
+		}
 
-		settings, err = yc.GetSettings(data.ContainerChain, data.GuildData.CS.ID, data.GuildData.CS.ParentID, guild.ID)
+		settings, err = yc.GetSettings(data.ContainerChain, channel_id, parent_id, guild.ID)
 		if err != nil {
 			resp = &CanExecuteError{
 				Type:    ReasonError,

--- a/web/web.go
+++ b/web/web.go
@@ -3,6 +3,7 @@ package web
 import (
 	"crypto/tls"
 	"flag"
+	"fmt"
 	"html/template"
 	"io/fs"
 	"net/http"
@@ -16,6 +17,7 @@ import (
 	"github.com/botlabs-gg/yagpdb/v2/common/patreon"
 	yagtmpl "github.com/botlabs-gg/yagpdb/v2/common/templates"
 	"github.com/botlabs-gg/yagpdb/v2/frontend"
+	"github.com/botlabs-gg/yagpdb/v2/lib/dcmd"
 	"github.com/botlabs-gg/yagpdb/v2/lib/discordgo"
 	"github.com/botlabs-gg/yagpdb/v2/web/discordblog"
 	"github.com/natefinch/lumberjack"
@@ -130,6 +132,11 @@ func BaseURL() string {
 	}
 
 	return "http://" + common.ConfHost.GetString()
+}
+
+
+func ManageServerURL(guild *dcmd.GuildContextData) string {
+	return fmt.Sprintf("%s/manage/%d", BaseURL(), guild.GS.ID)
 }
 
 func Run() {

--- a/youtube/youtube.go
+++ b/youtube/youtube.go
@@ -25,8 +25,8 @@ const (
 
 var (
 	confWebsubVerifytoken = config.RegisterOption("yagpdb.youtube.verify_token", "Youtube websub push verify token, set it to a random string and never change it", "asdkpoasdkpaoksdpako")
-
-	logger = common.GetPluginLogger(&Plugin{})
+	confResubBatchSize    = config.RegisterOption("yagpdb.youtube.resub_batch_size", "Number of Websubs to resubscribe to concurrently", 1)
+	logger                = common.GetPluginLogger(&Plugin{})
 )
 
 func KeyLastVidTime(channel string) string { return "youtube_last_video_time:" + channel }
@@ -114,6 +114,7 @@ func (p *Plugin) WebSubSubscribe(ytChannelID string) error {
 
 	resp, err := http.PostForm(GoogleWebsubHub, values)
 	if err != nil {
+		logger.WithError(err).Errorf("Failed to subscribe to youtube channel with id %s", ytChannelID)
 		return err
 	}
 


### PR DESCRIPTION
This PR intends to address a pattern of repeated behaviour, following QoL updates made to the errors of some commands, linking to their configuration pages in the case of configuration errors.

This includes the addition of `web.ManageServerURL`, which encapsulates the behaviour for appending `/manage/SERVER_ID` to the result of `web.BaseURL`, as well as updating instance where this pattern was used previously, to use this new function.

These changes should also be applied to the changes of PR #1407.