### PR TITLE
customcommands: properly cap multi queries at 100

### DIFF
--- a/customcommands/tmplextensions.go
+++ b/customcommands/tmplextensions.go
@@ -509,6 +509,11 @@ func tmplDBGetPattern(ctx *templates.Context, inverse bool) interface{} {
 		if amount > 100 {
 			amount = 100
 		}
+		// LIMIT 0 essentially means LIMIT ALL, or no limit at all.
+		// Make sure we actually cap it at the max documented limit.
+		if amount == 0 {
+			amount = 100
+		}
 
 		keyStr := limitString(templates.ToString(pattern), 256)
 		results, err := models.TemplatesUserDatabases(
@@ -569,6 +574,12 @@ func tmplDBDelMultiple(ctx *templates.Context) interface{} {
 		if amount > 100 {
 			amount = 100
 		}
+		// LIMIT 0 essentially means LIMIT ALL, or no limit at all.
+		// Make sure we actually cap it at the max documented limit.
+		if amount == 0 {
+			amount = 100
+		}
+
 		skip := int(templates.ToInt64(iSkip))
 		orderby := "value_num DESC, id DESC"
 		if q.Reverse {
@@ -744,6 +755,12 @@ func tmplDBTopEntries(ctx *templates.Context, bottom bool) interface{} {
 		amount := int(templates.ToInt64(iAmount))
 		skip := int(templates.ToInt64(iSkip))
 		if amount > 100 {
+			amount = 100
+		}
+
+		// LIMIT 0 essentially means LIMIT ALL, or no limit at all.
+		// Make sure we actually cap it at the max documented limit.
+		if amount == 0 {
 			amount = 100
 		}
 


### PR DESCRIPTION
Properly cap multiple database interactions at the documented maximum of
100 affected entries.

Without this change, Custom command code such as the following would be
able to circumvent the documented max limit of affected entries:
```
{{ dbDelMultiple [...] 0 0 }}
```
This code would affect as many entries as are matching defined by the
(for brevity omitted) query argument to this and related functions.

Clearly this is a bug — We deliberately limit interactions with the
custom commands database to *at most* 100 entries at a time, users being
able to bypass this is at best a simple oversight, at worst able to
bring the bot down due to high database load.

As for why/how this works, from the PostgreSQL documentation:
> If a limit count is given, no more than that many rows will be
> returned (but possibly fewer, if the query itself yields fewer rows).
> LIMIT ALL is the same as omitting the LIMIT clause, as is LIMIT with
> a NULL argument.
https://www.postgresql.org/docs/current/queries-limit.html

Essentially, this means `LIMIT 0` is the same as `LIMIT ALL`, or no
limit whatsoever. Obviously this isn't intended behaviour, as explained
above.

This change has a somewhat high priority, seeing as there is a potential
to maybe bring the bot down, or at least make it lagging due to high
database load.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
