### PR TITLE
common/templates: add "indent" flag to `tmplJson`

### DIFF
--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -1106,10 +1106,33 @@ func ToByte(from interface{}) []byte {
 	}
 }
 
-func tmplJson(v interface{}) (string, error) {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return "", err
+func tmplJson(v interface{}, flags ...bool) (string, error) {
+	var b []byte
+	var err error
+
+	switch len(flags) {
+
+	case 0:
+		b, err = json.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+
+	case 1:
+		if flags[0] {
+			b, err = json.MarshalIndent(v, "", "\t")
+			if err != nil {
+				return "", err
+			}
+		} else {
+			b, err = json.Marshal(v)
+			if err != nil {
+				return "", err
+			}
+		}
+
+	default:
+		return "", errors.New("Too many flags")
 	}
 
 	return string(b), nil


### PR DESCRIPTION
Add an "indent" flag to `tmplJson` in form of a variadic argument.

Generally, users use the `json` function to look at JSON -- with proper
indentation, that becomes like 100 times easier to do.

As to not break backwards compatibility, this flag in form of a boolean
(true/false) is optional and will (obviously) default to false.

The switch statement is basically a copy from the `KindOf` function in
the same file, so there shouldn't be any style issues with it.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
