### PR TITLE
Adding "self_video" and "self_video" to VoiceState in structs.go

### DIFF
--- a/lib/discordgo/structs.go
+++ b/lib/discordgo/structs.go
@@ -565,17 +565,17 @@ func (r Roles) Swap(i, j int) {
 
 // A VoiceState stores the voice states of Guilds
 type VoiceState struct {
-	UserID    int64  `json:"user_id,string"`
-	SessionID string `json:"session_id"`
-	ChannelID int64  `json:"channel_id,string"`
-	GuildID   int64  `json:"guild_id,string"`
-	Suppress  bool   `json:"suppress"`
-	SelfMute  bool   `json:"self_mute"`
-	SelfDeaf  bool   `json:"self_deaf"`
-	Mute      bool   `json:"mute"`
-	Deaf      bool   `json:"deaf"`
-	SelfStream      bool   `json:"self_stream"`
-	SelfVideo     bool   `json:"self_video"`
+	UserID     int64  `json:"user_id,string"`
+	SessionID  string `json:"session_id"`
+	ChannelID  int64  `json:"channel_id,string"`
+	GuildID    int64  `json:"guild_id,string"`
+	Suppress   bool   `json:"suppress"`
+	SelfMute   bool   `json:"self_mute"`
+	SelfDeaf   bool   `json:"self_deaf"`
+	Mute       bool   `json:"mute"`
+	Deaf       bool   `json:"deaf"`
+	SelfStream bool   `json:"self_stream"`
+	SelfVideo  bool   `json:"self_video"`
 }
 
 // A Presence stores the online, offline, or idle and game status of Guild members.

--- a/lib/discordgo/structs.go
+++ b/lib/discordgo/structs.go
@@ -574,6 +574,8 @@ type VoiceState struct {
 	SelfDeaf  bool   `json:"self_deaf"`
 	Mute      bool   `json:"mute"`
 	Deaf      bool   `json:"deaf"`
+	Live      bool   `json:"self_stream"`
+	Video     bool   `json:"self_video"`
 }
 
 // A Presence stores the online, offline, or idle and game status of Guild members.

--- a/lib/discordgo/structs.go
+++ b/lib/discordgo/structs.go
@@ -574,8 +574,8 @@ type VoiceState struct {
 	SelfDeaf  bool   `json:"self_deaf"`
 	Mute      bool   `json:"mute"`
 	Deaf      bool   `json:"deaf"`
-	Live      bool   `json:"self_stream"`
-	Video     bool   `json:"self_video"`
+	SelfStream      bool   `json:"self_stream"`
+	SelfVideo     bool   `json:"self_video"`
 }
 
 // A Presence stores the online, offline, or idle and game status of Guild members.


### PR DESCRIPTION
Currently it is not possible for the user to retrieve **camera** or **go-live activity** in a guild's voice channel (by using **.Guild.VoiceStates**), although discord allows this as documented [here](https://discord.com/developers/docs/resources/voice#voice-state-object).
This PR should  fix that.
