### PR TITLE
reputation: display user stats when thanked

### DIFF
--- a/reputation/plugin_bot.go
+++ b/reputation/plugin_bot.go
@@ -95,7 +95,15 @@ func handleMessageCreate(evt *eventsystem.EventData) {
 
 	go analytics.RecordActiveUnit(msg.GuildID, &Plugin{}, "auto_add_rep")
 
-	content := fmt.Sprintf("Gave +1 %s to **%s**", conf.PointsName, who.Mention())
+	newScore, newRank, err := GetUserStats(msg.GuildID, who.ID)
+	if err != nil {
+		newScore = -1
+		newRank = -1
+		logger.WithError(err).Error("Failed retrieving target stats")
+		return
+	}
+
+	content := fmt.Sprintf("Gave +1 %s to **%s** (current: `#%d` - `%d`)", conf.PointsName, who.Mention(), newRank, newScore)
 	common.BotSession.ChannelMessageSend(msg.ChannelID, content)
 }
 


### PR DESCRIPTION
Using variations of "thank you" in text to give rep doesn't show the updated rank and reputation like the actual commands. This PR makes the required changes to maintain consistency.