### PR TITLE
cc/web: grey out trigger on edit toggle if not premium

### DIFF
--- a/customcommands/assets/customcommands-editcmd.html
+++ b/customcommands/assets/customcommands-editcmd.html
@@ -152,7 +152,9 @@
                                                     value="{{.CC.TextTrigger}}">
                                             </div>
                                             {{checkbox "case_sensitive" "case_sensitive" "Case Sensitive?" .CC.TextTriggerCaseSensitive}}
-                                            {{checkbox "trigger_on_edit" "trigger_on_edit" "Trigger on edits? (Premium Only!)" .CC.TriggerOnEdit}}
+                                            {{$disabledClass := ""}}
+                                            {{if not .IsGuildPremium}}{{$disabledClass = "disabled"}}{{end}}
+                                            {{checkbox "trigger_on_edit" "trigger_on_edit" "Trigger on edits? (Premium Only!)" .CC.TriggerOnEdit $disabledClass}}
                                         </div>
                                     </div>
                                 </div>

--- a/customcommands/web.go
+++ b/customcommands/web.go
@@ -152,6 +152,7 @@ func handleGetCommand(w http.ResponseWriter, r *http.Request) (web.TemplateData,
 
 	templateData["CC"] = cc
 	templateData["Commands"] = true
+	templateData["IsGuildPremium"] = premium.ContextPremium(r.Context())
 
 	return serveGroupSelected(r, templateData, cc.GroupID.Int64, activeGuild.ID)
 }

--- a/frontend/static/css/custom.css
+++ b/frontend/static/css/custom.css
@@ -517,6 +517,10 @@ html.dark select optgroup {
           transform: rotateY(20deg);
 }
 
+.tgl:disabled~.tgl-btn, .tgl:disabled~.tgl-desc {
+  opacity: .5;
+}
+
 /* UNSAVED CHANGES POPUP */
 #unsaved-changes-popup{
   position: fixed;

--- a/web/template.go
+++ b/web/template.go
@@ -305,7 +305,7 @@ func tmplCheckbox(name, id, description string, checked bool, extraInputAttrs ..
 	}
 	builder.WriteString(`><label for="` + id + `" class="tgl-btn mb-2"></label>`)
 	// builder.WriteString(`><div class="switch"></div>`)
-	builder.WriteString(`<span class="ml-2 mb-2">` + description + `</span></div>`)
+	builder.WriteString(`<span class="tgl-desc ml-2 mb-2">` + description + `</span></div>`)
 	// builder.WriteString(`</div>`)
 
 	return template.HTML(builder.String())


### PR DESCRIPTION
Grey out the trigger on edit checkbox on non-premium servers. The backend already does this; I just thought it might be nice to have an additional visual cue.

Appearance on dark and light mode respectively:
![dark mode appearance](https://github.com/botlabs-gg/yagpdb/assets/56809242/15ae0756-d32e-4c4d-bdcb-1d6dc0430c00)
![light mode appearance](https://github.com/botlabs-gg/yagpdb/assets/56809242/a33f18d1-603a-4a10-97b3-7f7ec3f40b20)