### PR TITLE
reminders: Add privacy and cleaner empty reminder response

### DIFF
--- a/reminders/plugin_bot.go
+++ b/reminders/plugin_bot.go
@@ -107,7 +107,7 @@ var cmds = []*commands.YAGCommand{
 			}
 
 			out := "You have no reminders. Create reminders with the `Remindme` command."
-			if currentReminders != nil {
+			if len(currentReminders) > 0 {
 				out = "Your reminders:\n"
 				out += stringReminders(currentReminders, false)
 				out += "\nRemove a reminder with `delreminder/rmreminder (id)` where id is the first number for each reminder above.\nTo clear all reminders, use `delreminder` with the `-a` switch."

--- a/reminders/plugin_bot.go
+++ b/reminders/plugin_bot.go
@@ -90,7 +90,7 @@ var cmds = []*commands.YAGCommand{
 				return nil, err
 			}
 
-			return "Set a reminder in " + durString + " from now (<t:" + tUnix + ":f>)\nView reminders with the `Reminders` command", nil
+			return "Set a reminder in " + durString + " from now (<t:" + tUnix + ":f>)\nView reminders with the `reminders` command", nil
 		},
 	},
 	{
@@ -106,7 +106,7 @@ var cmds = []*commands.YAGCommand{
 				return nil, err
 			}
 
-			out := "You have no reminders. Create reminders with the `Remindme` command."
+			out := "You have no reminders. Create reminders with the `remindme` command."
 			if len(currentReminders) > 0 {
 				out = "Your reminders:\n"
 				out += stringReminders(currentReminders, false)

--- a/reminders/plugin_bot.go
+++ b/reminders/plugin_bot.go
@@ -137,7 +137,7 @@ var cmds = []*commands.YAGCommand{
 				return nil, err
 			}
 			out := "There are no reminders in this channel."
-			if currentReminders != nil {
+			if len(currentReminders) > 0 {
 				out = "Reminders in this channel:\n"
 				out += stringReminders(currentReminders, true)
 				out += "\nRemove a reminder with `delreminder/rmreminder (id)` where id is the first number for each reminder above"

--- a/reminders/plugin_bot.go
+++ b/reminders/plugin_bot.go
@@ -99,6 +99,7 @@ var cmds = []*commands.YAGCommand{
 		Description:         "Lists your active reminders",
 		SlashCommandEnabled: true,
 		DefaultEnabled:      true,
+		IsResponseEphemeral: true,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 			currentReminders, err := GetUserReminders(parsed.Author.ID)
 			if err != nil {
@@ -118,6 +119,7 @@ var cmds = []*commands.YAGCommand{
 		Description:         "Lists reminders in channel, only users with 'manage channel' permissions can use this.",
 		SlashCommandEnabled: true,
 		DefaultEnabled:      true,
+		IsResponseEphemeral: true,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 			ok, err := bot.AdminOrPermMS(parsed.GuildData.GS.ID, parsed.ChannelID, parsed.GuildData.MS, discordgo.PermissionManageChannels)
 			if err != nil {
@@ -152,6 +154,7 @@ var cmds = []*commands.YAGCommand{
 		},
 		SlashCommandEnabled: true,
 		DefaultEnabled:      true,
+		IsResponseEphemeral: true,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 			var reminder Reminder
 

--- a/reminders/plugin_bot.go
+++ b/reminders/plugin_bot.go
@@ -106,12 +106,13 @@ var cmds = []*commands.YAGCommand{
 				return nil, err
 			}
 
-			out := "You have no reminders. Create reminders with the `remindme` command."
-			if len(currentReminders) > 0 {
-				out = "Your reminders:\n"
-				out += stringReminders(currentReminders, false)
-				out += "\nRemove a reminder with `delreminder/rmreminder (id)` where id is the first number for each reminder above.\nTo clear all reminders, use `delreminder` with the `-a` switch."
+			if len(currentReminders) == 0 {
+				return "You have no reminders. Create reminders with the `remindme` command.", nil
 			}
+
+			out := "Your reminders:\n"
+			out += stringReminders(currentReminders, false)
+			out += "\nRemove a reminder with `delreminder/rmreminder (id)` where id is the first number for each reminder above.\nTo clear all reminders, use `delreminder` with the `-a` switch."
 			return out, nil
 		},
 	},
@@ -136,12 +137,14 @@ var cmds = []*commands.YAGCommand{
 			if err != nil {
 				return nil, err
 			}
-			out := "There are no reminders in this channel."
-			if len(currentReminders) > 0 {
-				out = "Reminders in this channel:\n"
-				out += stringReminders(currentReminders, true)
-				out += "\nRemove a reminder with `delreminder/rmreminder (id)` where id is the first number for each reminder above"
+
+			if len(currentReminders) == 0 {
+				return "There are no reminders in this channel.", nil
 			}
+
+			out := "Reminders in this channel:\n"
+			out += stringReminders(currentReminders, true)
+			out += "\nRemove a reminder with `delreminder/rmreminder (id)` where id is the first number for each reminder above"
 			return out, nil
 		},
 	},

--- a/reminders/plugin_bot.go
+++ b/reminders/plugin_bot.go
@@ -106,9 +106,12 @@ var cmds = []*commands.YAGCommand{
 				return nil, err
 			}
 
-			out := "Your reminders:\n"
-			out += stringReminders(currentReminders, false)
-			out += "\nRemove a reminder with `delreminder/rmreminder (id)` where id is the first number for each reminder above.\nTo clear all reminders, use `delreminder` with the `-a` switch."
+			out := "You have no reminders. Create reminders with the `Remindme` command."
+			if currentReminders != nil {
+				out = "Your reminders:\n"
+				out += stringReminders(currentReminders, false)
+				out += "\nRemove a reminder with `delreminder/rmreminder (id)` where id is the first number for each reminder above.\nTo clear all reminders, use `delreminder` with the `-a` switch."
+			}
 			return out, nil
 		},
 	},
@@ -133,10 +136,12 @@ var cmds = []*commands.YAGCommand{
 			if err != nil {
 				return nil, err
 			}
-
-			out := "Reminders in this channel:\n"
-			out += stringReminders(currentReminders, true)
-			out += "\nRemove a reminder with `delreminder/rmreminder (id)` where id is the first number for each reminder above"
+			out := "There are no reminders in this channel."
+			if currentReminders != nil {
+				out = "Reminders in this channel:\n"
+				out += stringReminders(currentReminders, true)
+				out += "\nRemove a reminder with `delreminder/rmreminder (id)` where id is the first number for each reminder above"
+			}
 			return out, nil
 		},
 	},


### PR DESCRIPTION
Based on unofficial suggestion here https://discord.com/channels/166207328570441728/525535451839463424/1132563547864440922 This pr changes some reminder commands to give ephemeral responses when used with the slash command. `reminders`, `creminders`, and `delreminder` are now ephemeral to respect user privacy. The `remindme` command was intentionally left out, hopefully to remind users that their reminders can not, and will not be ephemeral. I considered adding an additional notice to the `reminders` command illustrating this, would love to hear thoughts on the matter.

Additionally, it adds a response to `reminders` and `creminders` for when no reminders are found, as opposed to the current version which sends the prefixed and affixed messages with empty space in between.

Draft because I cannot test w/ my self host for a few days, want to double check for any unintended consequences.