### PR TITLE
refactor(moderation): No mute role error impl

### DIFF
--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -305,7 +305,7 @@ var ModerationCommands = []*commands.YAGCommand{
 			}
 
 			if config.MuteRole == "" {
-				return fmt.Sprintf("No mute role selected. Select one at <%s/manage/%d/moderation>", web.BaseURL(), parsed.GuildData.GS.ID), nil
+				return fmt.Sprintf("No mute role selected. Select one at <%s/moderation>", web.ManageServerURL(parsed.GuildData)), nil
 			}
 
 			reason := parsed.Args[2].Str()


### PR DESCRIPTION
Updating the implementation when a mute role isn't selected, to use `web.ManageServerURL`, inline with other similar errors.