### PR TITLE
customcommands/web: add database view page

### DIFF
--- a/customcommands/assets/customcommands_database.html
+++ b/customcommands/assets/customcommands_database.html
@@ -107,7 +107,7 @@
                         <td>{{.ID}}</td>
                         <td>{{.CreatedAt}}</td>
                         <td>{{.UpdatedAt}}</td>
-                        <td>{{.ExpiresAt}}</td>
+                        <td>{{if .ExpiresAt.IsZero}}never{{else}}{{.ExpiresAt}}{{end}}</td>
                         <td>{{.UserID}}</td>
                         <td>{{.Key}}</td>
                         <td>{{.Value}}</td>

--- a/customcommands/assets/customcommands_database.html
+++ b/customcommands/assets/customcommands_database.html
@@ -45,7 +45,7 @@
                         </div>
                         <div class="from-group col">
                             <label>Search For</label>
-                            <input type="text" name="Search" class="form-control" placeholder="Enter search term..." />
+                            <input type="text" name="Query" class="form-control" placeholder="Enter search term..." />
                         </div>
                     </div>
                     <button type="submit" class="btn btn-primary" value="Search" data-async-form>Search!</button>
@@ -68,7 +68,9 @@
                 <ul>
                     <li>ID: The unique ID of the entry.</li>
                     <li>User ID: The ID of the user associated with the entry.</li>
-                    <li>Key: The key of the entry.</li>
+                    <li>
+                        Key: The key of the entry. This supports PostgreSQL patterns (<code>%</code> and<code>_</code>).
+                    </li>
                 </ul>
                 </p>
             </div>
@@ -93,9 +95,9 @@
                 <thead>
                     <tr>
                         <th>ID</th>
-                        <th>Created At</th>
-                        <th>Updated At</th>
-                        <th>Expires At</th>
+                        <th>Created At (UTC)</th>
+                        <th>Updated At (UTC)</th>
+                        <th>Expires At (UTC)</th>
                         <th>User ID</th>
                         <th>Key</th>
                         <th>Value</th>
@@ -105,9 +107,10 @@
                     {{range .DBEntries}}
                     <tr>
                         <td>{{.ID}}</td>
-                        <td>{{.CreatedAt}}</td>
-                        <td>{{.UpdatedAt}}</td>
-                        <td>{{if .ExpiresAt.IsZero}}never{{else}}{{.ExpiresAt}}{{end}}</td>
+                        <td>{{.CreatedAt.UTC.Format "2006-01-02 15:04:05"}}</td>
+                        <td>{{.UpdatedAt.UTC.Format "2006-01-02 15:04:05"}}</td>
+                        <td>{{if .ExpiresAt.IsZero}}never{{else}}{{.ExpiresAt.UTC.Format "2006-01-02 15:04:05"}}{{end}}
+                        </td>
                         <td>{{.UserID}}</td>
                         <td>{{.Key}}</td>
                         <td>{{.Value}}</td>

--- a/customcommands/assets/customcommands_database.html
+++ b/customcommands/assets/customcommands_database.html
@@ -1,0 +1,143 @@
+{{define "cp_custom_commands_database"}}
+{{template "cp_head" .}}
+
+<style>
+    .db-footer,
+    .db-header,
+    .db-navigation {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+
+    .db-footer::after {
+        content: none !important;
+    }
+</style>
+
+<header class="page-header">
+    <h2>Custom Commands Database</h2>
+</header>
+{{template "cp_alerts" .}}
+
+<div class="row">
+    <div class="col-lg-6">
+        <section class="card">
+            <header class="card-header">
+                <h2 class="card-title">Search</h2>
+            </header>
+            <div class="card-body">
+                <p>
+                    This page allows you to view and delete stray entries in the custom commands database.
+                </p>
+                <p>
+                    <strong>Warning:</strong> Deleting a database entry is permanent and cannot be undone.
+                </p>
+                <form action="/manage/{{.ActiveGuild.ID}}/customcommands/database/search" method="post" data-async-form>
+                    <div class="form-row">
+                        <div class="form-group col">
+                            <label>Search By</label>
+                            <select class="form-control" id="filter-type-dropdown" name="Type">
+                                <option value="id">ID</option>
+                                <option value="user_id">User ID</option>
+                                <option value="key">Key</option>
+                            </select>
+                        </div>
+                        <div class="from-group col">
+                            <label>Search For</label>
+                            <input type="text" name="Search" class="form-control" placeholder="Enter search term..." />
+                        </div>
+                    </div>
+                    <button type="submit" class="btn btn-primary" value="Search" data-async-form>Search!</button>
+                </form>
+            </div>
+        </section>
+    </div>
+    <div class="col-lg-6">
+        <section class="card">
+            <header class="card-header">
+                <h2 class="card-title">Info</h2>
+            </header>
+            <div class="card-body">
+                <p>
+                    To search select a filter type and enter a value to search for. The search will return all entries
+                    that match the filter type and value.
+                </p>
+                <p>
+                    <strong>Filter Types:</strong>
+                <ul>
+                    <li>ID: The unique ID of the entry.</li>
+                    <li>User ID: The ID of the user associated with the entry.</li>
+                    <li>Key: The key of the entry.</li>
+                </ul>
+                </p>
+            </div>
+        </section>
+    </div>
+</div>
+<section class="card">
+    <header class="card-header db-header">
+        <div>
+            <h2 class="card-title">Database Entries</h2>
+        </div>
+        <div class="db-navigation">
+            {{if not .FirstPage}}
+            <a href="?after={{.Newest}}" class="nav-link btn btn-sm btn-primary mr-1">Newer</a>
+            {{end}}
+            <a href="?before={{.Oldest}}" class="nav-link btn btn-sm btn-primary">Older</a>
+        </div>
+    </header>
+    <div class="card-body">
+        <div class="table-responsive">
+            <table class="table table-hover table-striped table-responsive-md" id="db-table">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Created At</th>
+                        <th>Updated At</th>
+                        <th>Expires At</th>
+                        <th>User ID</th>
+                        <th>Key</th>
+                        <th>Value</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {{range .DBEntries}}
+                    <tr>
+                        <td>{{.ID}}</td>
+                        <td>{{.CreatedAt}}</td>
+                        <td>{{.UpdatedAt}}</td>
+                        <td>{{.ExpiresAt}}</td>
+                        <td>{{.UserID}}</td>
+                        <td>{{.Key}}</td>
+                        <td>{{.Value}}</td>
+                        {{ if $.IsAdmin }}
+                        <td>
+                            <form method="post" data-async-form>
+                                <input class="hidden" type="text" name="id" value="{{.ID}}" />
+                                <button type="submit"
+                                    formaction="/manage/{{$.ActiveGuild.ID}}/customcommands/database/delete/{{.ID}}"
+                                    class="btn btn-sm btn-danger" value="Delete" data-async-form>Delete</button>
+                            </form>
+                        </td>
+                        {{end}}
+                    </tr>
+                    {{end}}
+                </tbody>
+            </table>
+        </div>
+    </div>
+    <div class="card-footer db-footer">
+        <div class="db-navigation">
+            {{if not .FirstPage}}
+            <a href="?after={{.Newest}}" class="nav-link btn btn-sm btn-primary mr-1">Newer</a>
+            {{end}}
+            <a href="?before={{.Oldest}}" class="nav-link btn btn-sm btn-primary">Older</a>
+        </div>
+    </div>
+</section>
+</div>
+</div>
+
+{{template "cp_footer" .}}
+{{end}}

--- a/customcommands/customcommands.go
+++ b/customcommands/customcommands.go
@@ -35,6 +35,8 @@ const (
 	MinIntervalTriggerDurationHours   = 1
 	MaxIntervalTriggerDurationHours   = 744
 	MaxIntervalTriggerDurationMinutes = 44640
+
+	dbPageMaxDisplayLength = 64
 )
 
 func KeyCommands(guildID int64) string { return "custom_commands:" + discordgo.StrID(guildID) }
@@ -464,7 +466,7 @@ func convertEntries(result models.TemplatesUserDatabaseSlice) []*LightDBEntry {
 			continue
 		}
 
-		converted.Value = common.CutStringShort(string(b), 64)
+		converted.Value = common.CutStringShort(string(b), dbPageMaxDisplayLength)
 
 		entries = append(entries, converted)
 	}

--- a/customcommands/customcommands.go
+++ b/customcommands/customcommands.go
@@ -448,3 +448,26 @@ func getDatabaseEntries(ctx context.Context, guildID int64, before, after int64,
 	entries, err := models.TemplatesUserDatabases(qms...).AllG(ctx)
 	return entries, err
 }
+
+func convertEntries(result models.TemplatesUserDatabaseSlice) []*LightDBEntry {
+	entries := make([]*LightDBEntry, 0, len(result))
+	for _, v := range result {
+		converted, err := ToLightDBEntry(v)
+		if err != nil {
+			logger.WithError(err).Warn("[cc/web] failed converting to light db entry")
+			continue
+		}
+
+		b, err := json.Marshal(converted.Value)
+		if err != nil {
+			logger.WithError(err).Warn("[cc/web] failed converting to light db entry")
+			continue
+		}
+
+		converted.Value = common.CutStringShort(string(b), 64)
+
+		entries = append(entries, converted)
+	}
+
+	return entries
+}

--- a/customcommands/customcommands.go
+++ b/customcommands/customcommands.go
@@ -431,3 +431,20 @@ func (p *Plugin) AllFeatureFlags() []string {
 		featureFlagHasCommands, // set if this server has any custom commands at all
 	}
 }
+
+func getDatabaseEntries(ctx context.Context, guildID int64, before, after int64, limit int) (models.TemplatesUserDatabaseSlice, error) {
+	qms := []qm.QueryMod{
+		qm.OrderBy("id desc"),
+		qm.Limit(limit),
+		models.TemplatesUserDatabaseWhere.GuildID.EQ(guildID),
+	}
+
+	if before != 0 {
+		qms = append(qms, models.TemplatesUserDatabaseWhere.ID.LT(before))
+	} else if after != 0 {
+		qms = append(qms, models.TemplatesUserDatabaseWhere.ID.GT(after))
+	}
+
+	entries, err := models.TemplatesUserDatabases(qms...).AllG(ctx)
+	return entries, err
+}

--- a/customcommands/web.go
+++ b/customcommands/web.go
@@ -164,16 +164,7 @@ func handleGetDatabase(w http.ResponseWriter, r *http.Request) (web.TemplateData
 		return templateData, err
 	}
 
-	entries := make([]*LightDBEntry, 0, len(result))
-	for _, v := range result {
-		converted, err := ToLightDBEntry(v)
-		if err != nil {
-			logger.WithError(err).Warn("[cc/web] failed converting to light db entry")
-			continue
-		}
-
-		entries = append(entries, converted)
-	}
+	entries := convertEntries(result)
 
 	templateData["DBEntries"] = entries
 	if len(entries) > 0 {
@@ -212,16 +203,7 @@ func handleSearchDatabase(w http.ResponseWriter, r *http.Request) (web.TemplateD
 		return templateData, err
 	}
 
-	entries := make([]*LightDBEntry, 0, len(result))
-	for _, v := range result {
-		converted, err := ToLightDBEntry(v)
-		if err != nil {
-			logger.WithError(err).Warn("[cc/web] failed converting to light db entry")
-			continue
-		}
-
-		entries = append(entries, converted)
-	}
+	entries := convertEntries(result)
 
 	templateData["DBEntries"] = entries
 	if len(entries) > 0 {

--- a/customcommands/web.go
+++ b/customcommands/web.go
@@ -35,6 +35,9 @@ var PageHTMLEditCmd string
 //go:embed assets/customcommands.html
 var PageHTMLMain string
 
+//go:embed assets/customcommands_database.html
+var PageHTMLDatabase string
+
 // GroupForm is the form bindings used when creating or updating groups
 type GroupForm struct {
 	ID                int64
@@ -44,6 +47,11 @@ type GroupForm struct {
 
 	WhitelistRoles []int64 `valid:"role,true"`
 	BlacklistRoles []int64 `valid:"role,true"`
+}
+
+type SearchForm struct {
+	Search string
+	Type   string
 }
 
 var (
@@ -66,13 +74,23 @@ func (p *Plugin) InitWeb() {
 		Icon: "fas fa-closed-captioning",
 	})
 
+	web.AddHTMLTemplate("customcommands/assets/customcommands_database.html", PageHTMLDatabase)
+	web.AddSidebarItem(web.SidebarCategoryCore, &web.SidebarItem{
+		Name: "Custom command database",
+		URL:  "customcommands/database",
+		Icon: "fas fa-database",
+	})
+
 	getHandler := web.ControllerHandler(handleCommands, "cp_custom_commands")
 	getCmdHandler := web.ControllerHandler(handleGetCommand, "cp_custom_commands_edit_cmd")
 	getGroupHandler := web.ControllerHandler(handleGetCommandsGroup, "cp_custom_commands")
+	getDBHandler := web.ControllerHandler(handleGetDatabase, "cp_custom_commands_database")
+	getDBSearchHandler := web.ControllerHandler(handleSearchDatabase, "cp_custom_commands_database")
 
 	subMux := goji.SubMux()
 	web.CPMux.Handle(pat.New("/customcommands"), subMux)
 	web.CPMux.Handle(pat.New("/customcommands/*"), subMux)
+	web.CPMux.Handle(pat.New("/customcommands/database"), subMux)
 
 	subMux.Use(func(inner http.Handler) http.Handler {
 		h := func(w http.ResponseWriter, r *http.Request) {
@@ -92,6 +110,11 @@ func (p *Plugin) InitWeb() {
 	subMux.Handle(pat.Get(""), getHandler)
 	subMux.Handle(pat.Get("/"), getHandler)
 
+	subMux.Handle(pat.Get("/database"), getDBHandler)
+	subMux.Handle(pat.Get("/database/"), getDBHandler)
+	subMux.Handle(pat.Post("/database/search"), web.ControllerPostHandler(handleSearchDatabase, getDBSearchHandler, SearchForm{}))
+	subMux.Handle(pat.Post("/database/delete/:id"), web.ControllerPostHandler(handleDeleteDatabaseEntry, getDBHandler, nil))
+
 	subMux.Handle(pat.Get("/commands/:cmd/"), getCmdHandler)
 
 	subMux.Handle(pat.Get("/groups/:group/"), web.ControllerHandler(handleGetCommandsGroup, "cp_custom_commands"))
@@ -107,6 +130,123 @@ func (p *Plugin) InitWeb() {
 	subMux.Handle(pat.Post("/creategroup"), web.ControllerPostHandler(handleNewGroup, getHandler, GroupForm{}))
 	subMux.Handle(pat.Post("/groups/:group/update"), web.ControllerPostHandler(handleUpdateGroup, getGroupHandler, GroupForm{}))
 	subMux.Handle(pat.Post("/groups/:group/delete"), web.ControllerPostHandler(handleDeleteGroup, getHandler, nil))
+}
+
+func handleGetDatabase(w http.ResponseWriter, r *http.Request) (web.TemplateData, error) {
+	var err error
+
+	ctx := r.Context()
+	activeGuild, templateData := web.GetBaseCPContextData(ctx)
+
+	beforeID := 0
+	wantBefore := r.URL.Query().Get("before")
+	if wantBefore != "" {
+		beforeID, err = strconv.Atoi(wantBefore)
+		if err != nil {
+			templateData.AddAlerts(web.ErrorAlert("Failed parsing before id"))
+		}
+	} else {
+		templateData["FirstPage"] = true
+	}
+
+	afterID := 0
+	wantAfter := r.URL.Query().Get("after")
+	if wantAfter != "" {
+		afterID, err = strconv.Atoi(wantAfter)
+		if err != nil {
+			templateData.AddAlerts(web.ErrorAlert("Failed parsing after id"))
+		}
+		templateData["FirstPage"] = false
+	}
+
+	result, err := getDatabaseEntries(ctx, activeGuild.ID, int64(beforeID), int64(afterID), 100)
+	if err != nil {
+		return templateData, err
+	}
+
+	entries := make([]*LightDBEntry, 0, len(result))
+	for _, v := range result {
+		converted, err := ToLightDBEntry(v)
+		if err != nil {
+			logger.WithError(err).Warn("[cc/web] failed converting to light db entry")
+			continue
+		}
+
+		entries = append(entries, converted)
+	}
+
+	templateData["DBEntries"] = entries
+	if len(entries) > 0 {
+		templateData["Oldest"] = entries[len(entries)-1].ID
+		templateData["Newest"] = entries[0].ID
+	}
+
+	return templateData, nil
+}
+
+func handleSearchDatabase(w http.ResponseWriter, r *http.Request) (web.TemplateData, error) {
+	ctx := r.Context()
+	activeGuild, templateData := web.GetBaseCPContextData(ctx)
+
+	search := ctx.Value(common.ContextKeyParsedForm).(*SearchForm)
+	if search.Search == "" {
+		return handleGetDatabase(w, r)
+	}
+
+	qms := []qm.QueryMod{
+		qm.Where("guild_id = ?", activeGuild.ID),
+		qm.OrderBy("id desc"),
+	}
+
+	switch search.Type {
+	case "id":
+		qms = append(qms, qm.Where("id = ?", search.Search))
+	case "user_id":
+		qms = append(qms, qm.Where("user_id = ?", search.Search))
+	case "key":
+		qms = append(qms, qm.Where("key = ?", search.Search))
+	}
+
+	result, err := models.TemplatesUserDatabases(qms...).AllG(ctx)
+	if err != nil {
+		return templateData, err
+	}
+
+	entries := make([]*LightDBEntry, 0, len(result))
+	for _, v := range result {
+		converted, err := ToLightDBEntry(v)
+		if err != nil {
+			logger.WithError(err).Warn("[cc/web] failed converting to light db entry")
+			continue
+		}
+
+		entries = append(entries, converted)
+	}
+
+	templateData["DBEntries"] = entries
+	if len(entries) > 0 {
+		templateData["Oldest"] = entries[len(entries)-1].ID
+		templateData["Newest"] = entries[0].ID
+	}
+
+	return templateData, nil
+}
+
+func handleDeleteDatabaseEntry(w http.ResponseWriter, r *http.Request) (web.TemplateData, error) {
+	ctx := r.Context()
+	activeGuild, templateData := web.GetBaseCPContextData(ctx)
+
+	id, err := strconv.ParseInt(pat.Param(r, "id"), 10, 64)
+	if err != nil {
+		return templateData, err
+	}
+
+	_, err = models.TemplatesUserDatabases(qm.Where("guild_id = ? AND id = ?", activeGuild.ID, id)).DeleteAll(ctx, common.PQ)
+	if err != nil {
+		return templateData, err
+	}
+
+	return templateData.AddAlerts(), nil
 }
 
 func handleCommands(w http.ResponseWriter, r *http.Request) (web.TemplateData, error) {

--- a/customcommands/web.go
+++ b/customcommands/web.go
@@ -50,8 +50,8 @@ type GroupForm struct {
 }
 
 type SearchForm struct {
-	Search string
-	Type   string
+	Query string
+	Type  string
 }
 
 var (
@@ -180,22 +180,22 @@ func handleSearchDatabase(w http.ResponseWriter, r *http.Request) (web.TemplateD
 	activeGuild, templateData := web.GetBaseCPContextData(ctx)
 
 	search := ctx.Value(common.ContextKeyParsedForm).(*SearchForm)
-	if search.Search == "" {
+	if search.Query == "" {
 		return handleGetDatabase(w, r)
 	}
 
 	qms := []qm.QueryMod{
-		qm.Where("guild_id = ?", activeGuild.ID),
+		models.TemplatesUserDatabaseWhere.GuildID.EQ(activeGuild.ID),
 		qm.OrderBy("id desc"),
 	}
 
 	switch search.Type {
 	case "id":
-		qms = append(qms, qm.Where("id = ?", search.Search))
+		qms = append(qms, qm.Where("id = ?", search.Query))
 	case "user_id":
-		qms = append(qms, qm.Where("user_id = ?", search.Search))
+		qms = append(qms, qm.Where("user_id = ?", search.Query))
 	case "key":
-		qms = append(qms, qm.Where("key = ?", search.Search))
+		qms = append(qms, qm.Where("key ILIKE ?", search.Query))
 	}
 
 	result, err := models.TemplatesUserDatabases(qms...).AllG(ctx)


### PR DESCRIPTION
Add a database view page to the control panel, allowing users to view
their custom command database, and, as necessary, search for entries
matching specific criteria.

The output is, no matter the request, paginated to max 100 entries per
page, which is in-line with the maximum one can achieve via a `dbGetPattern`
call in custom commands.

I've also decided to add delete functionality for individual entries,
such that if a stray entry that is no longer needed is found, it can be
deleted without resorting to a custom command / `evalcc`.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
