### PR TITLE
Increase the maximum time for a temporary role duration to 400 days

### DIFF
--- a/rolecommands/assets/rolecommands.html
+++ b/rolecommands/assets/rolecommands.html
@@ -272,7 +272,7 @@
                     <div class="row">
                         <div class="form-group col-lg-4">
                             <label for="group-temporary-role">Temporary roles (minutes)</label>
-                            <input type="number" min="0" max="1440" class="form-control" id="group-temporary-role"
+                            <input type="number" min="0" max="576000" class="form-control" id="group-temporary-role"
                                 name="TemporaryRoleDuration" value="{{.Group.TemporaryRoleDuration}}">
                             <p class="help-block">Remove roles in this group after a certain duration after assignment
                                 (0 to disable)</p>

--- a/rolecommands/web.go
+++ b/rolecommands/web.go
@@ -62,7 +62,7 @@ type FormGroup struct {
 
 	SingleAutoToggleOff   bool
 	SingleRequireOne      bool
-	TemporaryRoleDuration int `valid:"0,1440"`
+	TemporaryRoleDuration int `valid:"0,576000"`
 }
 
 func (p *Plugin) InitWeb() {


### PR DESCRIPTION
Motivation: We have a server for which we would like members to agree to a code of conduct in order to access most channels, and have them recommit to that agreement every 60 days. The role assignment and channel access control is working fine as per [this tutorial](https://docs.yagpdb.xyz/tools-and-utilities/self-assignable-roles). The simplest way to implement the 60-day requirement would be to use the "Temporary role duration" setting, however, that is limited to 1440 minutes (24 hours).

This PR changes the limit to 576000 minutes (400 days).

TemporaryRoleDuration is an `int` (at least 32 bits), and is used as `time.Duration(temporaryDuration)*time.Minute`. The underlying type of [`time.Duration`](https://pkg.go.dev/time#Duration) is an `int64` measured in nanoseconds, and [`time.Time`](https://cs.opensource.google/go/go/+/refs/tags/go1.21.0:src/time/time.go;l=129) has a 33-bit seconds field, so this cannot introduce any possibility of overflow. The scheduled event is already persistent and should survive a server restart.