### PR TITLE
amod: fix violations expiring immediately

### DIFF
--- a/automod_legacy/rules.go
+++ b/automod_legacy/rules.go
@@ -78,7 +78,9 @@ func (r BaseRule) PushViolation(key string) (p Punishment, err error) {
 		return
 	}
 
-	common.RedisPool.Do(radix.FlatCmd(nil, "EXPIRE", key, r.ViolationsExpire*60))
+	if r.ViolationsExpire > 0 {
+		common.RedisPool.Do(radix.FlatCmd(nil, "EXPIRE", key, r.ViolationsExpire*60))
+	}
 
 	mute := r.MuteAfter > 0 && violations >= r.MuteAfter
 	kick := r.KickAfter > 0 && violations >= r.KickAfter


### PR DESCRIPTION
https://github.com/botlabs-gg/yagpdb/pull/1203 fixed the expiration being in seconds, instead of minutes but, it didn't fix the case when the expiration is set to 0. In that case, 60*0 is still 0 so the violation expires immediately.

This PR adds a condition check to only set an expiration in case there is an expiration to be set.

Context: https://discord.com/channels/166207328570441728/638478390323576873/809211413130248202