### PR TITLE
refact(youtube): Decouple channel fetching and URL parsing logic

### DIFF
--- a/youtube/feed.go
+++ b/youtube/feed.go
@@ -338,7 +338,7 @@ func (p *Plugin) parseYtUrl(channelUrl *url.URL) (id ytChannelID, err error) {
 	if strings.HasSuffix(host, "youtu.be") {
 		return p.parseYtVideoID(path)
 	} else if !strings.HasSuffix(host, "youtube.com") {
-		return nil, fmt.Errorf("\"%s\" is not a valid youtube domain", host)
+		return nil, fmt.Errorf("%q is not a valid youtube domain", host)
 	}
 
 	if strings.HasPrefix(path, "watch") {
@@ -354,13 +354,13 @@ func (p *Plugin) parseYtUrl(channelUrl *url.URL) (id ytChannelID, err error) {
 		if ytHandleRegex.MatchString(path) {
 			return searchChannelID(path), nil
 		} else {
-			return nil, fmt.Errorf("\"%s\" is not a valid youtube handle", path)
+			return nil, fmt.Errorf("%q is not a valid youtube handle", path)
 		}
 	}
 
 	pathSegments := strings.Split(path, "/")
 	if len(pathSegments) != 2 {
-		return nil, fmt.Errorf("\"%s\" is not a valid path", path)
+		return nil, fmt.Errorf("%q is not a valid path", path)
 	}
 
 	first := pathSegments[0]
@@ -373,14 +373,14 @@ func (p *Plugin) parseYtUrl(channelUrl *url.URL) (id ytChannelID, err error) {
 		if ytChannelIDRegex.MatchString(second) {
 			return channelID(second), nil
 		} else {
-			return nil, fmt.Errorf("\"%s\" is not a valid youtube channel id", id)
+			return nil, fmt.Errorf("%q is not a valid youtube channel id", id)
 		}
 	case "c":
 		return searchChannelID(second), nil
 	case "user":
 		return userID(second), nil
 	default:
-		return nil, fmt.Errorf("\"%s\" is not a valid path", path)
+		return nil, fmt.Errorf("%q is not a valid path", path)
 	}
 }
 
@@ -388,7 +388,7 @@ func (p *Plugin) parseYtVideoID(parse string) (id ytChannelID, err error) {
 	if ytVideoIDRegex.MatchString(parse) {
 		return videoID(parse), nil
 	} else {
-		return nil, fmt.Errorf("\"%s\" is not a valid youtube video id", parse)
+		return nil, fmt.Errorf("%q is not a valid youtube video id", parse)
 	}
 }
 

--- a/youtube/feed.go
+++ b/youtube/feed.go
@@ -298,10 +298,7 @@ func (id *videoID) getChannelList(p *Plugin, list *youtube.ChannelsListCall) (cR
 		return nil, errors.New("video not found")
 	}
 	cResp, err = list.Id(vResp.Items[0].Snippet.ChannelId).Do()
-	if err != nil {
-		err = common.ErrWithCaller(err)
-	}
-	return 
+	return cResp, common.ErrWithCaller(err)
 
 }
 
@@ -311,10 +308,7 @@ type channelID struct {
 
 func (id *channelID) getChannelList(p *Plugin, list *youtube.ChannelsListCall) (cResp *youtube.ChannelListResponse, err error) {
 	cResp, err = list.Id(id.id).Do()
-	if err != nil {
-		err = common.ErrWithCaller(err)
-	}
-	return
+	return cResp, common.ErrWithCaller(err)
 }
 
 type userID struct {
@@ -323,10 +317,7 @@ type userID struct {
 
 func (id *userID) getChannelList(p *Plugin, list *youtube.ChannelsListCall) (cResp *youtube.ChannelListResponse, err error) {
 	cResp, err = list.ForUsername(id.id).Do()
-	if err != nil {
-		err = common.ErrWithCaller(err)
-	}
-	return
+	return cResp, common.ErrWithCaller(err)
 }
 
 type searchChannelID struct {
@@ -343,10 +334,7 @@ func (id *searchChannelID) getChannelList(p *Plugin, list *youtube.ChannelsListC
 		return nil, ErrNoChannel
 	}
 	cResp, err = list.Id(sResp.Items[0].Id.ChannelId).Do()
-	if err != nil {
-		err = common.ErrWithCaller(err)
-	}
-	return
+	return cResp, common.ErrWithCaller(err)
 }
 
 func (p *Plugin) parseYtUrl(channelUrl *url.URL) (id ytChannelID, err error) {

--- a/youtube/feed.go
+++ b/youtube/feed.go
@@ -289,9 +289,9 @@ type videoID struct {
 	id string
 }
 
-func (id *videoID) getChannelList(p *Plugin, list *youtube.ChannelsListCall) (cResp *youtube.ChannelListResponse, err error) {
+func (v *videoID) getChannelList(p *Plugin, list *youtube.ChannelsListCall) (cResp *youtube.ChannelListResponse, err error) {
 	videoListCall := p.YTService.Videos.List(listParts)
-	vResp, err := videoListCall.Id(id.id).MaxResults(1).Do()
+	vResp, err := videoListCall.Id(v.id).MaxResults(1).Do()
 	if err != nil {
 		return nil, common.ErrWithCaller(err)
 	} else if len(vResp.Items) < 1 {
@@ -306,8 +306,8 @@ type channelID struct {
 	id string
 }
 
-func (id *channelID) getChannelList(p *Plugin, list *youtube.ChannelsListCall) (cResp *youtube.ChannelListResponse, err error) {
-	cResp, err = list.Id(id.id).Do()
+func (c *channelID) getChannelList(p *Plugin, list *youtube.ChannelsListCall) (cResp *youtube.ChannelListResponse, err error) {
+	cResp, err = list.Id(c.id).Do()
 	return cResp, common.ErrWithCaller(err)
 }
 
@@ -315,8 +315,8 @@ type userID struct {
 	id string
 }
 
-func (id *userID) getChannelList(p *Plugin, list *youtube.ChannelsListCall) (cResp *youtube.ChannelListResponse, err error) {
-	cResp, err = list.ForUsername(id.id).Do()
+func (u *userID) getChannelList(p *Plugin, list *youtube.ChannelsListCall) (cResp *youtube.ChannelListResponse, err error) {
+	cResp, err = list.ForUsername(u.id).Do()
 	return cResp, common.ErrWithCaller(err)
 }
 
@@ -324,8 +324,8 @@ type searchChannelID struct {
 	id string
 }
 
-func (id *searchChannelID) getChannelList(p *Plugin, list *youtube.ChannelsListCall) (cResp *youtube.ChannelListResponse, err error) {
-	q := url.QueryEscape(id.id)
+func (s *searchChannelID) getChannelList(p *Plugin, list *youtube.ChannelsListCall) (cResp *youtube.ChannelListResponse, err error) {
+	q := url.QueryEscape(s.id)
 	searchListCall := p.YTService.Search.List(listParts)
 	sResp, err := searchListCall.Q(q).Type("channel").MaxResults(1).Do()
 	if err != nil {

--- a/youtube/web.go
+++ b/youtube/web.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/botlabs-gg/yagpdb/v2/common"

--- a/youtube/web.go
+++ b/youtube/web.go
@@ -155,7 +155,7 @@ func (p *Plugin) HandleNew(w http.ResponseWriter, r *http.Request) (web.Template
 
 	id, err := p.parseYtUrl(parsedUrl)
 	if err != nil {
-		logger.WithError(err).Errorf("error occured parsing channel from url \"%s\"", channelUrl)
+		logger.WithError(err).Errorf("error occured parsing channel from url %q", channelUrl)
 		return templateData.AddAlerts(web.ErrorAlert(err)), err
 	}
 


### PR DESCRIPTION
This PR can be considered a continuation of #1466, and aims to address the issues I highlighted in a comment on that PR.

Notably, this moves the fetching logic previously handled by `Plugin.getYtChannel`, behind the `ytChannelID` interface, and a series of newtypes which will handle determining the fetching logic used. By having `Plugin.parseYtUrl` return `ytChannelID`, it becomes more appropriate for `Plugin.HandleNew` to call the method directly, thereby avoiding flattening fetching errors, with URL parsing errors, improving error reporting to end users, as well as entirely removing the need for `Plugin.getYtChannel`, the `ytUrlType` type, and its associated constants. With this change, some of the fetching logic used has also been optimised, such as using the `youtube.VideosService` to fetch videos by ID, rather than using the YouTube search service, as well as ensuring queries to the search API are properly escaped, meaning stripping the leading `@` from handles, is no longer necessary.

Additionally, this makes some auxiliary changes to the surrounding logic, such as making `Plugin.parseYtChannel` entirely responsible for domain validation logic, switching the variable path segmentation is based on, ensuring empty strings are visible in parsing errors, ensuring RegEx is formatted correctly, and simplifying RegEx validation logic where appropriate.