### PR TITLE
frontend: link to Discord statuspage for incidents

### DIFF
--- a/frontend/static/js/spongebob.js
+++ b/frontend/static/js/spongebob.js
@@ -242,6 +242,16 @@ function addAlert(kind, msg, id) {
 	).appendTo("#alerts");
 }
 
+    function addAlertHTML(kind, msg, id) {
+	const alert = $(`<div/>`);
+	if (id !== undefined) alert.prop("id", id)
+	alert.addClass("row").append(
+		$("<div/>").addClass("col-lg-12").append(
+			$("<div/>").addClass("alert alert-" + kind).html(msg)
+		)
+	).appendTo("#alerts");
+}
+
 function clearAlerts() {
 	$("#alerts").empty();
 }

--- a/frontend/static/js/spongebob.js
+++ b/frontend/static/js/spongebob.js
@@ -242,7 +242,7 @@ function addAlert(kind, msg, id) {
 	).appendTo("#alerts");
 }
 
-    function addAlertHTML(kind, msg, id) {
+function addAlertHTML(kind, msg, id) {
 	const alert = $(`<div/>`);
 	if (id !== undefined) alert.prop("id", id)
 	alert.addClass("row").append(

--- a/frontend/templates/cp_main.html
+++ b/frontend/templates/cp_main.html
@@ -161,8 +161,8 @@ $(function(){
     $.getJSON("https://srhpyqt94yxb.statuspage.io/api/v2/incidents/unresolved.json", function(data) {
         if (data.incidents) {
             data.incidents.forEach(function(incident) {
-                const incident_link = `<a href="${incident.shortlink}" target="_blank">${incident.name}</a>`
-                addAlert("warning", `Discord's ${incident.status} an incident: ${incident_link}. Functionality may be limited.`);
+                const incidentLink = `<a href="${incident.shortlink}" target="_blank">${incident.name}</a>`
+                addAlert("warning", `Discord's ${incident.status} an incident: ${incidentLink}. Functionality may be limited.`);
             })
         }
     });

--- a/frontend/templates/cp_main.html
+++ b/frontend/templates/cp_main.html
@@ -162,7 +162,7 @@ $(function(){
         if (data.incidents) {
             data.incidents.forEach(function(incident) {
                 const incidentLink = `<a href="${incident.shortlink}" target="_blank">${incident.name}</a>`
-                addAlert("warning", `Discord's ${incident.status} an incident: ${incidentLink}. Functionality may be limited.`);
+                addAlertHTML("warning", `Discord's ${incident.status} an incident: ${incidentLink}. Functionality may be limited.`);
             })
         }
     });

--- a/frontend/templates/cp_main.html
+++ b/frontend/templates/cp_main.html
@@ -161,7 +161,8 @@ $(function(){
     $.getJSON("https://srhpyqt94yxb.statuspage.io/api/v2/incidents/unresolved.json", function(data) {
         if (data.incidents) {
             data.incidents.forEach(function(incident) {
-                addAlert("warning", "Discord's " + incident.status + " an incident: " + incident.name + ". Functionality may be limited.");
+                const incident_link = "<a href=\"" + incident.shortlink + "\" target=\"_blank\">" + incident.name + "</a>";
+                addAlert("warning", "Discord's " + incident.status + " an incident: " + incident_link + ". Functionality may be limited.");
             })
         }
     });

--- a/frontend/templates/cp_main.html
+++ b/frontend/templates/cp_main.html
@@ -161,8 +161,8 @@ $(function(){
     $.getJSON("https://srhpyqt94yxb.statuspage.io/api/v2/incidents/unresolved.json", function(data) {
         if (data.incidents) {
             data.incidents.forEach(function(incident) {
-                const incident_link = "<a href=\"" + incident.shortlink + "\" target=\"_blank\">" + incident.name + "</a>";
-                addAlert("warning", "Discord's " + incident.status + " an incident: " + incident_link + ". Functionality may be limited.");
+                const incident_link = `<a href="${incident.shortlink}" target="_blank">${incident.name}</a>`
+                addAlert("warning", `Discord's ${incident.status} an incident: ${incident_link}. Functionality may be limited.`);
             })
         }
     });


### PR DESCRIPTION
Link to the relevant incident page when we are forwaring an incident
from Discord on the control panel, so there isn't much left to ask.

Relevant suggestion on the support server:
https://discord.com/channels/166207328570441728/356486960417734666/909083451704115231

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
