### PR TITLE
moderation: add clearwarns to mod-log

### DIFF
--- a/moderation/modlog.go
+++ b/moderation/modlog.go
@@ -37,6 +37,7 @@ var (
 	MATimeoutRemoved = ModlogAction{Prefix: "Timeout removed from", Emoji: "⏱", Color: 0x9b59b6}
 	MAGiveRole       = ModlogAction{Prefix: "", Emoji: "➕", Color: 0x53fcf9}
 	MARemoveRole     = ModlogAction{Prefix: "", Emoji: "➖", Color: 0x53fcf9}
+	MAClearWarnings  = ModlogAction{Prefix: "Cleared warnings", Emoji: "👌", Color: 0x62c65f}
 )
 
 func CreateModlogEmbed(config *Config, author *discordgo.User, action ModlogAction, target *discordgo.User, reason, logLink string) error {


### PR DESCRIPTION
See suggestion [No. 438](https://canary.discord.com/channels/166207328570441728/356486960417734666/772140829007282176):

> Log clw in the mod log channel [...]

----
* moderation: add MAClearWarnings modaction
  Add a new modaction MAClearWarnings. This will be used in a future
  commit adding mod-log functionality to the `clw` command.

* moderation: add mod-log functionality to clw
  Modify the clearwarnings command such that it logs the action to the
  modlog.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>