### PR TITLE
autorole: add option to ignore bots

### DIFF
--- a/autorole/assets/autorole.html
+++ b/autorole/assets/autorole.html
@@ -54,6 +54,9 @@
                         <div class="form-group">
                             {{checkbox "AssignRoleAfterScreening" "AssignRoleAfterScreening" `Only assign the role after a member has completed Discord's Membership Screening` .Autorole.AssignRoleAfterScreening}}
                         </div>
+                        <div class="form-group">
+                            {{checkbox "IgnoreBots" "IgnoreBots" `Ignore bots` .Autorole.IgnoreBots}}
+                        <div>
                         <br/>
                         <button type="submit" class="btn btn-success btn-lg btn-block">Save</button>
                     </div>

--- a/autorole/autorole.go
+++ b/autorole/autorole.go
@@ -40,6 +40,7 @@ type GeneralConfig struct {
 	IgnoreRoles              []int64 `valid:"role,true"`
 	OnlyOnJoin               bool
 	AssignRoleAfterScreening bool
+	IgnoreBots               bool
 }
 
 const (


### PR DESCRIPTION
Add an option to ignore bots from autorole assignment. This is a really
popular suggestion on the support server -- link below.

https://discord.com/channels/166207328570441728/356486960417734666/992525415405072414

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

----
P.S.: I'm not sure if this patch is good as-is; I tried to follow the
currently existing control flow by just adding the required check
where-ever similar control structures are present.

Local testing confirm it is working (though I did not test with
membership screening).
