### PR TITLE
customcommands: add Size field to LightDBEntry

### DIFF
--- a/customcommands/assets/customcommands_database.html
+++ b/customcommands/assets/customcommands_database.html
@@ -115,7 +115,7 @@
                         <td>{{.UserID}}</td>
                         <td>{{.Key}}</td>
                         <td>{{.Value}}</td>
-                        <td>{{.Size}}</td>
+                        <td>{{.ValueSize}}</td>
                         {{ if $.IsAdmin }}
                         <td>
                             <form method="post" data-async-form>

--- a/customcommands/assets/customcommands_database.html
+++ b/customcommands/assets/customcommands_database.html
@@ -101,6 +101,7 @@
                         <th>User ID</th>
                         <th>Key</th>
                         <th>Value</th>
+                        <th>Size</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -114,6 +115,7 @@
                         <td>{{.UserID}}</td>
                         <td>{{.Key}}</td>
                         <td>{{.Value}}</td>
+                        <td>{{.Size}}</td>
                         {{ if $.IsAdmin }}
                         <td>
                             <form method="post" data-async-form>

--- a/customcommands/tmplextensions.go
+++ b/customcommands/tmplextensions.go
@@ -841,7 +841,7 @@ type LightDBEntry struct {
 	Key   string
 	Value interface{}
 
-	Size int
+	ValueSize int
 
 	User discordgo.User
 
@@ -872,7 +872,7 @@ func ToLightDBEntry(m *models.TemplatesUserDatabase) (*LightDBEntry, error) {
 		Key:   m.Key,
 		Value: decodedValue,
 
-		Size: len(m.ValueRaw),
+		ValueSize: len(m.ValueRaw),
 
 		ExpiresAt: m.ExpiresAt.Time,
 	}

--- a/customcommands/tmplextensions.go
+++ b/customcommands/tmplextensions.go
@@ -841,6 +841,8 @@ type LightDBEntry struct {
 	Key   string
 	Value interface{}
 
+	Size int
+
 	User discordgo.User
 
 	ExpiresAt time.Time
@@ -869,6 +871,8 @@ func ToLightDBEntry(m *models.TemplatesUserDatabase) (*LightDBEntry, error) {
 
 		Key:   m.Key,
 		Value: decodedValue,
+
+		Size: len(m.ValueRaw),
 
 		ExpiresAt: m.ExpiresAt.Time,
 	}


### PR DESCRIPTION
Add (approximate) Size to the LightDBEntry struct, set to the length of
the raw byte value.

It should be noted that, although this reading may be inaccurate,
internally we already limit the raw byte value to 100_000 in length;
thus, this change (and by extension this reading) is consistent with how
entry size is already determined.

As an added bonus, and because it was requested in
botlabs-gg/yagpdb#1590, I've also added the size reading to the therein
introduced view page.

I believe to recall that such a thing was either suggested in
`#suggestions`, or that it was requested in a drive-by comment in one of
the help channels; but I cannot find either.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
