### PR TITLE
readme: get rid of diffstat artefact

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ There are two ways of selfhosting this bot: [standalone](#Hosting-Standalone), o
 
 Directions on creating an app and getting credentials may be found
 [here](https://github.com/reactiflux/discord-irc/wiki/Creating-a-discord-bot-&-getting-a-token).
-	@@ -37,129 +36,82 @@ via the Control Panel.
+
+YAGPDB does not require you to authorize the bot: all of that will be handled
+via the Control Panel.
 
 In addition, you will need to add the following urls to the bot's "REDIRECT URI(S)" configuration:
 


### PR DESCRIPTION
Get rid of the diffstat artefact introduced in 8ce2df141c00, restoring
the original text on that line.

The mentioned commit introduced some diffstat artefacts, hiding the
original text, presumably due to some copy-paste mistakes (they can
happen, no worries).

Thanks to git being very cool with regards to storing history, I was
able to restore the original text that was there. Kinda weird that
nobody bothered to fix it so far.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
