### PR TITLE
fix(rolecommands): Fix invalid URL in cmd error

### DIFF
--- a/rolecommands/menu.go
+++ b/rolecommands/menu.go
@@ -63,7 +63,7 @@ func cmdFuncRoleMenuCreate(parsed *dcmd.Data) (interface{}, error) {
 
 	cmdsLen := len(group.R.RoleCommands)
 	if cmdsLen < 1 {
-		return fmt.Sprintf("No commands in this group. Set them up at <%s/group/%d>.", panelURL, group.ID), nil
+		return fmt.Sprintf("No commands in this group. Set them up at <%sgroup/%d>.", panelURL, group.ID), nil
 	}
 
 	model := &models.RoleMenu{


### PR DESCRIPTION
Minor edit, removing a forward-slash from a `fmt.Sprintf` string, which would cause the URL provided in an error to be invalid, leading to a `404` page.