### PR TITLE
lib/discordgo: expose super reaction data

### DIFF
--- a/lib/discordgo/message.go
+++ b/lib/discordgo/message.go
@@ -158,7 +158,7 @@ type Message struct {
 	// This is a combination of bit masks; the presence of a certain permission can
 	// be checked by performing a bitwise AND between this int and the flag.
 	Flags MessageFlags `json:"flags"`
-  
+
 	Activity *MessageActivity `json:"activity"`
 }
 
@@ -365,9 +365,19 @@ func (e *MessageEmbed) MarshalJSON() ([]byte, error) {
 
 // MessageReactions holds a reactions object for a message.
 type MessageReactions struct {
-	Count int    `json:"count"`
-	Me    bool   `json:"me"`
-	Emoji *Emoji `json:"emoji"`
+	Count        int                          `json:"count"`
+	CountDetails MessageReactionsCountDetails `json:"count_details"`
+	Me           bool                         `json:"me"`
+	MeBurst      bool                         `json:"me_burst"`
+	Emoji        *Emoji                       `json:"emoji"`
+	BurstColors  []string                     `json:"burst_colors"`
+}
+
+// MessageReactionsCountDetails holds normal and super reaction counts for the
+// associated emoji.
+type MessageReactionsCountDetails struct {
+	Burst  int `json:"burst"`
+	Normal int `json:"normal"`
 }
 
 // ContentWithMentionsReplaced will replace all @<id> mentions with the


### PR DESCRIPTION
Allow accessing relevant super reaction data (for instance, via `.Message.Reactions` in custom commands), as requested in the popular suggestion no. 2114 on Discord.
