### PR TITLE
.Channel.OwnerID object (suggestion #2034)

### DIFF
--- a/common/templates/structs.go
+++ b/common/templates/structs.go
@@ -24,6 +24,7 @@ type CtxChannel struct {
 	Bitrate              int                              `json:"bitrate"`
 	PermissionOverwrites []*discordgo.PermissionOverwrite `json:"permission_overwrites"`
 	ParentID             int64                            `json:"parent_id"`
+	OwnerID              int64                            `json:"owner_id"`
 }
 
 func (c *CtxChannel) Mention() (string, error) {
@@ -53,6 +54,7 @@ func CtxChannelFromCS(cs *dstate.ChannelState) *CtxChannel {
 		Bitrate:              cs.Bitrate,
 		PermissionOverwrites: cop,
 		ParentID:             cs.ParentID,
+		OwnerID:              cs.OwnerID,
 	}
 
 	return ctxChannel

--- a/lib/discordgo/structs.go
+++ b/lib/discordgo/structs.go
@@ -228,8 +228,14 @@ type Channel struct {
 	// The ID of the parent channel, if the channel is under a category
 	ParentID int64 `json:"parent_id,string"`
 
+	// Period of time in which the user is unable to send another message or create a new thread for.
+	// Excludes "manage_messages" and "manage_channel" permissions
 	RateLimitPerUser int `json:"rate_limit_per_user"`
 
+	// The user ID of the owner of the guild.
+	OwnerID int64 `json:"owner_id,string"`
+
+	// Thread specific fields
 	ThreadMetadata *ThreadMetadata `json:"thread_metadata"`
 }
 

--- a/lib/discordgo/structs.go
+++ b/lib/discordgo/structs.go
@@ -232,7 +232,7 @@ type Channel struct {
 	// Excludes "manage_messages" and "manage_channel" permissions
 	RateLimitPerUser int `json:"rate_limit_per_user"`
 
-	// The user ID of the owner of the guild.
+	// The user ID of the owner of the thread. Nil on normal channels
 	OwnerID int64 `json:"owner_id,string"`
 
 	// Thread specific fields

--- a/lib/dstate/helpers.go
+++ b/lib/dstate/helpers.go
@@ -161,6 +161,7 @@ func ChannelStateFromDgo(c *discordgo.Channel) ChannelState {
 		NSFW:                 c.NSFW,
 		Position:             c.Position,
 		Bitrate:              c.Bitrate,
+		OwnerID:              c.OwnerID,
 	}
 }
 


### PR DESCRIPTION
This PR implements the `.Channel.OwnerID` object.
This returns `0` if the `.Channel` type is `GUILD_TEXT`
And the thread owners snowflake if the `.Channel` type is `PUBLIC_THREAD` or `PRIVATE_THREAD`