### PR TITLE
customcommands: evalcc command

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -175,6 +175,8 @@ type Context struct {
 
 	IsExecedByLeaveMessage bool
 
+	IsExecedByEvalCC bool
+
 	contextFuncsAdded bool
 }
 
@@ -318,8 +320,10 @@ func (c *Context) Parse(source string) (*template.Template, error) {
 }
 
 const (
-	MaxOpsNormal  = 1000000
-	MaxOpsPremium = 2500000
+	MaxOpsNormal      = 1000000
+	MaxOpsPremium     = 2500000
+	MaxOpsEvalNormal  = 5000
+	MaxOpsEvalPremium = 10000
 )
 
 func (c *Context) Execute(source string) (string, error) {
@@ -367,8 +371,14 @@ func (c *Context) executeParsed() (string, error) {
 
 	if c.IsPremium {
 		parsed = parsed.MaxOps(MaxOpsPremium)
+		if c.IsExecedByEvalCC {
+			parsed = parsed.MaxOps(MaxOpsEvalPremium)
+		}
 	} else {
 		parsed = parsed.MaxOps(MaxOpsNormal)
+		if c.IsExecedByEvalCC {
+			parsed = parsed.MaxOps(MaxOpsEvalNormal)
+		}
 	}
 
 	var buf bytes.Buffer
@@ -540,6 +550,9 @@ func (c *Context) IncreaseCheckCallCounterPremium(key string, normalLimit, premi
 }
 
 func (c *Context) IncreaseCheckGenericAPICall() bool {
+	if c.IsExecedByEvalCC {
+		return c.IncreaseCheckCallCounter("api_call", 20)
+	}
 	return c.IncreaseCheckCallCounter("api_call", 100)
 }
 

--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -61,7 +61,7 @@ var _ bot.BotInitHandler = (*Plugin)(nil)
 var _ commands.CommandProvider = (*Plugin)(nil)
 
 func (p *Plugin) AddCommands() {
-	commands.AddRootCommands(p, cmdListCommands, cmdFixCommands)
+	commands.AddRootCommands(p, cmdListCommands, cmdFixCommands, cmdEvalCommand)
 }
 
 func (p *Plugin) BotInit() {
@@ -115,6 +115,89 @@ type DelayedRunCCData struct {
 	UserKey interface{} `json:"user_key"`
 
 	IsExecedByLeaveMessage bool `json:"is_execed_by_leave_message"`
+}
+
+var cmdEvalCommand = &commands.YAGCommand{
+	CmdCategory:  commands.CategoryTool,
+	Name:         "Evalcc",
+	Description:  "executes small custom command code",
+	RequiredArgs: 1,
+	Arguments: []*dcmd.ArgDef{
+		{Name: "code", Type: dcmd.String},
+	},
+	SlashCommandEnabled: false,
+	DefaultEnabled:      true,
+	RunFunc: func(data *dcmd.Data) (interface{}, error) {
+		var hasCoreWriteRole bool
+
+		writeRoles := (common.GetCoreServerConfCached(data.GuildData.GS.ID)).AllowedWriteRoles
+		for _, r := range data.GuildData.MS.Member.Roles {
+			if common.ContainsInt64Slice(writeRoles, r) {
+				hasCoreWriteRole = true
+				break
+			}
+		}
+
+		adminOrPerms, err := bot.AdminOrPermMS(data.GuildData.GS.ID, data.GuildData.CS.ID, data.GuildData.MS, discordgo.PermissionManageServer)
+		if err != nil {
+			return nil, err
+		}
+
+		if !(adminOrPerms || hasCoreWriteRole) {
+			return "You need `Manage Server` permissions or control panel write access for this command", nil
+		}
+
+		// Disallow calling via exec / execAdmin
+		if data.Context().Value(commands.CtxKeyExecutedByCC) == true {
+			return "", nil
+		}
+
+		channel := data.GuildData.CS
+		ctx := templates.NewContext(data.GuildData.GS, channel, data.GuildData.MS)
+		ctx.IsExecedByEvalCC = true
+
+		maxRunes := 500
+		if ctx.IsPremium {
+			maxRunes = 1000
+		}
+
+		code := data.Args[0].Str()
+
+		code = parseCodeblock(code)
+
+		// Encourage only small code snippets being tested with this command
+		if utf8.RuneCountInString(code) > maxRunes {
+			return "Code is too long for in-place evaluation. Please use the control panel.", nil
+		}
+
+		if channel == nil {
+			return "Something weird happened... Contact the support server.", nil
+		}
+
+		out, err := ctx.Execute(code)
+
+		if err != nil {
+			errFormatted := err.Error()
+			return "An error caused the custom command to stop:\n`" + errFormatted + "`", nil
+		}
+
+		return out, nil
+	},
+}
+
+var codeblockRegexp = regexp.MustCompile(`(?m)\A(?:\x60{2} ?\x60)(?:go(?:lang)?\n)?([\S\s]+)(?:\x60 ?\x60{2})\z`)
+
+// Parses code wrapped in Discord markdown codeblocks.
+func parseCodeblock(input string) string {
+	parts := codeblockRegexp.FindStringSubmatch(input)
+
+	// No match found, input was not wrapped in (valid) codeblock markdown
+	// just dump it, don't bother fixing things for the user.
+	if parts == nil {
+		return input
+	}
+
+	return parts[1]
 }
 
 var cmdListCommands = &commands.YAGCommand{

--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -197,6 +197,8 @@ func parseCodeblock(input string) string {
 		return input
 	}
 
+	logger.Debugf("Found matches: %#v", parts)
+	logger.Debugf("Returning %s", parts[1])
 	return parts[1]
 }
 


### PR DESCRIPTION
Evaluate small code snippets quickly. Can only be used by beings of
high power, as it requires manage_guild permissions (and/or control panel read access).

This is a combination of several commits:

* customcommands: improve evalcc parsing

* customcommands: improve `evalcc` permissions

  Previously, this command only allowed users with  manage_server
  permissions to run this command. This is arguably bad design --
  server staff with write access to the control panel are just as able to
  create custom commands, thus should be able to run this command, too.

* customcommands: optimise check for AllowedWriteRoles

  Moving the call outside of the `range` reduces overhead (significance
  may be debatable), thus being preferable.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>