### PR TITLE
moderation: add mute and unmute cc functions

### DIFF
--- a/moderation/tmplextensions.go
+++ b/moderation/tmplextensions.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/botlabs-gg/yagpdb/v2/bot"
 	"github.com/botlabs-gg/yagpdb/v2/common"
 	"github.com/botlabs-gg/yagpdb/v2/common/templates"
 	"github.com/botlabs-gg/yagpdb/v2/logs"
@@ -13,6 +14,8 @@ import (
 func init() {
 	templates.RegisterSetupFunc(func(ctx *templates.Context) {
 		ctx.ContextFuncs["getWarnings"] = tmplGetWarnings(ctx)
+		ctx.ContextFuncs["muteUser"] = tmplMuteUser(ctx)
+		ctx.ContextFuncs["unmuteUser"] = tmplUnmuteUser(ctx)
 	})
 }
 
@@ -44,5 +47,80 @@ func tmplGetWarnings(ctx *templates.Context) interface{} {
 		}
 
 		return warns, nil
+	}
+}
+
+// muteUser mutes the target user for the specified duration.
+func tmplMuteUser(ctx *templates.Context) interface{} {
+	return func(target interface{}, duration string, reason string) (string, error) {
+		if ctx.IncreaseCheckCallCounterPremium("cc_moderation", 5, 10) {
+			return "", templates.ErrTooManyCalls
+		}
+
+		config, err := GetConfig(ctx.GS.ID)
+		if err != nil {
+			return "", err
+		}
+
+		if config.MuteRole == "" {
+			return "", fmt.Errorf("No mute role set up")
+		}
+
+		targetID := templates.TargetUserID(target)
+		if targetID == 0 {
+			return "", fmt.Errorf("Could not convert %T to a user ID", target)
+		}
+
+		member, err := bot.GetMember(ctx.GS.ID, targetID)
+		if err != nil || member == nil {
+			return "", fmt.Errorf("Could not find member")
+		}
+
+		dur, err := common.ParseDuration(duration)
+		if err != nil {
+			return "", err
+		}
+
+		err = MuteUnmuteUser(config, true, ctx.GS.ID, ctx.CurrentFrame.CS, ctx.Msg, ctx.Msg.Author, reason, member, int(dur.Minutes()))
+		if err != nil {
+			return "", err
+		}
+
+		return "", nil
+	}
+}
+
+// unmuteUser unmutes the target user.
+func tmplUnmuteUser(ctx *templates.Context) interface{} {
+	return func(target interface{}, reason string) (string, error) {
+		if ctx.IncreaseCheckCallCounterPremium("cc_moderation", 5, 10) {
+			return "", templates.ErrTooManyCalls
+		}
+
+		config, err := GetConfig(ctx.GS.ID)
+		if err != nil {
+			return "", err
+		}
+
+		if config.MuteRole == "" {
+			return "", fmt.Errorf("No mute role set up")
+		}
+
+		targetID := templates.TargetUserID(target)
+		if targetID == 0 {
+			return "", fmt.Errorf("Could not convert %T to a user ID", target)
+		}
+
+		member, err := bot.GetMember(ctx.GS.ID, targetID)
+		if err != nil || member == nil {
+			return "", fmt.Errorf("Could not find member")
+		}
+
+		err = MuteUnmuteUser(config, false, ctx.GS.ID, ctx.CurrentFrame.CS, ctx.Msg, ctx.Msg.Author, reason, member, 0)
+		if err != nil {
+			return "", err
+		}
+
+		return "", nil
 	}
 }

--- a/moderation/tmplextensions.go
+++ b/moderation/tmplextensions.go
@@ -1,6 +1,7 @@
 package moderation
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -63,7 +64,7 @@ func tmplMuteUser(ctx *templates.Context) interface{} {
 		}
 
 		if config.MuteRole == "" {
-			return "", fmt.Errorf("No mute role set up")
+			return "", errors.New("No mute role set up")
 		}
 
 		targetID := templates.TargetUserID(target)
@@ -73,7 +74,7 @@ func tmplMuteUser(ctx *templates.Context) interface{} {
 
 		member, err := bot.GetMember(ctx.GS.ID, targetID)
 		if err != nil || member == nil {
-			return "", fmt.Errorf("Could not find member")
+			return "", errors.New("Could not find member")
 		}
 
 		dur, err := common.ParseDuration(duration)
@@ -103,7 +104,7 @@ func tmplUnmuteUser(ctx *templates.Context) interface{} {
 		}
 
 		if config.MuteRole == "" {
-			return "", fmt.Errorf("No mute role set up")
+			return "", errors.New("No mute role set up")
 		}
 
 		targetID := templates.TargetUserID(target)
@@ -113,7 +114,7 @@ func tmplUnmuteUser(ctx *templates.Context) interface{} {
 
 		member, err := bot.GetMember(ctx.GS.ID, targetID)
 		if err != nil || member == nil {
-			return "", fmt.Errorf("Could not find member")
+			return "", errors.New("Could not find member")
 		}
 
 		err = MuteUnmuteUser(config, false, ctx.GS.ID, ctx.CurrentFrame.CS, ctx.Msg, ctx.Msg.Author, reason, member, 0)


### PR DESCRIPTION
Add muteUser and unmuteUser functions as convenience functions for
moderation to the custom command engine.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
