### PR TITLE
Additional files for use on CapRover

### DIFF
--- a/captain-definition
+++ b/captain-definition
@@ -1,0 +1,4 @@
+ {
+  "schemaVersion" : 2,
+  "dockerfilePath" : "./yagpdb_docker/Dockerfile.exthttps"
+ }

--- a/yagpdb_docker/Dockerfile.exthttps
+++ b/yagpdb_docker/Dockerfile.exthttps
@@ -1,0 +1,26 @@
+FROM golang:stretch as builder
+
+WORKDIR /appbuild/yagpdb
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+WORKDIR /appbuild/yagpdb/cmd/yagpdb
+RUN CGO_ENABLED=0 GOOS=linux go build -v -ldflags "-X github.com/botlabs-gg/yagpdb/v2/common.VERSION=$(git describe --tags)"
+
+
+
+FROM alpine:latest
+
+WORKDIR /app
+VOLUME ["/app/soundboard"]
+EXPOSE 80 443
+
+# Dependencies: ca-certificates for client TLS, tzdata for timezone and ffmpeg for soundboard support
+RUN apk --no-cache add ca-certificates ffmpeg tzdata
+
+COPY --from=builder /appbuild/yagpdb/cmd/yagpdb/yagpdb yagpdb
+
+ENTRYPOINT ["/app/yagpdb"]
+CMD ["-all", "-pa", "-exthttps=true", "-https=false"]


### PR DESCRIPTION
When I was deploying **yagpdb** on my server running CapRover, I saw that the unofficial docker image mentioned in the docker compose file wasn't up-to-date.

So I came up with this little change which should be useful especially - but not solely - for CapRover users like me.

First change is a new Dockerfile for use with external https like when you are using a reverse proxy doing https for you.

Second change is a captain-definition file which basically just tells CapRover to use the new Dockerfile when building the image.

Both changes combined will allow a CapRover user to simply download the `.tar.gz` file from a new release and quickly decompress it before uploading it in order to deploy (an update) directly via Tarball.