### PR TITLE
evalcc: Bypass dcmd argument parsing

### DIFF
--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -156,7 +156,7 @@ var cmdEvalCommand = &commands.YAGCommand{
 		ctx := templates.NewContext(data.GuildData.GS, channel, data.GuildData.MS)
 		ctx.IsExecedByEvalCC = true
 
-		code := common.ParseCodeblock(data.Args[0].Str())
+		code := common.ParseCodeblock(data.TraditionalTriggerData.MessageStrippedPrefix)
 
 		// Encourage only small code snippets being tested with this command
 		maxRunes := 1000

--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -156,6 +156,8 @@ var cmdEvalCommand = &commands.YAGCommand{
 		ctx := templates.NewContext(data.GuildData.GS, channel, data.GuildData.MS)
 		ctx.IsExecedByEvalCC = true
 
+		// Access stripped message directly, so Dcmd argument parsing can't mess with the user's code
+		// code := common.ParseCodeblock(data.Args[0].Str())
 		code := common.ParseCodeblock(data.TraditionalTriggerData.MessageStrippedPrefix)
 
 		// Encourage only small code snippets being tested with this command

--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -156,8 +156,9 @@ var cmdEvalCommand = &commands.YAGCommand{
 		ctx := templates.NewContext(data.GuildData.GS, channel, data.GuildData.MS)
 		ctx.IsExecedByEvalCC = true
 
-		// Access stripped message directly, so Dcmd argument parsing can't mess with the user's code
-		// code := common.ParseCodeblock(data.Args[0].Str())
+		// use stripped message content instead of parsed arg data to avoid dcmd
+		// from misinterpreting backslashes and losing spaces in input; see
+		// https://github.com/botlabs-gg/yagpdb/pull/1547
 		code := common.ParseCodeblock(data.TraditionalTriggerData.MessageStrippedPrefix)
 
 		// Encourage only small code snippets being tested with this command


### PR DESCRIPTION
This PR addresses issues noted here: https://discord.com/channels/166207328570441728/871323274066407454/1131615601937371177 and here: https://discord.com/channels/166207328570441728/525535451839463424/1132267904033894451, where Dcmd is messing with the sender's snippet while parsing the argument. The two examples I've seen so far are with backslash tokens and container trimming. Summary to my understanding:

Evaluating `{{ "\s" }}` with evalcc fails for "invalid syntax," which makes sense because `\s` is not a valid character. However, when trying to escape the backslash, with `{{ "\\s" }}`, the intended output would be a string that reads "\s", however again this fails due to invalid syntax. Evidently yag is still attempting to evaluate `\s` despite the attempts to escape the backslash. I don't have any satisfactory hypothesis around why this happens, however I can confidently blame dcmd, as this issue does not occur with this pr.
Demonstrated in the following screenshot: Current behaviour of evalcc evaluating `{{ "\\s" }}`, followed by intended behaviour as demonstrated by a proper CC execution, and finally demonstration of evalcc's behaviour after this pr.
<img width="957" alt="Screenshot 2023-07-27 at 9 17 42 PM" src="https://github.com/botlabs-gg/yagpdb/assets/110698921/3965e250-abdd-4283-92b6-3adc0291dfd5">
(I've edited the screenshot to add backticks since the commands was not clear otherwise)

Evaluating `{{ len " 123" }}` with evalcc, a string that should be 4 characters long, returns 3. Same when using backticks instead of quotes. Dcmd appears to be trimming leading whitespace of stings inside of containers. The issue that was caught was when trying to use math commands, the functions would accept strings with spaces prefixed to the numbers, ex: `{{ add " 1" " 2" }}` returns 3. If working properly, `tmplToInt` would have evaluated each number with leading whitespace as `0`.
Demonstrated in the following screenshot: Current behaviour of evalcc evaluating `{{ len " 123" }}` (and equivalent with backticks), followed by intended behaviour as demonstrated by a proper CC execution, and finally demonstration of evalcc's behaviour after this pr.
<img width="486" alt="Screenshot 2023-07-27 at 17 47 09" src="https://github.com/botlabs-gg/yagpdb/assets/110698921/4dd93532-c848-4f30-989f-60fa0d221512">

To avoid Dcmd messing with the code input, to preserve the original message for a more accurate evaluation, this pr switches from using the parsed string argument to the `MessageStrippedPrefix` from the trigger data. This grabs the message before the arguments get parsed, but just after slicing off the trigger, so it will still work regardless of prefix length, or if a mention trigger was used. This will fail if evalcc is used as a slash command, however I don't anticipate that happening anytime soon.