### PR TITLE
frontend: remove beta notice for read access

### DIFF
--- a/frontend/templates/cp_core_settings.html
+++ b/frontend/templates/cp_core_settings.html
@@ -18,8 +18,8 @@
                 <div class="card-body">
                     <div class="form-group">
                         <label>Allow people with the following roles <code>read</code> access the control panel
-                            <b>(beta)</b></label><br>
-                        <select class="multiselect" name="AllowedReadOnlyRoles" data-plugin-multiselect
+                            </label><br>
+                            <select class="multiselect" name="AllowedReadOnlyRoles" data-plugin-multiselect
                             multiple="multiple">
                             {{roleOptionsMulti .ActiveGuild.Roles nil .CoreConfig.AllowedReadOnlyRoles}}
                         </select>


### PR DESCRIPTION
Remove the beta notice for the control panel read access setting, as it
is certainly to be considered stable by now.

Definitely a small and very minor change, but I noticed it whilst I was
browsing the control panel for something else.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
