### PR TITLE
frontend: add note about dismissing PNotify

### DIFF
--- a/frontend/static/js/spongebob.js
+++ b/frontend/static/js/spongebob.js
@@ -150,6 +150,7 @@ function showAlerts(alertsJson) {
 		if (alert.Style === "success") {
 			notice = new PNotify({
 				title: alert.Message,
+				text: "(Click to dismiss)",
 				type: 'success',
 				addclass: 'stack-bar-top click-2-close',
 				stack: stack_bar_top,
@@ -163,7 +164,7 @@ function showAlerts(alertsJson) {
 		} else if (alert.Style === "danger") {
 			notice = new PNotify({
 				title: alert.Message,
-				text: "Read the docs and contact support if you don't know what went wrong.",
+				text: "Read the docs and contact support if you don't know what went wrong.\n(Click to dismiss)",
 				type: 'error',
 				addclass: 'stack-bar-top click-2-close',
 				stack: stack_bar_top,


### PR DESCRIPTION
Add a friendly note about dismissing PNotify alerts.
It isn't much, but a nice info to have nonetheless, QoL wise.
(I used to wait a while too until I figured you can click it to dismiss it)

Signed-off-by: Luca Zeuch <l-zeuch@email.de>