### PR TITLE
feat(logs): Add login prompt for members only logs

### DIFF
--- a/logs/web.go
+++ b/logs/web.go
@@ -232,7 +232,11 @@ func CheckCanAccessLogs(w http.ResponseWriter, r *http.Request, config *models.G
 
 	member := web.ContextMember(ctx)
 	if member == nil {
-		tmpl.AddAlerts(web.ErrorAlert("This server has restricted log access to members only."))
+		goTo := url.QueryEscape(r.RequestURI)
+		alertLink := fmt.Sprintf(`<a href="%s/login?goto=%s>here</a>`, web.BaseURL(), goTo)
+		alertMsg := fmt.Sprintf("This server has restricted log access to members only.\nIf you are a member, click %s to login.", alertLink)
+
+		tmpl.AddAlerts(web.ErrorAlert(alertMsg))
 		return false
 	}
 

--- a/logs/web.go
+++ b/logs/web.go
@@ -7,8 +7,14 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/volatiletech/null/v8"
+	"github.com/volatiletech/sqlboiler/v4/boil"
+	"goji.io"
+	"goji.io/pat"
 
 	"github.com/botlabs-gg/yagpdb/v2/bot/botrest"
 	"github.com/botlabs-gg/yagpdb/v2/common"
@@ -17,10 +23,6 @@ import (
 	"github.com/botlabs-gg/yagpdb/v2/lib/discordgo"
 	"github.com/botlabs-gg/yagpdb/v2/logs/models"
 	"github.com/botlabs-gg/yagpdb/v2/web"
-	"github.com/volatiletech/null/v8"
-	"github.com/volatiletech/sqlboiler/v4/boil"
-	"goji.io"
-	"goji.io/pat"
 )
 
 //go:embed assets/logs_control_panel.html


### PR DESCRIPTION
Users have continually expressed confusion regarding the error used
when attempting to open a message log for a server,
where logs are restricted to members only.
The current message implies the user isn't a member of the server,
even if they are.

This pull request attempts to rectify this, by adding a prompt
suggesting the user should use the provided login link, if they are a member.