### PR TITLE
common/templates: add silent key to complexMessage

### DIFF
--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -266,6 +266,11 @@ func CreateMessageSend(values ...interface{}) (*discordgo.MessageSend, error) {
 			msg.Reference = &discordgo.MessageReference{
 				MessageID: msgID,
 			}
+		case "silent":
+			if val == nil || val == false {
+				continue
+			}
+			msg.Flags |= discordgo.MessageFlagsSuppressNotifications
 		default:
 			return nil, errors.New(`invalid key "` + key + `" passed to send message builder`)
 		}
@@ -319,6 +324,11 @@ func CreateMessageEdit(values ...interface{}) (*discordgo.MessageEdit, error) {
 				}
 				msg.Embeds = []*discordgo.MessageEmbed{embed}
 			}
+		case "silent":
+			if val == nil || val == false {
+				continue
+			}
+			msg.Flags |= discordgo.MessageFlagsSuppressNotifications
 		default:
 			return nil, errors.New(`invalid key "` + key + `" passed to message edit builder`)
 		}

--- a/lib/discordgo/message.go
+++ b/lib/discordgo/message.go
@@ -193,6 +193,8 @@ const (
 	MessageFlagsLoading MessageFlags = 1 << 7
 	// MessageFlagsFailedToMentionSomeRolesInThread this message failed to mention some roles and add their members to the thread.
 	MessageFlagsFailedToMentionSomeRolesInThread MessageFlags = 1 << 8
+	// MessageFlagsSuppressNotifications this message will not trigger push and desktop notifications
+	MessageFlagsSuppressNotifications MessageFlags = 1 << 12
 )
 
 // File stores info about files you e.g. send in messages.
@@ -211,6 +213,7 @@ type MessageSend struct {
 	Files           []*File            `json:"-"`
 	AllowedMentions AllowedMentions    `json:"allowed_mentions,omitempty"`
 	Reference       *MessageReference  `json:"message_reference,omitempty"`
+	Flags           MessageFlags       `json:"flags,omitempty"`
 
 	// TODO: Remove this when compatibility is not required.
 	File *File `json:"-"`


### PR DESCRIPTION
This is a combination of two commits: ea8711a and db8e1d6.

Add the recently introduced `SUPPRESS_NOTIFICATIONS` message flag to
the set of `discordgo.MessageFlags`.

Also add a `Flags` field to both `MessageEdit` and `MessageSend` struct,
so that we can introduce a new key for `complexMessage` to suppress
notifications.

Add a "silent" key to complexMessage to suppress notifications.

Just recently a user on the support server asked whether it is possible
(with yagpdb) to use the new `@silent` feature -- standing now, that is
not the case.

So, I've gone ahead and implemented exactly that sort of feature. I'm
not expecting to have this released until the next scheduled release;
we've went quite some time without it, chances are that users can still
wait until the next release.

A minimal working example, silently pinging the triggering user:
```go
{{ sendMessage nil (complexMessage "content" .User.Mention "silent" true) }}
```

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
