### PR TITLE
Add Forum Post Support

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -657,10 +657,16 @@ func baseContextFuncs(c *Context) {
 	c.addContextFunc("getPinCount", c.tmplGetChannelPins(true))
 	c.addContextFunc("getRole", c.tmplGetRole)
 	c.addContextFunc("getThread", c.tmplGetThread)
+
+	// thread functions
 	c.addContextFunc("createThread", c.tmplCreateThread)
 	c.addContextFunc("deleteThread", c.tmplDeleteThread)
 	c.addContextFunc("addThreadMember", c.tmplThreadMemberAdd)
 	c.addContextFunc("removeThreadMember", c.tmplThreadMemberRemove)
+
+	// forum functions
+	c.addContextFunc("createForumPost", c.tmplCreateForumPost)
+	c.addContextFunc("removeForumPost", c.tmplRemoveForumPost)
 
 	c.addContextFunc("currentUserAgeHuman", c.tmplCurrentUserAgeHuman)
 	c.addContextFunc("currentUserAgeMinutes", c.tmplCurrentUserAgeMinutes)

--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -666,7 +666,7 @@ func baseContextFuncs(c *Context) {
 
 	// forum functions
 	c.addContextFunc("createForumPost", c.tmplCreateForumPost)
-	c.addContextFunc("removeForumPost", c.tmplRemoveForumPost)
+	c.addContextFunc("deleteForumPost", c.tmplDeleteThread)
 
 	c.addContextFunc("currentUserAgeHuman", c.tmplCurrentUserAgeHuman)
 	c.addContextFunc("currentUserAgeMinutes", c.tmplCurrentUserAgeMinutes)

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -1424,6 +1424,7 @@ func (c *Context) tmplCreateThread(channel, msgID interface{}, name string, priv
 	return CtxChannelFromCS(&tstate), nil
 }
 
+// This function can delete both basic threads and forum threads
 func (c *Context) tmplDeleteThread(thread interface{}) (string, error) {
 
 	if c.IncreaseCheckCallCounterPremium("delete_thread", 1, 1) {
@@ -1646,10 +1647,6 @@ func (c *Context) tmplCreateForumPost(channel interface{}, name string, content 
 	c.AddThreadToGuildSet(&tstate)
 
 	return CtxChannelFromCS(&tstate), nil
-}
-
-func (c *Context) tmplRemoveForumPost(thread interface{}) (string, error) {
-	return c.tmplDeleteThread(thread)
 }
 
 func (c *Context) tmplGetChannelOrThread(channel interface{}) (*CtxChannel, error) {

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -1371,7 +1371,7 @@ func (c *Context) AddThreadToGuildSet(t *dstate.ChannelState) {
 	c.GS = &gsCopy
 }
 
-func (c *Context) tmplCreateThread(channel, msgID interface{}, name string, private ...interface{}) (*CtxChannel, error) {
+func (c *Context) tmplCreateThread(channel, msgID, name interface{}, private ...interface{}) (*CtxChannel, error) {
 
 	if c.IncreaseCheckCallCounterPremium("create_thread", 1, 1) {
 		return nil, ErrTooManyCalls
@@ -1400,10 +1400,10 @@ func (c *Context) tmplCreateThread(channel, msgID interface{}, name string, priv
 	}
 
 	start := &discordgo.ThreadStart{
-		Name:                name,
-		AutoArchiveDuration: 10080, // 7 days
-		Type:                threadType,
-		Invitable:           false,
+		Name: ToString(name),
+		//AutoArchiveDuration: 10080, // 7 days
+		Type:      threadType,
+		Invitable: false,
 	}
 
 	var ctxThread *discordgo.Channel
@@ -1584,7 +1584,7 @@ func ProcessOptionalForumPostArgs(c *dstate.ChannelState, values ...interface{})
 	return rateLimit, tags, nil
 }
 
-func (c *Context) tmplCreateForumPost(channel interface{}, name string, content interface{}, optional ...interface{}) (*CtxChannel, error) {
+func (c *Context) tmplCreateForumPost(channel, name, content interface{}, optional ...interface{}) (*CtxChannel, error) {
 
 	// shares same counter as create thread
 	if c.IncreaseCheckCallCounterPremium("create_thread", 1, 1) {
@@ -1615,7 +1615,7 @@ func (c *Context) tmplCreateForumPost(channel interface{}, name string, content 
 	}
 
 	start := &discordgo.ThreadStart{
-		Name:             name,
+		Name:             ToString(name),
 		Type:             discordgo.ChannelTypeGuildPublicThread,
 		Invitable:        false,
 		RateLimitPerUser: rateLimit,

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -1583,7 +1583,7 @@ func ProcessOptionalForumPostArgs(c *dstate.ChannelState, values ...interface{})
 	return rateLimit, tags, nil
 }
 
-func (c *Context) tmplCreateForumPost(channel, content interface{}, name string, optional ...interface{}) (*CtxChannel, error) {
+func (c *Context) tmplCreateForumPost(channel interface{}, name string, content interface{}, optional ...interface{}) (*CtxChannel, error) {
 
 	// shares same counter as create thread
 	if c.IncreaseCheckCallCounterPremium("create_thread", 1, 1) {

--- a/common/templates/structs.go
+++ b/common/templates/structs.go
@@ -15,6 +15,7 @@ type CtxChannel struct {
 	GuildID   int64
 	IsPrivate bool
 	IsThread  bool
+	IsForum   bool
 
 	Name                 string                           `json:"name"`
 	Type                 discordgo.ChannelType            `json:"type"`
@@ -25,6 +26,9 @@ type CtxChannel struct {
 	PermissionOverwrites []*discordgo.PermissionOverwrite `json:"permission_overwrites"`
 	ParentID             int64                            `json:"parent_id"`
 	OwnerID              int64                            `json:"owner_id"`
+
+	AvailableTags []discordgo.ForumTag `json:"available_tags"`
+	AppliedTags   []int64              `json:"applied_tags"`
 }
 
 func (c *CtxChannel) Mention() (string, error) {
@@ -45,6 +49,7 @@ func CtxChannelFromCS(cs *dstate.ChannelState) *CtxChannel {
 		ID:                   cs.ID,
 		IsPrivate:            cs.IsPrivate(),
 		IsThread:             cs.Type.IsThread(),
+		IsForum:              cs.Type.IsForum(),
 		GuildID:              cs.GuildID,
 		Name:                 cs.Name,
 		Type:                 cs.Type,
@@ -55,6 +60,8 @@ func CtxChannelFromCS(cs *dstate.ChannelState) *CtxChannel {
 		PermissionOverwrites: cop,
 		ParentID:             cs.ParentID,
 		OwnerID:              cs.OwnerID,
+		AvailableTags:        cs.AvailableTags,
+		AppliedTags:          cs.AppliedTags,
 	}
 
 	return ctxChannel

--- a/lib/discordgo/structs.go
+++ b/lib/discordgo/structs.go
@@ -158,6 +158,28 @@ type Invite struct {
 // ChannelType is the type of a Channel
 type ChannelType int
 
+// ForumSortOrderType represents sort order of a forum channel.
+type ForumSortOrderType int
+
+const (
+	// ForumSortOrderLatestActivity sorts posts by activity.
+	ForumSortOrderLatestActivity ForumSortOrderType = 0
+	// ForumSortOrderCreationDate sorts posts by creation time (from most recent to oldest).
+	ForumSortOrderCreationDate ForumSortOrderType = 1
+)
+
+// ForumLayout represents layout of a forum channel.
+type ForumLayout int
+
+const (
+	// ForumLayoutNotSet represents no default layout.
+	ForumLayoutNotSet ForumLayout = 0
+	// ForumLayoutListView displays forum posts as a list.
+	ForumLayoutListView ForumLayout = 1
+	// ForumLayoutGalleryView displays forum posts as a collection of tiles.
+	ForumLayoutGalleryView ForumLayout = 2
+)
+
 // Block contains known ChannelType values
 const (
 	ChannelTypeGuildText          ChannelType = 0  // a text channel within a server
@@ -176,6 +198,10 @@ const (
 
 func (t ChannelType) IsThread() bool {
 	return t == ChannelTypeGuildPrivateThread || t == ChannelTypeGuildPublicThread
+}
+
+func (t ChannelType) IsForum() bool {
+	return t == ChannelTypeGuildForum
 }
 
 // A Channel holds all data related to an individual Discord channel.
@@ -237,6 +263,27 @@ type Channel struct {
 
 	// Thread specific fields
 	ThreadMetadata *ThreadMetadata `json:"thread_metadata"`
+
+	// The set of tags that can be used in a forum channel.
+	AvailableTags []ForumTag `json:"available_tags"`
+
+	// The IDs of the set of tags that have been applied to a thread in a forum channel.
+	AppliedTags IDSlice `json:"applied_tags"`
+
+	// Emoji to use as the default reaction to a forum post.
+	DefaultReactionEmoji ForumDefaultReaction `json:"default_reaction_emoji"`
+
+	// The initial RateLimitPerUser to set on newly created threads in a channel.
+	// This field is copied to the thread at creation time and does not live update.
+	DefaultThreadRateLimitPerUser int `json:"default_thread_rate_limit_per_user"`
+
+	// The default sort order type used to order posts in forum channels.
+	// Defaults to null, which indicates a preferred sort order hasn't been set by a channel admin.
+	DefaultSortOrder *ForumSortOrderType `json:"default_sort_order"`
+
+	// The default forum layout view used to display posts in forum channels.
+	// Defaults to ForumLayoutNotSet, which indicates a layout view has not been set by a channel admin.
+	DefaultForumLayout ForumLayout `json:"default_forum_layout"`
 }
 
 func (c *Channel) GetChannelID() int64 {
@@ -297,7 +344,7 @@ type ThreadStart struct {
 	RateLimitPerUser    int         `json:"rate_limit_per_user,omitempty"`
 
 	// NOTE: forum threads only - these are IDs
-	AppliedTags []string `json:"applied_tags,string,omitempty"`
+	AppliedTags IDSlice `json:"applied_tags,string,omitempty"`
 }
 
 // ThreadsList represents a list of threads alongisde with thread member objects for the current user.
@@ -318,7 +365,7 @@ type AddedThreadMember struct {
 // NOTE: Exactly one of EmojiID and EmojiName must be set.
 type ForumDefaultReaction struct {
 	// The id of a guild's custom emoji.
-	EmojiID string `json:"emoji_id,omitempty"`
+	EmojiID int64 `json:"emoji_id,string,omitempty"`
 	// The unicode character of the emoji.
 	EmojiName string `json:"emoji_name,omitempty"`
 }

--- a/lib/dstate/helpers.go
+++ b/lib/dstate/helpers.go
@@ -151,17 +151,23 @@ func ChannelStateFromDgo(c *discordgo.Channel) ChannelState {
 	}
 
 	return ChannelState{
-		ID:                   c.ID,
-		GuildID:              c.GuildID,
-		PermissionOverwrites: pos,
-		ParentID:             c.ParentID,
-		Name:                 c.Name,
-		Topic:                c.Topic,
-		Type:                 c.Type,
-		NSFW:                 c.NSFW,
-		Position:             c.Position,
-		Bitrate:              c.Bitrate,
-		OwnerID:              c.OwnerID,
+		ID:                            c.ID,
+		GuildID:                       c.GuildID,
+		PermissionOverwrites:          pos,
+		ParentID:                      c.ParentID,
+		Name:                          c.Name,
+		Topic:                         c.Topic,
+		Type:                          c.Type,
+		NSFW:                          c.NSFW,
+		Position:                      c.Position,
+		Bitrate:                       c.Bitrate,
+		OwnerID:                       c.OwnerID,
+		AvailableTags:                 c.AvailableTags,
+		AppliedTags:                   c.AppliedTags,
+		DefaultReactionEmoji:          c.DefaultReactionEmoji,
+		DefaultThreadRateLimitPerUser: c.DefaultThreadRateLimitPerUser,
+		DefaultSortOrder:              c.DefaultSortOrder,
+		DefaultForumLayout:            c.DefaultForumLayout,
 	}
 }
 

--- a/lib/dstate/interface.go
+++ b/lib/dstate/interface.go
@@ -263,6 +263,14 @@ type ChannelState struct {
 	ThreadMetadata   *discordgo.ThreadMetadata `json:"thread_metadata"`
 
 	PermissionOverwrites []discordgo.PermissionOverwrite `json:"permission_overwrites"`
+
+	AvailableTags []discordgo.ForumTag `json:"available_tags"`
+	AppliedTags   []int64              `json:"applied_tags"`
+
+	DefaultReactionEmoji          discordgo.ForumDefaultReaction `json:"default_reaction_emoji"`
+	DefaultThreadRateLimitPerUser int                            `json:"default_thread_rate_limit_per_user"`
+	DefaultSortOrder              *discordgo.ForumSortOrderType  `json:"default_sort_order"`
+	DefaultForumLayout            discordgo.ForumLayout          `json:"default_forum_layout"`
 }
 
 func (c *ChannelState) IsPrivate() bool {


### PR DESCRIPTION
Continuation of #1604 and #1453 

This PR does two things:
* Updates discordgo, dstate with new fields related to forums (available tags, applied tags, default thread rate limits, etc.)
* Adds `createForumPost` and `deleteForumPost` templates

Other Info:
* Limits for create and remove are currently shared with thread's create and remove limits
* Optional args for `createForumPost` are set to use key-value style so that order doesn't matter and we can also expose other optional args later

API (templates):

Field | Description
--- | ---
.Channel.IsForum | true if channel is forum type
.Channel.AvailableTags | Slice of discordgo.ForumTag. Only present if channel is forum type.
.Channel.AppliedTags | Slice of int64 representing tag ids. Only present if channel represents a specific forum thread/post.

API (functions):

#### createForumPost channel name content (optional: "slowmode" arg "tags" arg)
> Creates a new forum post in `channel`. `content` can be a string, embed or complex message. `name` represents the title of the post. `"slowmode" arg` allows the user to specify the thread's slowmode (in seconds). `"tags" arg` allows the user to specify one or more forum tags. Duplicate and invalid tags are ignored, and `arg` can be either a string or cslice. Returns *templates.CtxChannel upon success.

#### deleteForumPost post
> Removes `post`. Can be either thread's ID or mention.

Examples:

(Create)

    {{$forumChannel := ...}}
    {{$postTitle := "Forum Post Title"}}
    {{$post := createForumPost $forumChannel $postTitle "post content as string"}}

    {{$tags = cslice "discussion" "bot" "info"}}
    {{$post = createForumPost $forumChannel $postTitle (cembed ...) "tags" $tags}}

    {{$oneMinute := 60}}
    {{$post = createForumPost $forumChannel $postTitle (cembed ...) "slowmode" $oneMinute}}

    {{$post = createForumPost $forumChannel $postTitle (cembed ...) "tags" $tags "slowmode" $oneMinute}}

(Delete)

    {{deleteForumPost $post.ID}}
