### PR TITLE
lib/dstate: add GuildSet.IconURL method

### DIFF
--- a/lib/dstate/interface.go
+++ b/lib/dstate/interface.go
@@ -138,6 +138,24 @@ func (gs *GuildSet) GetChannelOrThread(id int64) *ChannelState {
 	return gs.GetThread(id)
 }
 
+// IconURL returns a URL to the guild icon.
+//
+//	size: The size of the guild's icon as a power of two
+//	      if size is an emptry string, no size parameter will
+//	      be added to the URL.
+func (gs *GuildSet) IconURL(size string) string {
+	if gs.Icon == "" {
+		return ""
+	}
+
+	url := discordgo.EndpointGuildIcon(gs.ID, gs.Icon)
+	if size != "" {
+		url += "?size=" + size
+	}
+
+	return url
+}
+
 type GuildState struct {
 	ID          int64  `json:"id,string"`
 	Available   bool   `json:"available"`


### PR DESCRIPTION
Add a IconURL method to the dstate.GuildSet struct to retrieve the
guild's icon URL.

Currently, we have to use the following code to retrieve a guild's icon
in custom commands:

```
{{$ex := or (and (hasPrefix "a_" .Guild.Icon) "gif" ) "png" }}
{{$icon := printf "https://cdn.discordapp.com/icons/%d/%s.%s?size=1024" .Guild.ID .Guild.Icon $ex }}
```

With this change, users will be able to condense the above down to the
following:

```
{{ $icon := .Guild.IconURL "1024" }}
```
Which quite obviously is a lot cleaner and space-efficient.

I wasn't able to find a relevant suggestion to back myself up with, but
I believe this addition was rather long due and will make it a bit
easier for our users in the long run.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
