### PR TITLE
readme: bump Go version req to ^1.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ docker-compose -f yagpdb/yagpdb_docker/docker-compose.dev.yml up
 
 #### Requirements
 
-* Golang 1.16 or above
+* Golang 1.20 or above
 * PostgreSQL 9.6 or later
 * Redis version 5.x or later
 


### PR DESCRIPTION
Bump the minimum required Go version to ^1.20, as per `go.mod`:

https://github.com/botlabs-gg/yagpdb/blob/60fb9d292843bdac0cadbbf53accac42a7f77eaf/go.mod#L3

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
