### PR TITLE
lib: fix always returning png in gs.IconURL

### DIFF
--- a/lib/discordgo/endpoints.go
+++ b/lib/discordgo/endpoints.go
@@ -90,17 +90,18 @@ var (
 	EndpointGuildIntegrationSync = func(gID, iID int64) string {
 		return ""
 	}
-	EndpointGuildRoles     = func(gID int64) string { return "" }
-	EndpointGuildRole      = func(gID, rID int64) string { return "" }
-	EndpointGuildInvites   = func(gID int64) string { return "" }
-	EndpointGuildEmbed     = func(gID int64) string { return "" }
-	EndpointGuildPrune     = func(gID int64) string { return "" }
-	EndpointGuildIcon      = func(gID int64, hash string) string { return "" }
-	EndpointGuildSplash    = func(gID int64, hash string) string { return "" }
-	EndpointGuildWebhooks  = func(gID int64) string { return "" }
-	EndpointGuildAuditLogs = func(gID int64) string { return "" }
-	EndpointGuildEmojis    = func(gID int64) string { return "" }
-	EndpointGuildEmoji     = func(gID, eID int64) string { return "" }
+	EndpointGuildRoles        = func(gID int64) string { return "" }
+	EndpointGuildRole         = func(gID, rID int64) string { return "" }
+	EndpointGuildInvites      = func(gID int64) string { return "" }
+	EndpointGuildEmbed        = func(gID int64) string { return "" }
+	EndpointGuildPrune        = func(gID int64) string { return "" }
+	EndpointGuildIcon         = func(gID int64, hash string) string { return "" }
+	EndpointGuildIconAnimated = func(gID int64, hash string) string { return "" }
+	EndpointGuildSplash       = func(gID int64, hash string) string { return "" }
+	EndpointGuildWebhooks     = func(gID int64) string { return "" }
+	EndpointGuildAuditLogs    = func(gID int64) string { return "" }
+	EndpointGuildEmojis       = func(gID int64) string { return "" }
+	EndpointGuildEmoji        = func(gID, eID int64) string { return "" }
 
 	EndpointChannel                   = func(cID int64) string { return "" }
 	EndpointChannelPermissions        = func(cID int64) string { return "" }
@@ -269,6 +270,7 @@ func CreateEndpoints(base string) {
 	EndpointGuildEmbed = func(gID int64) string { return EndpointGuilds + StrID(gID) + "/embed" }
 	EndpointGuildPrune = func(gID int64) string { return EndpointGuilds + StrID(gID) + "/prune" }
 	EndpointGuildIcon = func(gID int64, hash string) string { return EndpointCDNIcons + StrID(gID) + "/" + hash + ".png" }
+	EndpointGuildIconAnimated = func(gID int64, hash string) string { return EndpointCDNIcons + StrID(gID) + "/" + hash + ".gif" }
 	EndpointGuildSplash = func(gID int64, hash string) string { return EndpointCDNSplashes + StrID(gID) + "/" + hash + ".png" }
 	EndpointGuildWebhooks = func(gID int64) string { return EndpointGuilds + StrID(gID) + "/webhooks" }
 	EndpointGuildAuditLogs = func(gID int64) string { return EndpointGuilds + StrID(gID) + "/audit-logs" }

--- a/lib/dstate/interface.go
+++ b/lib/dstate/interface.go
@@ -144,11 +144,17 @@ func (gs *GuildSet) GetChannelOrThread(id int64) *ChannelState {
 //	      if size is an emptry string, no size parameter will
 //	      be added to the URL.
 func (gs *GuildSet) IconURL(size string) string {
+	var url string
 	if gs.Icon == "" {
 		return ""
 	}
 
-	url := discordgo.EndpointGuildIcon(gs.ID, gs.Icon)
+	if strings.HasPrefix(gs.Icon, "a_") {
+		url = discordgo.EndpointGuildIconAnimated(gs.ID, gs.Icon)
+	} else {
+		url = discordgo.EndpointGuildIcon(gs.ID, gs.Icon)
+	}
+
 	if size != "" {
 		url += "?size=" + size
 	}


### PR DESCRIPTION
I've noticed during testing with an animated guild icon that
`.Guild.IconURL` *always* returns a static png. It can be argued that
this is a sort of regression in comparison to the old way, which #1519
attempted to get rid of.

Unfortunately I wasn't able to test with an animated guild icon during
the development of the above mentioned pull request ~~because I refuse
to give Discord money~~, because such a guild wasn't available to me at
that time.

I've decided to implement a new endpoint in discordgo that returns the
gif version of the guild icon. Furthermore, I've modified dstate's
GuildSet.IconURL to make use of that new endpoint if it finds indication
that the guild icon is animated.

It'd be really cool if we can get this in before the scheduled release on
monday as a sort of hotfix, but it's not that urgent.

---
This is a combination of two commits:

* lib/discordgo: add EndpointGuildIconAnimated

    Add a new endpoint EndpointGuildIconAnimated to retrieve a gif version
    of the guild icon.

    We're going to use this in a future commit to fix a small (but
    non-critical) oversight in dstate's GuildSet.IconURL function, which
    currently only ever returns the guild's icon as a png.

* lib/dstate: also support gifs in GuildSet.IconURL

    Make use of the previously added EndpointGuildIconAnimated endpoint
    in discordgo, to stop always giving back a png, regardless of
    whether the icon is animated.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
