### PR TITLE
frontend: favour globalname for logged in users

### DIFF
--- a/frontend/templates/cp_nav.html
+++ b/frontend/templates/cp_nav.html
@@ -110,7 +110,7 @@
                         class="rounded-circle" data-lock-picture="img/!logged-user.jpg" />{{end}}
                 </figure>
                 <div class="profile-info" data-lock-name="{{.User.Username}}" data-lock-email="">
-                    <span class="name">{{.User.Username}}</span>
+                    <span class="name">{{or .User.Globalname .User.Username}}</span>
                     <span class="role">{{adjective | title}}</span>
                 </div>
 


### PR DESCRIPTION
For logged in users, favour the global_name they have set, otherwise use
their username in the account box.

This change is fully backwards-compatible. Users without their display
name set will continue to see their username; users with a pomelo name
and no display name will obviously see their pomelo name instead.

See: Suggestion No. 2091
https://discord.com/channels/166207328570441728/356486960417734666/1116722286989426758

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
