### PR TITLE
custom commands: Trim whitespace on response before character count validation

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -418,6 +418,9 @@ func (c *Context) newContextFrame(cs *dstate.ChannelState) *ContextFrame {
 func (c *Context) ExecuteAndSendWithErrors(source string, channelID int64) error {
 	out, err := c.Execute(source)
 
+	// trim whitespace for accurate character count
+	out = strings.TrimSpace(out)
+
 	if utf8.RuneCountInString(out) > 2000 {
 		out = "Template output for " + c.Name + " was longer than 2k (contact an admin on the server...)"
 	}

--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -859,6 +859,9 @@ func ExecuteCustomCommand(cmd *models.CustomCommand, tmplCtx *templates.Context)
 	chanMsg := cmd.Responses[rand.Intn(len(cmd.Responses))]
 	out, err := tmplCtx.Execute(chanMsg)
 
+	// trim whitespace for accurate character count
+	out = strings.TrimSpace(out)
+
 	if utf8.RuneCountInString(out) > 2000 {
 		out = "Custom command (#" + discordgo.StrID(cmd.LocalID) + ") response was longer than 2k (contact an admin on the server...)"
 	}


### PR DESCRIPTION
This pr simply trims leading and trailing whitespace from custom command response before validating the character count. Since Discord would do this anyways, leading and trailing whitespace does not count towards it's 2000 character limit, and therefore imo should not throw an error for response length.

Of course it is still good practice for users to trim space within the code itself, especially when printing to the response within a `range` function, or even simply in multiple lines along the code.

I understand that this pr may encourage some users to learn bad habits and not trim their own whitespace when using `range`, however I believe it is already difficult for users to understand the concept of the `range` function generating whitespaces since, as aforementioned, Discord trims leading and trailing whitespace in the message, and the users are never actually able to see it. I feel like it is confusing that the following code runs fine, and produces a message with 6 characters:
<img width="676" alt="Screenshot 2023-08-14 at 22 46 35" src="https://github.com/botlabs-gg/yagpdb/assets/110698921/16baf756-9eac-406b-89b6-65cf027be04c">

meanwhile this code, seemingly out of nowhere has a response length of >2k:
<img width="714" alt="Screenshot 2023-08-14 at 22 46 46" src="https://github.com/botlabs-gg/yagpdb/assets/110698921/4c6aacd2-d022-4832-a4d6-fe48e7619f69">

But now with this pr:
<img width="663" alt="Screenshot 2023-08-14 at 22 47 21" src="https://github.com/botlabs-gg/yagpdb/assets/110698921/a317f714-f775-4354-8d02-455fcf83b1ce">

For these reasons, I believe that this pr will increase consistency and accuracy of the response length error, and these qualities are worth pursuing, even if it means handholding the user a little more.