### PR TITLE
reddit spoiler usage toggle

### DIFF
--- a/reddit/assets/reddit.html
+++ b/reddit/assets/reddit.html
@@ -82,6 +82,7 @@
                 </div>{{end}}
             </div>
 
+            {{checkbox "spoilers_enabled" (printf "format-new-slow-%t" .Slow) `Spoilers enabled<small class="ml-2">(On Reddit posts marked as spoilers)</small>` true}}
             {{checkbox "use_embeds" (printf "format-new-slow-%t" .Slow) `Use embeds<small class="ml-2">(Videos won't be attached, but just linked)</small>` true}}
 
             <button type="submit" class="btn btn-success">Add</button>
@@ -129,6 +130,10 @@
         </div>
         <div class="col-lg">
             <div class="form-row">
+                <div class="col d-flex flex-column">
+                    <Span class="mb-2">Enable Spoilers</span>
+                    {{checkbox "spoilers_enabled" (joinStr "" "format-" .ID) `` .SpoilersEnabled}}
+                </div>
                 <div class="col d-flex flex-column">
                     <Span class="mb-2">Use embed</span>
                     {{checkbox "use_embeds" (joinStr "" "format-" .ID) `` .UseEmbeds}}

--- a/reddit/models/reddit_feeds.go
+++ b/reddit/models/reddit_feeds.go
@@ -28,6 +28,7 @@ type RedditFeed struct {
 	ChannelID  int64  `boil:"channel_id" json:"channel_id" toml:"channel_id" yaml:"channel_id"`
 	Subreddit  string `boil:"subreddit" json:"subreddit" toml:"subreddit" yaml:"subreddit"`
 	FilterNSFW int    `boil:"filter_nsfw" json:"filter_nsfw" toml:"filter_nsfw" yaml:"filter_nsfw"`
+	SpoilersEnabled bool    `boil:"spoilers_enabled" json:"spoilers_enabled" toml:"spoilers_enabled" yaml:"spoilers_enabled"`
 	MinUpvotes int    `boil:"min_upvotes" json:"min_upvotes" toml:"min_upvotes" yaml:"min_upvotes"`
 	UseEmbeds  bool   `boil:"use_embeds" json:"use_embeds" toml:"use_embeds" yaml:"use_embeds"`
 	Slow       bool   `boil:"slow" json:"slow" toml:"slow" yaml:"slow"`
@@ -43,6 +44,7 @@ var RedditFeedColumns = struct {
 	ChannelID  string
 	Subreddit  string
 	FilterNSFW string
+	SpoilersEnabled string
 	MinUpvotes string
 	UseEmbeds  string
 	Slow       string
@@ -53,6 +55,7 @@ var RedditFeedColumns = struct {
 	ChannelID:  "channel_id",
 	Subreddit:  "subreddit",
 	FilterNSFW: "filter_nsfw",
+	SpoilersEnabled: "spoilers_enabled",
 	MinUpvotes: "min_upvotes",
 	UseEmbeds:  "use_embeds",
 	Slow:       "slow",
@@ -103,6 +106,7 @@ var RedditFeedWhere = struct {
 	ChannelID  whereHelperint64
 	Subreddit  whereHelperstring
 	FilterNSFW whereHelperint
+	SpoilersEnabled whereHelperbool
 	MinUpvotes whereHelperint
 	UseEmbeds  whereHelperbool
 	Slow       whereHelperbool
@@ -113,6 +117,7 @@ var RedditFeedWhere = struct {
 	ChannelID:  whereHelperint64{field: "\"reddit_feeds\".\"channel_id\""},
 	Subreddit:  whereHelperstring{field: "\"reddit_feeds\".\"subreddit\""},
 	FilterNSFW: whereHelperint{field: "\"reddit_feeds\".\"filter_nsfw\""},
+	SpoilersEnabled: whereHelperbool{field: "\"reddit_feeds\".\"spoilers_enabled\""},
 	MinUpvotes: whereHelperint{field: "\"reddit_feeds\".\"min_upvotes\""},
 	UseEmbeds:  whereHelperbool{field: "\"reddit_feeds\".\"use_embeds\""},
 	Slow:       whereHelperbool{field: "\"reddit_feeds\".\"slow\""},
@@ -136,8 +141,8 @@ func (*redditFeedR) NewStruct() *redditFeedR {
 type redditFeedL struct{}
 
 var (
-	redditFeedAllColumns            = []string{"id", "guild_id", "channel_id", "subreddit", "filter_nsfw", "min_upvotes", "use_embeds", "slow", "disabled"}
-	redditFeedColumnsWithoutDefault = []string{"guild_id", "channel_id", "subreddit", "filter_nsfw", "min_upvotes", "use_embeds", "slow"}
+	redditFeedAllColumns            = []string{"id", "guild_id", "channel_id", "subreddit", "filter_nsfw", "spoilers_enabled", "min_upvotes", "use_embeds", "slow", "disabled"}
+	redditFeedColumnsWithoutDefault = []string{"guild_id", "channel_id", "subreddit", "filter_nsfw", "spoilers_enabled", "min_upvotes", "use_embeds", "slow"}
 	redditFeedColumnsWithDefault    = []string{"id", "disabled"}
 	redditFeedPrimaryKeyColumns     = []string{"id"}
 )

--- a/reddit/schema.go
+++ b/reddit/schema.go
@@ -21,4 +21,5 @@ CREATE INDEX IF NOT EXISTS redidt_feeds_subreddit_idx ON reddit_feeds(subreddit)
 
 `, `
 ALTER TABLE reddit_feeds ADD COLUMN IF NOT EXISTS disabled BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE reddit_feeds ADD COLUMN IF NOT EXISTS spoilers_enabled BOOLEAN NOT NULL DEFAULT TRUE;
 `}


### PR DESCRIPTION
This pr adds a toggle to enable wrapping reddit posts in spoilers, as suggested in [suggestion #2022](https://discord.com/channels/166207328570441728/356486960417734666/1050921841599979550). Currently Yag will spoil anything marked by the poster as a spoiler, this toggle would allow users to disable this. This value defaults to enabled to maintain current functionality.

I cannot get reddit working on my self host, so I cannot demonstrate this feature. I originally wrote this code in December, and subsequently re-wrote it in August, and am now pr'ing in October because I am not like other girls.