### PR TITLE
lib/dice: prevent panic from zero-sided die

### DIFF
--- a/lib/dice/std.go
+++ b/lib/dice/std.go
@@ -1,6 +1,7 @@
 package dice
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"regexp"
@@ -41,6 +42,9 @@ func (StdRoller) Roll(matches []string) (RollResult, error) {
 	sides, err := strconv.ParseInt(matches[2], 10, 0)
 	if err != nil {
 		return nil, err
+	}
+	if sides <= 0 {
+		return nil, errors.New("Must have at least one side")
 	}
 
 	keep := ""


### PR DESCRIPTION
Return an error when user provides a zero-sided (D&D) die, preventing
the bot from panicking.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>