### PR TITLE
feat(youtube): Redesign YouTube matching logic

### DIFF
--- a/youtube/feed.go
+++ b/youtube/feed.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -278,39 +279,67 @@ var (
 	ErrMaxCustomMessageLength = errors.New("max length of custom message can be 500 chars")
 )
 
-func (p *Plugin) parseYtUrl(url string) (t ytUrlType, id string, err error) {
-	if ytUrlShortRegex.MatchString(url) {
-		capturingGroups := ytUrlShortRegex.FindAllStringSubmatch(url, -1)
-		if len(capturingGroups) > 0 && len(capturingGroups[0]) > 0 && len(capturingGroups[0][2]) > 0 {
-			return ytUrlTypeVideo, capturingGroups[0][2], nil
-		}
-	} else if ytVideoUrlRegex.MatchString(url) {
-		capturingGroups := ytVideoUrlRegex.FindAllStringSubmatch(url, -1)
-		if len(capturingGroups) > 0 && len(capturingGroups[0]) > 0 && len(capturingGroups[0][4]) > 0 {
-			return ytUrlTypeVideo, capturingGroups[0][4], nil
-		}
-	} else if ytChannelUrlRegex.MatchString(url) {
-		capturingGroups := ytChannelUrlRegex.FindAllStringSubmatch(url, -1)
-		if len(capturingGroups) > 0 && len(capturingGroups[0]) > 0 && len(capturingGroups[0][5]) > 0 {
-			return ytUrlTypeChannel, capturingGroups[0][5], nil
-		}
-	} else if ytCustomUrlRegex.MatchString(url) {
-		capturingGroups := ytCustomUrlRegex.FindAllStringSubmatch(url, -1)
-		if len(capturingGroups) > 0 && len(capturingGroups[0]) > 0 && len(capturingGroups[0][5]) > 0 {
-			return ytUrlTypeCustom, capturingGroups[0][5], nil
-		}
-	} else if ytUserUrlRegex.MatchString(url) {
-		capturingGroups := ytUserUrlRegex.FindAllStringSubmatch(url, -1)
-		if len(capturingGroups) > 0 && len(capturingGroups[0]) > 0 && len(capturingGroups[0][5]) > 0 {
-			return ytUrlTypeUser, capturingGroups[0][5], nil
-		}
-	} else if ytHandleUrlRegex.MatchString(url) {
-		capturingGroups := ytHandleUrlRegex.FindAllStringSubmatch(url, -1)
-		if len(capturingGroups) > 0 && len(capturingGroups[0]) > 0 && len(capturingGroups[0][5]) > 0 {
-			return ytUrlTypeHandle, capturingGroups[0][5], nil
+func (p *Plugin) parseYtUrl(channelUrl *url.URL) (idType ytUrlType, id string, err error) {
+	// First set of URL types should only have one segment,
+	// so trimming leading forward slash simplifies following operations
+	path := strings.TrimPrefix(channelUrl.Path, "/")
+
+	if strings.HasSuffix(channelUrl.Host, "youtu.be") {
+		return p.parseYtVideoID(path)
+	}
+
+	if strings.HasPrefix(path, "watch") {
+		// `v` key-value pair should identify the video ID
+		// in URLs with a `watch` segment.
+		val := channelUrl.Query().Get("v")
+		return p.parseYtVideoID(val)
+	}
+
+	// Prefix check allows method to provide a more helpful error message,
+	// when attempting to parse an invalid handle URL.
+	if strings.HasPrefix(path, "@") {
+		handle := ytHandleRegex.FindStringSubmatch(path)
+		if handle != nil {
+			return ytUrlTypeHandle, handle[1], nil
+		} else {
+			return ytUrlTypeInvalid, id, errors.New("invalid handle format")
 		}
 	}
-	return ytUrlTypeInvalid, "", errors.New("invalid or incomplete url")
+
+	pathSegments := strings.SplitAfter(channelUrl.Path, "/")
+	if len(pathSegments) != 2 {
+		return ytUrlTypeInvalid, id, errors.New("invalid number of path segments in url")
+	}
+
+	first := pathSegments[0]
+	second := pathSegments[1]
+
+	switch first {
+	case "shorts":
+		return p.parseYtVideoID(second)
+	case "channel":
+		id = ytChannelIDRegex.FindString(second)
+		if id != "" {
+			return ytUrlTypeChannel, id, nil
+		} else {
+			return ytUrlTypeInvalid, id, errors.New("invalid channel id")
+		}
+	case "c":
+		return ytUrlTypeCustom, second, nil
+	case "user":
+		return ytUrlTypeUser, second, nil
+	default:
+		return ytUrlTypeInvalid, id, errors.New("invalid or incomplete url") 
+	}
+}
+
+func (p *Plugin) parseYtVideoID(parse string) (idType ytUrlType, id string, err error) {
+	id = ytVideoIDRegex.FindString(parse)
+	if id == "" {
+		idType = ytUrlTypeInvalid
+		err = errors.New("invalid video id format")
+	}
+	return
 }
 
 func (p *Plugin) getYtChannel(url string) (channel *youtube.Channel, err error) {

--- a/youtube/feed.go
+++ b/youtube/feed.go
@@ -342,7 +342,7 @@ func (p *Plugin) parseYtVideoID(parse string) (idType ytUrlType, id string, err 
 	return
 }
 
-func (p *Plugin) getYtChannel(url string) (channel *youtube.Channel, err error) {
+func (p *Plugin) getYtChannel(url *url.URL) (channel *youtube.Channel, err error) {
 	urlType, id, err := p.parseYtUrl(url)
 	if err != nil {
 		return nil, err

--- a/youtube/web.go
+++ b/youtube/web.go
@@ -63,13 +63,9 @@ const (
 )
 
 var (
-	ytUrlRegex        = regexp.MustCompile(`^(https?:\/\/)?((www|m)\.)?youtube\.com`)
-	ytUrlShortRegex   = regexp.MustCompile(`^(https?:\/\/)?youtu\.be\/([a-zA-Z0-9_-]+).*`)
-	ytVideoUrlRegex   = regexp.MustCompile(`^(https?:\/\/)?((www|m)\.)?youtube\.com\/watch\?.*v=([a-zA-Z0-9_-]+).*`)
-	ytChannelUrlRegex = regexp.MustCompile(`^(https?:\/\/)?((www|m)\.)?youtube\.com\/(channel)\/(UC[\w-]{21}[AQgw])$`)
-	ytCustomUrlRegex  = regexp.MustCompile(`^(https?:\/\/)?((www|m)\.)?youtube\.com\/(c\/)?([\w-]+)$`)
-	ytUserUrlRegex    = regexp.MustCompile(`^(https?:\/\/)?((www|m)\.)?youtube\.com\/(user\/)([\w-]+)$`)
-	ytHandleUrlRegex  = regexp.MustCompile(`^(https?:\/\/)?((www|m)\.)?youtube\.com\/(@)([\w-]+)$`)
+	ytVideoIDRegex = regexp.MustCompile(`\A[\w-]+\z`)
+	ytChannelIDRegex = regexp.MustCompile(`\AUC[\w-]{21}[AQgw]\z`)
+	ytHandleRegex = regexp.MustCompile(`\A@([\w\-.]{3,30})\z`)
 )
 
 func (p *Plugin) InitWeb() {


### PR DESCRIPTION
This PR is aimed at updating elements of the URL parsing logic for the YouTube feed, by adding checks of the URL path in order to streamline parsing logic, as well as raise more relevant, context-sensitive errors.

Additionally, these changes come alongside using these changes to add support for URLs using the `shorts` path in the process.