### PR TITLE
Implement custom status type

### DIFF
--- a/lib/discordgo/gateway.go
+++ b/lib/discordgo/gateway.go
@@ -820,34 +820,18 @@ func newUpdateStatusData(activityType ActivityType, statusType Status, statusTex
 // UpdateStatus is used to update the user's status.
 // Set the custom status to statusText.
 // Set the online status to statusType.
-func (s *Session) UpdateStatus(activityType string, statusType Status, statusText, streamingUrl string) (err error) {
+func (s *Session) UpdateStatus(activityType ActivityType, statusType Status, statusText, streamingUrl string) (err error) {
 	if streamingUrl != "" {
-		activityType = "streaming"
+		activityType = ActivityTypeStreaming
 	}
-
-	switch activityType {
-	case "playing":
-		return s.UpdatePlayingStatus(statusText, statusType)
-	case "streaming":
-		return s.UpdateStreamingStatus(statusText, statusType, streamingUrl)
-	case "listening":
-		return s.UpdateListeningStatus(statusText, statusType)
-	case "watching":
-		return s.UpdateWatchingStatus(statusText, statusType)
-	case "custom":
-		return s.UpdateCustomStatus(statusText, statusType)
-	case "competing":
-		return s.UpdateCompetingStatus(statusText, statusType)
-	default: // covers any values that shouldn't happen, lol
-		return s.UpdateCustomStatus(statusText, statusType)
-	}
+	return s.UpdateStatusComplex(*newUpdateStatusData(activityType, statusType, statusText, streamingUrl))
 }
 
 // UpdatePlayingStatus is used to update the user's playing status.
 // Set the game being played to status.
 // Set the online status to statusType.
 func (s *Session) UpdatePlayingStatus(statusText string, statusType Status) (err error) {
-	return s.UpdateStatusComplex(*newUpdateStatusData(ActivityTypeGame, statusType, statusText, ""))
+	return s.UpdateStatusComplex(*newUpdateStatusData(ActivityTypePlaying, statusType, statusText, ""))
 }
 
 // UpdateStreamingStatus is used to update the user's streaming status.

--- a/lib/discordgo/gateway.go
+++ b/lib/discordgo/gateway.go
@@ -799,12 +799,13 @@ func (g *GatewayConnection) Close() error {
 
 func newUpdateStatusData(activityType ActivityType, statusType Status, statusText, streamingUrl string) *UpdateStatusData {
 	usd := &UpdateStatusData{
+		AFK:    false,
 		Status: statusType,
 	}
-
-	/*if idle > 0 {
-		usd.IdleSince = &idle
-	}*/
+	now := int(time.Now().Unix())
+	if statusType == StatusIdle {
+		usd.IdleSince = &now
+	}
 
 	if statusText != "" {
 		usd.Activity = &Activity{

--- a/lib/discordgo/gateway.go
+++ b/lib/discordgo/gateway.go
@@ -797,52 +797,71 @@ func (g *GatewayConnection) Close() error {
 	return nil
 }
 
-func newUpdateStatusData(idle int, gameType GameType, game, url string) *UpdateStatusData {
+func newUpdateStatusData(gameType ActivityType, statusType Status, status, streamingUrl string) *UpdateStatusData {
 	usd := &UpdateStatusData{
-		Status: "online",
+		Status: statusType,
 	}
 
-	if idle > 0 {
+	/*if idle > 0 {
 		usd.IdleSince = &idle
-	}
+	}*/
 
-	if game != "" {
-		usd.Game = &Game{
-			Name: game,
-			Type: gameType,
-			URL:  url,
+	if status != "" {
+		usd.Activity = &Activity{
+			Name:  status,
+			State: status,
+			Type:  gameType,
+			URL:   streamingUrl,
 		}
 	}
-
 	return usd
 }
 
 // UpdateStatus is used to update the user's status.
-// If idle>0 then set status to idle.
-// If game!="" then set game.
-// if otherwise, set status to active, and no game.
-func (s *Session) UpdateStatus(idle int, game string) (err error) {
-	return s.UpdateStatusComplex(*newUpdateStatusData(idle, GameTypeGame, game, ""))
+// Set the custom status to status.
+// Set the online status to statusType.
+func (s *Session) UpdateStatus(status string, statusType Status) (err error) {
+	return s.UpdateStatusComplex(*newUpdateStatusData(ActivityTypeCustom, statusType, status, ""))
+}
+
+// UpdatePlayingStatus is used to update the user's playing status.
+// Set the game being played to status.
+// Set the online status to statusType.
+func (s *Session) UpdatePlayingStatus(status string, statusType Status) (err error) {
+	return s.UpdateStatusComplex(*newUpdateStatusData(ActivityTypeGame, statusType, status, ""))
 }
 
 // UpdateStreamingStatus is used to update the user's streaming status.
-// If idle>0 then set status to idle.
-// If game!="" then set game.
-// If game!="" and url!="" then set the status type to streaming with the URL set.
-// if otherwise, set status to active, and no game.
-func (s *Session) UpdateStreamingStatus(idle int, game string, url string) (err error) {
-	gameType := GameTypeGame
+// Set the name of the stream to status.
+// Set the online status to statusType.
+// Set the stream URL to url.
+func (s *Session) UpdateStreamingStatus(status string, statusType Status, url string) (err error) {
+	gameType := ActivityTypeCustom
 	if url != "" {
-		gameType = GameTypeStreaming
+		gameType = ActivityTypeStreaming
 	}
-	return s.UpdateStatusComplex(*newUpdateStatusData(idle, gameType, game, url))
+	return s.UpdateStatusComplex(*newUpdateStatusData(gameType, statusType, status, url))
 }
 
-// UpdateListeningStatus is used to set the user to "Listening to..."
-// If game!="" then set to what user is listening to
-// Else, set user to active and no game.
-func (s *Session) UpdateListeningStatus(game string) (err error) {
-	return s.UpdateStatusComplex(*newUpdateStatusData(0, GameTypeListening, game, ""))
+// UpdateListeningStatus is used to update the user's listening status
+// Set what the user is listening to to status.
+// Set the online status to statusType.
+func (s *Session) UpdateListeningStatus(status string, statusType Status) (err error) {
+	return s.UpdateStatusComplex(*newUpdateStatusData(ActivityTypeListening, statusType, status, ""))
+}
+
+// UpdateWatchingStatus is used to update the user's watching status
+// Set what the user is watching to status.
+// Set the online status to statusType.
+func (s *Session) UpdateWatchingStatus(status string, statusType Status) (err error) {
+	return s.UpdateStatusComplex(*newUpdateStatusData(ActivityTypeWatching, statusType, status, ""))
+}
+
+// UpdateCompetingStatus is used to update the user's competing status
+// Set what the user is competing in to status.
+// Set the online status to statusType.
+func (s *Session) UpdateCompetingStatus(status string, statusType Status) (err error) {
+	return s.UpdateStatusComplex(*newUpdateStatusData(ActivityTypeCompeting, statusType, status, ""))
 }
 
 func (s *Session) UpdateStatusComplex(usd UpdateStatusData) (err error) {
@@ -1423,10 +1442,10 @@ type resumeData struct {
 }
 
 type UpdateStatusData struct {
-	IdleSince *int   `json:"since"`
-	Game      *Game  `json:"game"`
-	AFK       bool   `json:"afk"`
-	Status    string `json:"status"`
+	IdleSince *int      `json:"since"`
+	Activity  *Activity `json:"game"`
+	AFK       bool      `json:"afk"`
+	Status    Status    `json:"status"`
 }
 
 type RequestGuildMembersData struct {

--- a/lib/discordgo/structs.go
+++ b/lib/discordgo/structs.go
@@ -611,10 +611,10 @@ func (p *Presence) NKeys() int {
 	return 0
 }
 
-type Activities []*Game
+type Activities []*Activity
 
 func (a *Activities) UnmarshalJSONArray(dec *gojay.Decoder) error {
-	instance := Game{}
+	instance := Activity{}
 	err := dec.Object(&instance)
 	if err != nil {
 		return err
@@ -623,53 +623,55 @@ func (a *Activities) UnmarshalJSONArray(dec *gojay.Decoder) error {
 	return nil
 }
 
-// GameType is the type of "game" (see GameType* consts) in the Game struct
-type GameType int
+// ActivityType is the type of presence (see ActivityType* consts) in the Activity struct
+type ActivityType int
 
-// Valid GameType values
+// Valid ActivityType values
 const (
-	GameTypeGame GameType = iota
-	GameTypeStreaming
-	GameTypeListening
-	GameTypeWatching
+	ActivityTypeGame ActivityType = iota
+	ActivityTypeStreaming
+	ActivityTypeListening
+	ActivityTypeWatching
+	ActivityTypeCustom
+	ActivityTypeCompeting
 )
 
-// A Game struct holds the name of the "playing .." game for a user
-type Game struct {
-	Name       string     `json:"name"`
-	Type       GameType   `json:"type"`
-	URL        string     `json:"url,omitempty"`
-	Details    string     `json:"details,omitempty"`
-	State      string     `json:"state,omitempty"`
-	TimeStamps TimeStamps `json:"timestamps,omitempty"`
-	Assets     Assets     `json:"assets,omitempty"`
-	Instance   int8       `json:"instance,omitempty"`
+// An Activity struct holds data about a user's activity.
+type Activity struct {
+	Name       string       `json:"name"`
+	Type       ActivityType `json:"type"`
+	URL        string       `json:"url,omitempty"`
+	Details    string       `json:"details,omitempty"`
+	State      string       `json:"state,omitempty"`
+	TimeStamps TimeStamps   `json:"timestamps,omitempty"`
+	Assets     Assets       `json:"assets,omitempty"`
+	Instance   int8         `json:"instance,omitempty"`
 }
 
 // implement gojay.UnmarshalerJSONObject
-func (g *Game) UnmarshalJSONObject(dec *gojay.Decoder, key string) error {
+func (a *Activity) UnmarshalJSONObject(dec *gojay.Decoder, key string) error {
 	switch key {
 	case "name":
-		return dec.String(&g.Name)
+		return dec.String(&a.Name)
 	case "type":
-		return dec.Int((*int)(&g.Type))
+		return dec.Int((*int)(&a.Type))
 	case "url":
-		return dec.String(&g.URL)
+		return dec.String(&a.URL)
 	case "details":
-		return dec.String(&g.Details)
+		return dec.String(&a.Details)
 	case "state":
-		return dec.String(&g.State)
+		return dec.String(&a.State)
 	case "timestamps":
-		return dec.Object(&g.TimeStamps)
+		return dec.Object(&a.TimeStamps)
 	case "assets":
 	case "instance":
-		return dec.Int8(&g.Instance)
+		return dec.Int8(&a.Instance)
 	}
 
 	return nil
 }
 
-func (g *Game) NKeys() int {
+func (a *Activity) NKeys() int {
 	return 0
 }
 

--- a/lib/discordgo/structs.go
+++ b/lib/discordgo/structs.go
@@ -628,7 +628,7 @@ type ActivityType int
 
 // Valid ActivityType values
 const (
-	ActivityTypeGame ActivityType = iota
+	ActivityTypePlaying ActivityType = iota
 	ActivityTypeStreaming
 	ActivityTypeListening
 	ActivityTypeWatching

--- a/lib/dstate/helpers.go
+++ b/lib/dstate/helpers.go
@@ -98,7 +98,7 @@ func MemberStateFromPresence(p *discordgo.PresenceUpdate) *MemberState {
 
 	// get the main activity
 	// it either gets the first one, or the one with typ 1 (streaming)
-	var mainActivity *discordgo.Game
+	var mainActivity *discordgo.Activity
 	for i, v := range p.Activities {
 		if i == 0 || v.Type == 1 {
 			mainActivity = v

--- a/lib/dstate/interface.go
+++ b/lib/dstate/interface.go
@@ -323,7 +323,7 @@ type LightGame struct {
 	Details string `json:"details,omitempty"`
 	State   string `json:"state,omitempty"`
 
-	Type discordgo.GameType `json:"type"`
+	Type discordgo.ActivityType `json:"type"`
 }
 
 func MemberStateFromMember(member *discordgo.Member) *MemberState {

--- a/stdcommands/setstatus/setstatus.go
+++ b/stdcommands/setstatus/setstatus.go
@@ -1,6 +1,8 @@
 package setstatus
 
 import (
+	"fmt"
+
 	"github.com/botlabs-gg/yagpdb/v2/bot"
 	"github.com/botlabs-gg/yagpdb/v2/commands"
 	"github.com/botlabs-gg/yagpdb/v2/lib/dcmd"
@@ -28,22 +30,16 @@ var Command = &commands.YAGCommand{
 		statusText := data.Args[0].Str()
 		streamingUrl := data.Switch("url").Str()
 		switch activityType {
-		case "playing":
-		case "streaming":
-		case "listening":
-		case "watching":
-		case "custom":
-		case "competing":
+		case "playing", "streaming", "listening", "watching", "custom", "competing":
+			// Valid activity type, do nothing
 		default:
-			activityType = "custom"
+			return nil, commands.NewUserError(fmt.Sprintf("Invalid activity type %q. Allowed values are 'playing', 'streaming', 'listening', 'watching', 'custom', 'competing'", activityType))
 		}
 		switch statusType {
-		case "online":
-		case "idle":
-		case "dnd":
-		case "offline":
+		case "online", "idle", "dnd", "offline":
+			// Valid status type, do nothing
 		default:
-			statusType = "online"
+			return nil, commands.NewUserError(fmt.Sprintf("Invalid status type %q. Allowed values are 'online', 'idle', 'dnd', 'offline'", statusType))
 		}
 		bot.SetStatus(activityType, statusType, statusText, streamingUrl)
 		return "Doneso", nil

--- a/stdcommands/setstatus/setstatus.go
+++ b/stdcommands/setstatus/setstatus.go
@@ -19,10 +19,33 @@ var Command = &commands.YAGCommand{
 	},
 	ArgSwitches: []*dcmd.ArgDef{
 		{Name: "url", Type: dcmd.String, Default: ""},
+		{Name: "type", Type: dcmd.String, Help: "Game type. Allowed values are 'playing', 'streaming', 'listening', 'watching', 'custom', 'competing'.", Default: "custom"},
+		{Name: "status", Type: dcmd.String, Help: "Online status. Allowed values are 'online', 'idle', 'dnd', 'offline'.", Default: "online"},
 	},
 	RunFunc: util.RequireBotAdmin(func(data *dcmd.Data) (interface{}, error) {
-		streamingURL := data.Switch("url").Str()
-		bot.SetStatus(streamingURL, data.Args[0].Str())
+		statusText := data.Args[0].Str()
+		streamingUrl := data.Switch("url").Str()
+		gameType := data.Switch("type").Str()
+		statusType := data.Switch("status").Str()
+		switch gameType {
+		case "playing":
+		case "streaming":
+		case "listening":
+		case "watching":
+		case "custom":
+		case "competing":
+		default:
+			gameType = "custom"
+		}
+		switch statusType {
+		case "online":
+		case "idle":
+		case "dnd":
+		case "offline":
+		default:
+			statusType = "online"
+		}
+		bot.SetStatus(gameType, statusText, statusType, streamingUrl)
 		return "Doneso", nil
 	}),
 }

--- a/stdcommands/setstatus/setstatus.go
+++ b/stdcommands/setstatus/setstatus.go
@@ -12,22 +12,22 @@ var Command = &commands.YAGCommand{
 	CmdCategory:          commands.CategoryDebug,
 	HideFromCommandsPage: true,
 	Name:                 "setstatus",
-	Description:          "Sets the bot's status and optional streaming url. Bot Admin Only",
+	Description:          "Sets the bot's presence type, status text, online status, and optional streaming URL. Bot Admin Only",
 	HideFromHelp:         true,
 	Arguments: []*dcmd.ArgDef{
 		{Name: "status", Type: dcmd.String, Default: ""},
 	},
 	ArgSwitches: []*dcmd.ArgDef{
-		{Name: "url", Type: dcmd.String, Default: ""},
-		{Name: "type", Type: dcmd.String, Help: "Game type. Allowed values are 'playing', 'streaming', 'listening', 'watching', 'custom', 'competing'.", Default: "custom"},
-		{Name: "status", Type: dcmd.String, Help: "Online status. Allowed values are 'online', 'idle', 'dnd', 'offline'.", Default: "online"},
+		{Name: "url", Type: dcmd.String, Help: "The URL to the stream. Must be on twitch.tv or youtube.com. Activity type will always be streaming if this is set.", Default: ""},
+		{Name: "type", Type: dcmd.String, Help: "Set activity type. Allowed values are 'playing', 'streaming', 'listening', 'watching', 'custom', 'competing'. Defaults to custom status", Default: "custom"},
+		{Name: "status", Type: dcmd.String, Help: "Set online status. Allowed values are 'online', 'idle', 'dnd', 'offline'. Defaults to online", Default: "online"},
 	},
 	RunFunc: util.RequireBotAdmin(func(data *dcmd.Data) (interface{}, error) {
+		activityType := data.Switch("type").Str()
+		statusType := data.Switch("status").Str()
 		statusText := data.Args[0].Str()
 		streamingUrl := data.Switch("url").Str()
-		gameType := data.Switch("type").Str()
-		statusType := data.Switch("status").Str()
-		switch gameType {
+		switch activityType {
 		case "playing":
 		case "streaming":
 		case "listening":
@@ -35,7 +35,7 @@ var Command = &commands.YAGCommand{
 		case "custom":
 		case "competing":
 		default:
-			gameType = "custom"
+			activityType = "custom"
 		}
 		switch statusType {
 		case "online":
@@ -45,7 +45,7 @@ var Command = &commands.YAGCommand{
 		default:
 			statusType = "online"
 		}
-		bot.SetStatus(gameType, statusText, statusType, streamingUrl)
+		bot.SetStatus(activityType, statusType, statusText, streamingUrl)
 		return "Doneso", nil
 	}),
 }

--- a/streaming/bot.go
+++ b/streaming/bot.go
@@ -283,9 +283,9 @@ func CheckPresenceSparse(client radix.Client, config *Config, p *discordgo.Prese
 	return nil
 }
 
-func retrieveMainActivity(p *discordgo.Presence) *discordgo.Game {
+func retrieveMainActivity(p *discordgo.Presence) *discordgo.Activity {
 	for _, v := range p.Activities {
-		if v.Type == discordgo.GameTypeStreaming {
+		if v.Type == discordgo.ActivityTypeStreaming {
 			return v
 		}
 	}


### PR DESCRIPTION
Implementing custom status type so that `-setstatus` will use custom status instead of Playing... now that it's available to bots
Flags have been added to permit the user to choose the presence type and online status of the bot
`GameType` has been renamed to `ActivityType`
`ActivityTypeCustom` and `ActivityTypeCompeting` have been added to the ActivityType struct
`UpdateStatus` now uses `ActivityTypeCustom` by default
`UpdatePlayingStatus`, `UpdateWatchingStatus`, and `UpdateCompetingStatus` have been added
`Update*Status` have had their parameters adjusted to allow the user to set online/idle/dnd/offline
Two new fields have been added to the Redis DB to store chosen presence type and online status.
Also thanks @l-zeuch for helping test and then helping me set up selfhost so I could test myself