### PR TITLE
feat(youtube): Add playlist URL support

### DIFF
--- a/youtube/feed.go
+++ b/youtube/feed.go
@@ -329,6 +329,21 @@ func (s searchChannelID) getChannelList(p *Plugin, list *youtube.ChannelsListCal
 	return cResp, common.ErrWithCaller(err)
 }
 
+type playlistID string
+
+func (pl playlistID) getChannelList(p *Plugin, list *youtube.ChannelsListCall) (cResp *youtube.ChannelListResponse, err error) {
+	id := string(pl)
+	playlistListCall := p.YTService.Playlists.List(listParts)
+	pResp, err := playlistListCall.Id(id).MaxResults(1).Do()
+	if err != nil {
+		return nil, common.ErrWithCaller(err)
+	} else if len(pResp.Items) < 1 {
+		return nil, ErrNoChannel
+	}
+	cResp, err = list.Id(pResp.Items[0].Snippet.ChannelId).Do()
+	return cResp, common.ErrWithCaller(err)
+}
+
 func (p *Plugin) parseYtUrl(channelUrl *url.URL) (id ytChannelID, err error) {
 	// First set of URL types should only have one segment,
 	// so trimming leading forward slash simplifies following operations

--- a/youtube/feed.go
+++ b/youtube/feed.go
@@ -361,6 +361,13 @@ func (p *Plugin) parseYtUrl(channelUrl *url.URL) (id ytChannelID, err error) {
 		// in URLs with a `watch` segment.
 		val := channelUrl.Query().Get("v")
 		return p.parseYtVideoID(val)
+	} else if strings.HasPrefix(path, "playlist") {
+		val := channelUrl.Query().Get("list")
+		if ytPlaylistIDRegex.MatchString(val) {
+			return playlistID(val), nil
+		} else {
+			return nil, fmt.Errorf("%q is not a valid playlist ID", val)
+		}
 	}
 
 	// Prefix check allows method to provide a more helpful error message,

--- a/youtube/web.go
+++ b/youtube/web.go
@@ -52,9 +52,10 @@ type YoutubeAnnouncementForm struct {
 }
 
 var (
-	ytVideoIDRegex   = regexp.MustCompile(`\A[\w\-]+\z`)
-	ytChannelIDRegex = regexp.MustCompile(`\AUC[\w\-]{21}[AQgw]\z`)
-	ytHandleRegex    = regexp.MustCompile(`\A@[\w\-.]{3,30}\z`)
+	ytVideoIDRegex    = regexp.MustCompile(`\A[\w\-]+\z`)
+	ytPlaylistIDRegex = regexp.MustCompile(`\A(?:PL|OLAK|RDCLAK)[-_0-9A-Za-z]+\z`)
+	ytChannelIDRegex  = regexp.MustCompile(`\AUC[\w\-]{21}[AQgw]\z`)
+	ytHandleRegex     = regexp.MustCompile(`\A@[\w\-.]{3,30}\z`)
 )
 
 func (p *Plugin) InitWeb() {


### PR DESCRIPTION
This is a brief PR to add support for parsing `youtube.com` URLs with the `playlist` path, and fetching channels based on the playlist ID parsed. Consequently, this adds the `playlistID` newtype, and accompanying `playlistID.getChannelList` method, based on the `youtube.PlaylistService` type.