### PR TITLE
Forex stdcommands: fixed bug from my previous PR, changed the way numbers are shown

### DIFF
--- a/stdcommands/forex/forex.go
+++ b/stdcommands/forex/forex.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"io"
 
+	"math"
 	"net/http"
 	"sort"
 	"strings"
 	"time"
-	"math"
 
 	"github.com/botlabs-gg/yagpdb/v2/bot/paginatedmessages"
 	"github.com/botlabs-gg/yagpdb/v2/commands"
@@ -43,7 +43,7 @@ var Command = &commands.YAGCommand{
 		from := check.Symbols[strings.ToUpper(data.Args[1].Str())]
 		to := check.Symbols[strings.ToUpper(data.Args[2].Str())]
 		// Checks the max amount of pages by the number of symbols on each page (15)
-		maxPages := int(math.Ceil(float64(len(check.Symbols))/float64(15)))
+		maxPages := int(math.Ceil(float64(len(check.Symbols)) / float64(15)))
 		if (to == nil) || (from == nil) {
 			_, err = paginatedmessages.CreatePaginatedMessage(
 				data.GuildData.GS.ID, data.ChannelID, 1, maxPages, func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
@@ -54,17 +54,14 @@ var Command = &commands.YAGCommand{
 			}
 			return nil, nil
 		}
-		output, err := requestAPI(fmt.Sprintf("https://api.exchangerate.host/convert?from=%s&to=%s&amount=1", from.Code, to.Code))
+		output, err := requestAPI(fmt.Sprintf("https://api.exchangerate.host/convert?from=%s&to=%s&amount=%.3f", from.Code, to.Code, amount))
 		if err != nil {
 			return nil, err
-		}
-		if output.Info.Rate == 0 {
-			return "Something went wrong :c", err //VEF is bugged but i dont see any way to fix it yet. other than API fixing it themself :/
 		}
 		p := message.NewPrinter(language.English)
 		embed := &discordgo.MessageEmbed{
 			Title:       "💱Currency Exchange Rate",
-			Description: fmt.Sprintf("\n%s **%s** (%s) is %s **%s** (%s).", p.Sprintf("%g", amount), from.Description, output.Query.From, p.Sprintf("%0.2f", amount*output.Result), to.Description, output.Query.To),
+			Description: p.Sprintf("\n%.2f **%s** (%s) is %.3f **%s** (%s).", amount, from.Description, output.Query.From, output.Result, to.Description, output.Query.To),
 			Color:       0xAE27FF,
 			Footer:      &discordgo.MessageEmbedFooter{Text: fmt.Sprintf("Based on currency rate 1 : %f", output.Info.Rate)},
 			Timestamp:   time.Now().UTC().Format(time.RFC3339),


### PR DESCRIPTION
1. there was a smol bug in query from my last PR (sorry), where converting 2 currencies with huge difference (inr & btc) was broken.
![image](https://user-images.githubusercontent.com/66721908/219857391-d64eeb60-f826-4049-abd0-6edbc7a442e8.png)

2. Fixed output to show numbers like 1,000,000 instead of 1e6 (idk what to call it, scientific notation?)
![image](https://user-images.githubusercontent.com/66721908/219857482-9aaa3e3a-11de-431b-b5c1-d01570d12599.png)

hopefully we stop playing ping pong with this command now xD