### PR TITLE
notifications: wrap topic message in codeblocks

### DIFF
--- a/notifications/plugin_bot.go
+++ b/notifications/plugin_bot.go
@@ -232,7 +232,7 @@ func HandleChannelUpdate(evt *eventsystem.EventData) (retry bool, err error) {
 	go analytics.RecordActiveUnit(cu.GuildID, &Plugin{}, "posted_topic_change")
 
 	go func() {
-		_, err := common.BotSession.ChannelMessageSend(topicChannel, fmt.Sprintf("Topic in channel <#%d> changed to **%s**", cu.ID, cu.Topic))
+		_, err := common.BotSession.ChannelMessageSend(topicChannel, fmt.Sprintf("Topic in channel <#%d> changed to \x60\x60\x60\n%s\x60\x60\x60", cu.ID, cu.Topic))
 		if err != nil {
 			logger.WithError(err).WithField("guild", cu.GuildID).Warn("Failed sending topic change message")
 		}


### PR DESCRIPTION
For ease of viewing the markdown, wrap the topic changed message in
codeblocks instead of bold.

There's also a relevant suggestion, though it isn't that popular, found
here.
https://discord.com/channels/166207328570441728/356486960417734666/999860483559534652

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
