### PR TITLE
discordgo: fix button message component emoji errors

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -503,7 +503,7 @@ func (c *Context) SendResponse(content string) (*discordgo.Message, error) {
 					discordgo.Button{
 						Label:    "Show Server Info",
 						Style:    discordgo.PrimaryButton,
-						Emoji:    discordgo.ComponentEmoji{Name: "📬"},
+						Emoji:    &discordgo.ComponentEmoji{Name: "📬"},
 						CustomID: fmt.Sprintf("DM_%d", c.GS.ID),
 					},
 				},

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -368,7 +368,7 @@ func (c *Context) tmplSendMessage(filterSpecialMentions bool, returnID bool) fun
 						discordgo.Button{
 							Label:    "Show Server Info",
 							Style:    discordgo.PrimaryButton,
-							Emoji:    discordgo.ComponentEmoji{Name: "📬"},
+							Emoji:    &discordgo.ComponentEmoji{Name: "📬"},
 							CustomID: fmt.Sprintf("DM_%d", c.GS.ID),
 						},
 					},

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -52,7 +52,7 @@ func (c *Context) tmplSendDM(s ...interface{}) string {
 				discordgo.Button{
 					Label:    "Show Server Info",
 					Style:    discordgo.PrimaryButton,
-					Emoji:    discordgo.ComponentEmoji{Name: "📬"},
+					Emoji:    &discordgo.ComponentEmoji{Name: "📬"},
 					CustomID: fmt.Sprintf("DM_%d", c.GS.ID),
 				},
 			},

--- a/lib/cardsagainstdiscord/game.go
+++ b/lib/cardsagainstdiscord/game.go
@@ -130,17 +130,17 @@ func GetCommonCahButtons() []discordgo.MessageComponent {
 		discordgo.ActionsRow{
 			Components: []discordgo.MessageComponent{
 				discordgo.Button{
-					Emoji:    discordgo.ComponentEmoji{Name: JoinEmoji},
+					Emoji:    &discordgo.ComponentEmoji{Name: JoinEmoji},
 					Style:    discordgo.SuccessButton,
 					CustomID: CahGameJoined,
 				},
 				discordgo.Button{
-					Emoji:    discordgo.ComponentEmoji{Name: LeaveEmoji},
+					Emoji:    &discordgo.ComponentEmoji{Name: LeaveEmoji},
 					Style:    discordgo.DangerButton,
 					CustomID: CahGameLeft,
 				},
 				discordgo.Button{
-					Emoji:    discordgo.ComponentEmoji{Name: PlayPauseEmoji},
+					Emoji:    &discordgo.ComponentEmoji{Name: PlayPauseEmoji},
 					Style:    discordgo.PrimaryButton,
 					CustomID: CahGamePlayPause,
 				},
@@ -823,17 +823,17 @@ func (g *Game) presentPickedResponseCards(edit bool) {
 		discordgo.ActionsRow{
 			Components: []discordgo.MessageComponent{
 				discordgo.Button{
-					Emoji:    discordgo.ComponentEmoji{Name: JoinEmoji},
+					Emoji:    &discordgo.ComponentEmoji{Name: JoinEmoji},
 					Style:    discordgo.SuccessButton,
 					CustomID: CahGameJoined,
 				},
 				discordgo.Button{
-					Emoji:    discordgo.ComponentEmoji{Name: LeaveEmoji},
+					Emoji:    &discordgo.ComponentEmoji{Name: LeaveEmoji},
 					Style:    discordgo.DangerButton,
 					CustomID: CahGameLeft,
 				},
 				discordgo.Button{
-					Emoji:    discordgo.ComponentEmoji{Name: PlayPauseEmoji},
+					Emoji:    &discordgo.ComponentEmoji{Name: PlayPauseEmoji},
 					Style:    discordgo.PrimaryButton,
 					CustomID: CahGamePlayPause,
 				},

--- a/lib/discordgo/components.go
+++ b/lib/discordgo/components.go
@@ -127,10 +127,10 @@ type ComponentEmoji struct {
 
 // Button represents button component.
 type Button struct {
-	Label    string         `json:"label"`
-	Style    ButtonStyle    `json:"style"`
-	Disabled bool           `json:"disabled"`
-	Emoji    ComponentEmoji `json:"emoji"`
+	Label    string          `json:"label"`
+	Style    ButtonStyle     `json:"style"`
+	Disabled bool            `json:"disabled"`
+	Emoji    *ComponentEmoji `json:"emoji,omitempty"`
 
 	// NOTE: Only button with LinkButton style can have link. Also, URL is mutually exclusive with CustomID.
 	URL      string `json:"url,omitempty"`

--- a/notifications/plugin_bot.go
+++ b/notifications/plugin_bot.go
@@ -166,7 +166,7 @@ func sendTemplate(gs *dstate.GuildSet, cs *dstate.ChannelState, tmpl string, ms 
 					discordgo.Button{
 						Label:    "Show Server Info",
 						Style:    discordgo.PrimaryButton,
-						Emoji:    discordgo.ComponentEmoji{Name: "📬"},
+						Emoji:    &discordgo.ComponentEmoji{Name: "📬"},
 						CustomID: fmt.Sprintf("DM_%d", gs.ID),
 					},
 				},


### PR DESCRIPTION
Change discordgo.Button.Emoji to *discordgo.ComponentEmoji and include
the omitempty tag.

Discord no longer allows the `emojis` field in button objects to be
null, and instead require it be absent. This commit adds the "omitempty"
tag to the Emoji field, and changes the value to a pointer.

See also the suggested fix from the Discord Gophers server:
https://discord.com/channels/118456055842734083/155361364909621248/1192299819012722748