### PR TITLE
discordgo: correct default avatar URLs

### DIFF
--- a/lib/discordgo/endpoints.go
+++ b/lib/discordgo/endpoints.go
@@ -124,7 +124,7 @@ var (
 	EndpointWebhook         = func(wID int64) string { return "" }
 	EndpointWebhookToken    = func(wID int64, token string) string { return "" }
 
-	EndpointDefaultUserAvatar = func(uDiscriminator string) string { return "" }
+	EndpointDefaultUserAvatar = func(index int) string { return "" }
 
 	EndpointMessageReactionsAll = func(cID, mID int64) string { return "" }
 	EndpointMessageReactions    = func(cID, mID int64, emoji EmojiName) string {
@@ -301,9 +301,8 @@ func CreateEndpoints(base string) {
 	EndpointWebhook = func(wID int64) string { return EndpointWebhooks + StrID(wID) }
 	EndpointWebhookToken = func(wID int64, token string) string { return EndpointWebhooks + StrID(wID) + "/" + token }
 
-	EndpointDefaultUserAvatar = func(uDiscriminator string) string {
-		uDiscriminatorInt, _ := strconv.Atoi(uDiscriminator)
-		return EndpointCDN + "embed/avatars/" + strconv.Itoa(uDiscriminatorInt%5) + ".png"
+	EndpointDefaultUserAvatar = func(index int) string {
+		return EndpointCDN + "embed/avatars/" + strconv.Itoa(index) + ".png"
 	}
 
 	EndpointMessageReactionsAll = func(cID, mID int64) string {


### PR DESCRIPTION
In introducing the new username system, Discord also switched to a different indexing scheme for default avatar URLs. In particular, per https://discord.com/developers/docs/reference#image-formatting-cdn-endpoints:

> For users on the new username system, `index` will be `(user_id >> 22) % 6`.

This PR thus adjusts `User.AvatarURL` to account for this, aligning the output of `User.AvatarURL` with what is displayed on Discord.