### PR TITLE
forex: clear invalid currency code (#1383)

### DIFF
--- a/stdcommands/forex/forex.go
+++ b/stdcommands/forex/forex.go
@@ -98,6 +98,7 @@ func requestAPI(query string) (*ExchangeAPIResult, error) {
 
 func errEmbed(check *ExchangeAPIResult, page int) (*discordgo.MessageEmbed, error) {
 	desc := "CODE | Description\n------------------"
+	var exchangeSymbols string = "https://api.exchangerate.host/symbols"
 	codes := make([]string, 0, len(check.Symbols))
 	for k := range check.Symbols {
 		codes = append(codes, k)
@@ -112,10 +113,10 @@ func errEmbed(check *ExchangeAPIResult, page int) (*discordgo.MessageEmbed, erro
 	}
 	embed := &discordgo.MessageEmbed{
 		Title:       "Invalid currency code",
-		URL:         "https://api.exchangerate.host/symbols",
+		URL:         exchangeSymbols,
 		Color:       0xAE27FF,
 		Timestamp:   time.Now().UTC().Format(time.RFC3339),
-		Description: fmt.Sprintf("Check out available codes on: https://api.exchangerate.host/symbols ```\n%s```", desc),
+		Description: fmt.Sprintf("Check out available codes on: %s ```\n%s```", exchangeSymbols, desc),
 	}
 	return embed, nil
 }

--- a/stdcommands/forex/forex.go
+++ b/stdcommands/forex/forex.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
+
 	"net/http"
 	"sort"
 	"strings"
 	"time"
+	"math"
 
 	"github.com/botlabs-gg/yagpdb/v2/bot/paginatedmessages"
 	"github.com/botlabs-gg/yagpdb/v2/commands"
@@ -41,9 +42,11 @@ var Command = &commands.YAGCommand{
 		}
 		from := check.Symbols[strings.ToUpper(data.Args[1].Str())]
 		to := check.Symbols[strings.ToUpper(data.Args[2].Str())]
+		// Checks the max amount of pages by the number of symbols on each page (15)
+		maxPages := int(math.Ceil(float64(len(check.Symbols))/float64(15)))
 		if (to == nil) || (from == nil) {
 			_, err = paginatedmessages.CreatePaginatedMessage(
-				data.GuildData.GS.ID, data.ChannelID, 1, int(math.Ceil(float64(len(check.Symbols))/float64(15))), func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
+				data.GuildData.GS.ID, data.ChannelID, 1, maxPages, func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
 					return errEmbed(check, page)
 				})
 			if err != nil {

--- a/stdcommands/forex/forex.go
+++ b/stdcommands/forex/forex.go
@@ -4,10 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
+	"github.com/botlabs-gg/yagpdb/v2/bot/paginatedmessages"
 	"github.com/botlabs-gg/yagpdb/v2/commands"
 	"github.com/botlabs-gg/yagpdb/v2/lib/dcmd"
 	"github.com/botlabs-gg/yagpdb/v2/lib/discordgo"
@@ -39,7 +42,14 @@ var Command = &commands.YAGCommand{
 		from := check.Symbols[strings.ToUpper(data.Args[1].Str())]
 		to := check.Symbols[strings.ToUpper(data.Args[2].Str())]
 		if (to == nil) || (from == nil) {
-			return "Invalid currency code.\nCheck out available codes on: <https://api.exchangerate.host/symbols>", nil
+			_, err = paginatedmessages.CreatePaginatedMessage(
+				data.GuildData.GS.ID, data.ChannelID, 1, int(math.Ceil(float64(len(check.Symbols))/float64(15))), func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
+					return errEmbed(check, page)
+				})
+			if err != nil {
+				return nil, err
+			}
+			return nil, nil
 		}
 		output, err := requestAPI(fmt.Sprintf("https://api.exchangerate.host/convert?from=%s&to=%s&amount=1", from.Code, to.Code))
 		if err != nil {
@@ -84,6 +94,32 @@ func requestAPI(query string) (*ExchangeAPIResult, error) {
 		return nil, err
 	}
 	return result, nil
+}
+
+func errEmbed(check *ExchangeAPIResult, page int) (*discordgo.MessageEmbed, error) {
+	desc := "CODE | Description\n ------------------"
+	codes := make([]string, 0, len(check.Symbols))
+	for k := range check.Symbols {
+		codes = append(codes, k)
+	}
+	sort.Strings(codes)
+	count := 0
+	start := (page * 15) - 15
+	end := page * 15
+	for _, c := range codes {
+		if count < end && count >= start {
+			desc = fmt.Sprintf("%s\n %s | %s", desc, c, check.Symbols[c].Description)
+		}
+		count++
+	}
+	embed := &discordgo.MessageEmbed{
+		Title:       "Check out available codes",
+		URL:         "https://api.exchangerate.host/symbols",
+		Color:       0xAE27FF,
+		Timestamp:   time.Now().UTC().Format(time.RFC3339),
+		Description: fmt.Sprintf("```\n%s```", desc),
+	}
+	return embed, nil
 }
 
 type CurrencySymbolInfo struct {

--- a/stdcommands/forex/forex.go
+++ b/stdcommands/forex/forex.go
@@ -107,7 +107,7 @@ func errEmbed(check *ExchangeAPIResult, page int) (*discordgo.MessageEmbed, erro
 	end := page * 15
 	for i, c := range codes {
 		if i < end && i >= start {
-			desc = fmt.Sprintf("%s\n%s | %s", desc, c, check.Symbols[c].Description)
+			desc = fmt.Sprintf("%s\n%s  | %s", desc, c, check.Symbols[c].Description)
 		}
 	}
 	embed := &discordgo.MessageEmbed{

--- a/stdcommands/forex/forex.go
+++ b/stdcommands/forex/forex.go
@@ -103,14 +103,12 @@ func errEmbed(check *ExchangeAPIResult, page int) (*discordgo.MessageEmbed, erro
 		codes = append(codes, k)
 	}
 	sort.Strings(codes)
-	count := 0
 	start := (page * 15) - 15
 	end := page * 15
-	for _, c := range codes {
-		if count < end && count >= start {
+	for i, c := range codes {
+		if i < end && i >= start {
 			desc = fmt.Sprintf("%s\n %s | %s", desc, c, check.Symbols[c].Description)
 		}
-		count++
 	}
 	embed := &discordgo.MessageEmbed{
 		Title:       "Check out available codes",

--- a/stdcommands/forex/forex.go
+++ b/stdcommands/forex/forex.go
@@ -97,7 +97,7 @@ func requestAPI(query string) (*ExchangeAPIResult, error) {
 }
 
 func errEmbed(check *ExchangeAPIResult, page int) (*discordgo.MessageEmbed, error) {
-	desc := "CODE | Description\n ------------------"
+	desc := "CODE | Description\n------------------"
 	codes := make([]string, 0, len(check.Symbols))
 	for k := range check.Symbols {
 		codes = append(codes, k)
@@ -107,7 +107,7 @@ func errEmbed(check *ExchangeAPIResult, page int) (*discordgo.MessageEmbed, erro
 	end := page * 15
 	for i, c := range codes {
 		if i < end && i >= start {
-			desc = fmt.Sprintf("%s\n %s | %s", desc, c, check.Symbols[c].Description)
+			desc = fmt.Sprintf("%s\n%s | %s", desc, c, check.Symbols[c].Description)
 		}
 	}
 	embed := &discordgo.MessageEmbed{

--- a/stdcommands/forex/forex.go
+++ b/stdcommands/forex/forex.go
@@ -111,11 +111,11 @@ func errEmbed(check *ExchangeAPIResult, page int) (*discordgo.MessageEmbed, erro
 		}
 	}
 	embed := &discordgo.MessageEmbed{
-		Title:       "Check out available codes",
+		Title:       "Invalid currency code",
 		URL:         "https://api.exchangerate.host/symbols",
 		Color:       0xAE27FF,
 		Timestamp:   time.Now().UTC().Format(time.RFC3339),
-		Description: fmt.Sprintf("```\n%s```", desc),
+		Description: fmt.Sprintf("Check out available codes on: https://api.exchangerate.host/symbols ```\n%s```", desc),
 	}
 	return embed, nil
 }


### PR DESCRIPTION
Had to re-open this yet again because I PR'ed to the wrong branch after GitHub automatically closed the original Pull after I renamed my branches. So sorry for any hassle.

> This commit implements the requested clearer invalid currency code in #1383 by @jo3-l 
> Commit includes @Shadow21AR's updated embed which presents the `forex` response in a much cleaner look
> Couldn't push change to Shadow's branch so I had to create a new PR

> Forex response with clear notice that the currency code is invalid
![image](https://user-images.githubusercontent.com/72880161/214718868-3517761e-c880-4f4e-9aa2-94c189dfe728.png)