### PR TITLE
lib/{dstate,discordgo}: add Banner to Guild struct

### DIFF
--- a/lib/discordgo/endpoints.go
+++ b/lib/discordgo/endpoints.go
@@ -39,6 +39,7 @@ var (
 	EndpointCDNIcons        string
 	EndpointCDNSplashes     string
 	EndpointCDNChannelIcons string
+	EndpointCDNBanners      string
 
 	EndpointAuth           string
 	EndpointLogin          string
@@ -90,18 +91,20 @@ var (
 	EndpointGuildIntegrationSync = func(gID, iID int64) string {
 		return ""
 	}
-	EndpointGuildRoles        = func(gID int64) string { return "" }
-	EndpointGuildRole         = func(gID, rID int64) string { return "" }
-	EndpointGuildInvites      = func(gID int64) string { return "" }
-	EndpointGuildEmbed        = func(gID int64) string { return "" }
-	EndpointGuildPrune        = func(gID int64) string { return "" }
-	EndpointGuildIcon         = func(gID int64, hash string) string { return "" }
-	EndpointGuildIconAnimated = func(gID int64, hash string) string { return "" }
-	EndpointGuildSplash       = func(gID int64, hash string) string { return "" }
-	EndpointGuildWebhooks     = func(gID int64) string { return "" }
-	EndpointGuildAuditLogs    = func(gID int64) string { return "" }
-	EndpointGuildEmojis       = func(gID int64) string { return "" }
-	EndpointGuildEmoji        = func(gID, eID int64) string { return "" }
+	EndpointGuildRoles          = func(gID int64) string { return "" }
+	EndpointGuildRole           = func(gID, rID int64) string { return "" }
+	EndpointGuildInvites        = func(gID int64) string { return "" }
+	EndpointGuildEmbed          = func(gID int64) string { return "" }
+	EndpointGuildPrune          = func(gID int64) string { return "" }
+	EndpointGuildIcon           = func(gID int64, hash string) string { return "" }
+	EndpointGuildIconAnimated   = func(gID int64, hash string) string { return "" }
+	EndpointGuildSplash         = func(gID int64, hash string) string { return "" }
+	EndpointGuildWebhooks       = func(gID int64) string { return "" }
+	EndpointGuildAuditLogs      = func(gID int64) string { return "" }
+	EndpointGuildEmojis         = func(gID int64) string { return "" }
+	EndpointGuildEmoji          = func(gID, eID int64) string { return "" }
+	EndpointGuildBanner         = func(gID int64, hash string) string { return "" }
+	EndpointGuildBannerAnimated = func(gID int64, hash string) string { return "" }
 
 	EndpointChannel                   = func(cID int64) string { return "" }
 	EndpointChannelPermissions        = func(cID int64) string { return "" }
@@ -209,6 +212,7 @@ func CreateEndpoints(base string) {
 	EndpointCDNIcons = EndpointCDN + "icons/"
 	EndpointCDNSplashes = EndpointCDN + "splashes/"
 	EndpointCDNChannelIcons = EndpointCDN + "channel-icons/"
+	EndpointCDNBanners = EndpointCDN + "banners/"
 
 	EndpointAuth = EndpointAPI + "auth/"
 	EndpointLogin = EndpointAuth + "login"
@@ -276,6 +280,8 @@ func CreateEndpoints(base string) {
 	EndpointGuildAuditLogs = func(gID int64) string { return EndpointGuilds + StrID(gID) + "/audit-logs" }
 	EndpointGuildEmojis = func(gID int64) string { return EndpointGuilds + StrID(gID) + "/emojis" }
 	EndpointGuildEmoji = func(gID, eID int64) string { return EndpointGuilds + StrID(gID) + "/emojis/" + StrID(eID) }
+	EndpointGuildBanner = func(gID int64, hash string) string { return EndpointCDNBanners + StrID(gID) + "/" + hash + ".png" }
+	EndpointGuildBannerAnimated = func(gID int64, hash string) string { return EndpointCDNBanners + StrID(gID) + "/" + hash + ".gif" }
 
 	EndpointChannel = func(cID int64) string { return EndpointChannels + StrID(cID) }
 	EndpointChannelPermissions = func(cID int64) string { return EndpointChannels + StrID(cID) + "/permissions" }

--- a/lib/discordgo/structs.go
+++ b/lib/discordgo/structs.go
@@ -363,6 +363,8 @@ type Guild struct {
 
 	Description string `json:"description"`
 
+	Banner string `json:"banner"`
+
 	PreferredLocale string `json:"preferred_locale"`
 
 	// The hash of the guild's icon. Use Session.GuildIcon

--- a/lib/dstate/helpers.go
+++ b/lib/dstate/helpers.go
@@ -181,6 +181,7 @@ func GuildStateFromDgo(guild *discordgo.Guild) *GuildState {
 		Region:                      guild.Region,
 		Name:                        guild.Name,
 		Icon:                        guild.Icon,
+		Banner:                      guild.Banner,
 		Description:                 guild.Description,
 		PreferredLocale:             guild.PreferredLocale,
 		AfkChannelID:                guild.AfkChannelID,

--- a/lib/dstate/interface.go
+++ b/lib/dstate/interface.go
@@ -162,6 +162,25 @@ func (gs *GuildSet) IconURL(size string) string {
 	return url
 }
 
+func (gs *GuildSet) BannerURL(size string) string {
+	var url string
+	if gs.Banner == "" {
+		return ""
+	}
+
+	if strings.HasPrefix(gs.Banner, "a_") {
+		url = discordgo.EndpointGuildBannerAnimated(gs.ID, gs.Banner)
+	} else {
+		url = discordgo.EndpointGuildBanner(gs.ID, gs.Banner)
+	}
+
+	if size != "" {
+		url += "?size=" + size
+	}
+
+	return url
+}
+
 type GuildState struct {
 	ID          int64  `json:"id,string"`
 	Available   bool   `json:"available"`
@@ -170,6 +189,7 @@ type GuildState struct {
 	Region      string `json:"region"`
 	Name        string `json:"name"`
 	Icon        string `json:"icon"`
+	Banner      string `json:"banner"`
 
 	Description string `json:"description"`
 


### PR DESCRIPTION
Add the Banner field to discordgo.Guild and dstate.GuildSet structs,
thus exposing them to custom commands.
Furthermore add a BannerURL method on dstate.GuildSet, returning the
appropriate URL (animated/static) to the Banner.

A relevant suggestion can be found here:
https://canary.discord.com/channels/166207328570441728/356486960417734666/992995802093981726

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
