### PR TITLE
stdcommands/customembed: allow codeblock and YAML

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -654,3 +654,22 @@ func FormatList(list []string, conjunction string) string {
 func BoolToPointer(b bool) *bool {
 	return &b
 }
+
+// Also accepts spaces due to how dcmd reconstructs arguments wrapped in triple backticks.
+var codeblockRegexp = regexp.MustCompile(`(?m)\A(?:\x60{2} ?\x60)(?:.*\n)?([\S\s]+)(?:\x60 ?\x60{2})\z`)
+
+// parseCodeblock returns the content wrapped in a Discord markdown block.
+// If no (valid) codeblock was found, the given input is returned back.
+func ParseCodeblock(input string) string {
+	parts := codeblockRegexp.FindStringSubmatch(input)
+
+	// No match found, input was not wrapped in (valid) codeblock markdown
+	// just dump it, don't bother fixing things for the user.
+	if parts == nil {
+		return input
+	}
+
+	logger.Debugf("Found matches: %#v", parts)
+	logger.Debugf("Returning %s", parts[1])
+	return parts[1]
+}

--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -156,7 +156,7 @@ var cmdEvalCommand = &commands.YAGCommand{
 		ctx := templates.NewContext(data.GuildData.GS, channel, data.GuildData.MS)
 		ctx.IsExecedByEvalCC = true
 
-		code := parseCodeblock(data.Args[0].Str())
+		code := common.ParseCodeblock(data.Args[0].Str())
 
 		// Encourage only small code snippets being tested with this command
 		maxRunes := 1000
@@ -176,25 +176,6 @@ var cmdEvalCommand = &commands.YAGCommand{
 
 		return out, nil
 	},
-}
-
-// Also accepts spaces due to how dcmd reconstructs arguments wrapped in triple backticks.
-var codeblockRegexp = regexp.MustCompile(`(?m)\A(?:\x60{2} ?\x60)(?:go(?:lang)?\n)?([\S\s]+)(?:\x60 ?\x60{2})\z`)
-
-// parseCodeblock returns the content wrapped in a Discord markdown block.
-// If no (valid) codeblock was found, the given input is returned back.
-func parseCodeblock(input string) string {
-	parts := codeblockRegexp.FindStringSubmatch(input)
-
-	// No match found, input was not wrapped in (valid) codeblock markdown
-	// just dump it, don't bother fixing things for the user.
-	if parts == nil {
-		return input
-	}
-
-	logger.Debugf("Found matches: %#v", parts)
-	logger.Debugf("Returning %s", parts[1])
-	return parts[1]
 }
 
 var cmdListCommands = &commands.YAGCommand{

--- a/stdcommands/customembed/customembed.go
+++ b/stdcommands/customembed/customembed.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 
 	"github.com/botlabs-gg/yagpdb/v2/commands"
+	"github.com/botlabs-gg/yagpdb/v2/common"
 	"github.com/botlabs-gg/yagpdb/v2/lib/dcmd"
 	"github.com/botlabs-gg/yagpdb/v2/lib/discordgo"
+	"gopkg.in/yaml.v3"
 )
 
 var Command = &commands.YAGCommand{
@@ -20,11 +22,20 @@ var Command = &commands.YAGCommand{
 		{Name: "Json", Type: dcmd.String},
 	},
 	RunFunc: func(data *dcmd.Data) (interface{}, error) {
+		j := common.ParseCodeblock(data.Args[0].Str())
 		var parsed *discordgo.MessageEmbed
-		err := json.Unmarshal([]byte(data.Args[0].Str()), &parsed)
+
+		// attempt to parse as YAML first.
+		// We don't care about the error here, as we're going to try parsing it as JSON anyway.
+		err := yaml.Unmarshal([]byte(j), &parsed)
 		if err != nil {
-			return "Failed parsing json: " + err.Error(), err
+			// Maybe it is JSON instead?
+			err = json.Unmarshal([]byte(j), &parsed)
+			if err != nil {
+				return "Failed parsing as YAML or JSON", err
+			}
 		}
+
 		if discordgo.IsEmbedEmpty(parsed) {
 			return "Cannot send an empty embed", nil
 		}


### PR DESCRIPTION
Allow codeblocks and YAML to be used in the `customembed` command.

Users will now be able to invoke the command with a codeblock wrapped
around their JSON or YAML, which makes writing and reading said data
quite a lot easier.

This change is fully backwards-compatible.

Here's an example of the new usage:

![2023-07-09-130747_473x793_scrot](https://github.com/botlabs-gg/yagpdb/assets/71897876/f4785222-6d55-4683-ba6e-c8c55d4e9e94)

----
This is a combination of two commits:

* common/util: export ParseCodeblock func
    Export the ParseCodeblock function in common util, moving it out
    from its unexported location in customcommands.

    We'll be using this later for the customembed command and honestly
    it should have been exported from the get-go.

* stdcommands/customembed: allow codeblock and YAML
    Allow Discord codeblocks to be used in the customembed command. For
    bonus points, also allow YAML to be given instead, falling back to
    JSON as necessary.

    This was a suggestion on the support server with quite a lot of
    upvotes (understandably so), which you can find here:
    https://canary.discord.com/channels/166207328570441728/356486960417734666/868190676347658260

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
