### PR TITLE
frontend: move moderation pages to their own tab

### DIFF
--- a/automod/automod_web.go
+++ b/automod/automod_web.go
@@ -56,7 +56,7 @@ var (
 
 func (p *Plugin) InitWeb() {
 	web.AddHTMLTemplate("automod/assets/automod.html", PageHTML)
-	web.AddSidebarItem(web.SidebarCategoryTools, &web.SidebarItem{
+	web.AddSidebarItem(web.SidebarCategoryModeration, &web.SidebarItem{
 		Name: "Advanced Automoderator",
 		URL:  "automod",
 		Icon: "fas fa-robot",

--- a/automod_legacy/web.go
+++ b/automod_legacy/web.go
@@ -27,7 +27,7 @@ var panelLogKeyUpdatedSettings = cplogs.RegisterActionFormat(&cplogs.ActionForma
 func (p *Plugin) InitWeb() {
 	web.AddHTMLTemplate("automod_legacy/assets/automod_legacy.html", PageHTML)
 
-	web.AddSidebarItem(web.SidebarCategoryTools, &web.SidebarItem{
+	web.AddSidebarItem(web.SidebarCategoryModeration, &web.SidebarItem{
 		Name: "Basic Automoderator",
 		URL:  "automod_legacy",
 		Icon: "fas fa-robot",

--- a/frontend/templates/cp_nav.html
+++ b/frontend/templates/cp_nav.html
@@ -189,6 +189,17 @@
                             {{end}}
                         </ul>
                     </li>
+                    <li class="nav-parent">
+                        <a class="nav-link" href="#">
+                            <i class="fas fa-user-shield" aria-hidden="true"></i>
+                            <span>Moderation</span>
+                        </a>
+                        <ul class="nav nav-children">
+                            {{range (index .SidebarItems "Moderation")}}
+                            {{template "sidebar_item" (dict "ActiveGuild" $ag "Item" .)}}
+                            {{end}}
+                        </ul>
+                    </li>
                     <li class="nav-parent   ">
                         <a class="nav-link" href="#">
                             <i class="fas fa-rss" aria-hidden="true"></i>

--- a/logs/web.go
+++ b/logs/web.go
@@ -64,7 +64,7 @@ func (lp *Plugin) InitWeb() {
 	web.AddHTMLTemplate("logs/assets/logs_control_panel.html", PageHTMLControlPanel)
 	web.AddHTMLTemplate("logs/assets/logs_view.html", PageHTMLView)
 
-	web.AddSidebarItem(web.SidebarCategoryTools, &web.SidebarItem{
+	web.AddSidebarItem(web.SidebarCategoryModeration, &web.SidebarItem{
 		Name: "Logging",
 		URL:  "logging/",
 		Icon: "fas fa-database",

--- a/moderation/plugin_web.go
+++ b/moderation/plugin_web.go
@@ -25,7 +25,7 @@ var (
 func (p *Plugin) InitWeb() {
 	web.AddHTMLTemplate("moderation/assets/moderation.html", PageHTML)
 
-	web.AddSidebarItem(web.SidebarCategoryTools, &web.SidebarItem{
+	web.AddSidebarItem(web.SidebarCategoryModeration, &web.SidebarItem{
 		Name: "Moderation",
 		URL:  "moderation",
 		Icon: "fas fa-gavel",

--- a/verification/verification_web.go
+++ b/verification/verification_web.go
@@ -49,7 +49,7 @@ func (p *Plugin) InitWeb() {
 	web.AddHTMLTemplate("verification/assets/verification_control_panel.html", PageHTMLControlPanel)
 	web.AddHTMLTemplate("verification/assets/verification_verify_page.html", PageHTMLVerifyPage)
 
-	web.AddSidebarItem(web.SidebarCategoryTools, &web.SidebarItem{
+	web.AddSidebarItem(web.SidebarCategoryModeration, &web.SidebarItem{
 		Name: "Verification",
 		URL:  "verification",
 		Icon: "fas fa-address-card",

--- a/web/web.go
+++ b/web/web.go
@@ -134,7 +134,6 @@ func BaseURL() string {
 	return "http://" + common.ConfHost.GetString()
 }
 
-
 func ManageServerURL(guild *dcmd.GuildContextData) string {
 	return fmt.Sprintf("%s/manage/%d", BaseURL(), guild.GS.ID)
 }
@@ -432,11 +431,12 @@ func loadCoreHTMLTemplate(path string) {
 }
 
 const (
-	SidebarCategoryTopLevel = "Top"
-	SidebarCategoryFeeds    = "Feeds"
-	SidebarCategoryTools    = "Tools"
-	SidebarCategoryFun      = "Fun"
-	SidebarCategoryCore     = "Core"
+	SidebarCategoryTopLevel   = "Top"
+	SidebarCategoryFeeds      = "Feeds"
+	SidebarCategoryTools      = "Tools"
+	SidebarCategoryFun        = "Fun"
+	SidebarCategoryCore       = "Core"
+	SidebarCategoryModeration = "Moderation"
 )
 
 type SidebarItem struct {


### PR DESCRIPTION
Move subpages relevant to moderation to their own tab in order to
declutter the Tools & Utilities category on the control panel.

Seeing as Tools & Utilities is one of the largest cagetory on the
control panel, it can be viewed as a "catch-all", which is undesirable.

See also suggestion 2148.
https://discord.com/channels/166207328570441728/356486960417734666/1163826271231418380

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
