### PR TITLE
lib/discordgo: add activity to message struct

### DIFF
--- a/lib/discordgo/message.go
+++ b/lib/discordgo/message.go
@@ -153,6 +153,8 @@ type Message struct {
 	// This means responses to message component interactions do not include this property,
 	// instead including a MessageReference, as components exist on preexisting messages.
 	Interaction *MessageInteraction `json:"interaction"`
+
+	Activity *MessageActivity `json:"activity"`
 }
 
 func (m *Message) GetGuildID() int64 {

--- a/lib/discordgo/structs.go
+++ b/lib/discordgo/structs.go
@@ -746,6 +746,12 @@ type Assets struct {
 	SmallText    string `json:"small_text,omitempty"`
 }
 
+// A MessageActivity represents the activity sent with a message, such as a game invite.
+type MessageActivity struct {
+	Type    int    `json:"type"`
+	PartyID string `json:"party_id"`
+}
+
 // A Member stores user information for Guild members. A guild
 // member represents a certain user's presence in a guild.
 type Member struct {


### PR DESCRIPTION
Add a new MessageActivity type to the Message struct.
This MessageActivity type represents the activity sent with a message,
commonly referred to as an invite to a game session and such.

This is a suggestion on the support server, found here:
https://discord.com/channels/166207328570441728/356486960417734666/1125192216650977360

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
