### PR TITLE
template: don't swallow returns in try-catch actions

### DIFF
--- a/lib/template/exec_test.go
+++ b/lib/template/exec_test.go
@@ -599,6 +599,9 @@ var execTests = []execTest{
 	{"return top level", `12{{return}}23`, "12", tVal, true},
 	{"return in nested template", `{{define "tmpl"}}12{{return}}34{{end}}{{template "tmpl"}}45`, "1245", tVal, true},
 	{"return in range", `{{range .SI}}{{return}}23{{end}}34`, "", tVal, true},
+	{"return in while", `{{$i := 0}}{{while lt $i 5}}{{return}}{{end}}NOTREACHED`, "", tVal, true},
+	{"return in try", `{{try}}{{return}}{{catch}}{{end}}NOTREACHED`, "", tVal, true},
+	{"return in catch", `{{try}}{{.MyError true}}{{catch}}{{return}}{{end}}NOTREACHED`, "", tVal, true},
 	{"return in if", `{{if true}}{{return}}{{end}}12`, "", tVal, true},
 	{"return with value", `12{{return 34}}45`, "12", tVal, true},
 


### PR DESCRIPTION
The following program
```
{{try}}{{return}}{{catch}}{{end}}BAD
```
currently outputs `BAD` — the return inside the try action is erroneously swallowed. (A similar issue occurs with returns in the catch list.)

This PR addresses this issue by properly propagating control flow signals in `walkTry`, and adds a couple tests to ensure correctness. The patch is slightly complicated by the need to return from a deferred function — to do so, we introduce a named return variable and assign to it as needed.