### PR TITLE
frontend: add server name to tab title

### DIFF
--- a/frontend/templates/cp_main.html
+++ b/frontend/templates/cp_main.html
@@ -29,7 +29,7 @@
     <meta property="og:title" content="YAGPDB" />
     <meta property="og:description" content="Yet Another General Purpose Discord Bot" />
 
-    <title>YAGPDB - Control panel</title>
+    <title>YAGPDB - Control Panel{{if .ActiveGuild}} | {{.ActiveGuild.Name}}{{end}}</title>
     <meta name="keywords" content="YAGPDB Discord bot control panel" />
     <meta name="description" content="YAGPDB - Yet Another General Purpose Discord Bot">
     <meta name="author" content="jonas747">


### PR DESCRIPTION
Add the server name to the tab title if a server's control panel is
open.

Though this is a rather small change, it is useful for those who have
multiple tabs open with different servers -- that way, one can easily
differentiate between open tabs.

I'm not sure how many actually do this, but it was bugging me enough to
whip up a patch, so that must mean something. :)

Signed-off-by: Luca Zeuch <l-zeuch@email.de>