### PR TITLE
fix: thanks detection logic for blacklist/whitelist

### DIFF
--- a/reputation/plugin_bot.go
+++ b/reputation/plugin_bot.go
@@ -69,7 +69,7 @@ func handleMessageCreate(evt *eventsystem.EventData) {
 	}
 
 	// Check if thanks detection is allowed in the parent channel
-	if cState.Type.IsForum() || cState.Type.IsThread() {
+	if cState.Type.IsThread() {
 		if !isThanksDetectionAllowedInChannel(conf, cState.ParentID) {
 			return
 		}

--- a/reputation/plugin_bot.go
+++ b/reputation/plugin_bot.go
@@ -63,8 +63,20 @@ func handleMessageCreate(evt *eventsystem.EventData) {
 		return
 	}
 
-	if !isThanksDetectionAllowedInChannel(conf, msg.ChannelID) {
-		return
+	cState := evt.CSOrThread()
+	if cState == nil {
+		return // No channel state, ignore
+	}
+
+	// Check if thanks detection is allowed in the parent channel
+	if cState.Type.IsForum() || cState.Type.IsThread() {
+		if !isThanksDetectionAllowedInChannel(conf, cState.ParentID) {
+			return
+		}
+	} else {
+		if !isThanksDetectionAllowedInChannel(conf, msg.ChannelID) {
+			return
+		}
 	}
 
 	who := msg.Mentions[0]

--- a/reputation/plugin_bot.go
+++ b/reputation/plugin_bot.go
@@ -68,15 +68,13 @@ func handleMessageCreate(evt *eventsystem.EventData) {
 		return // No channel state, ignore
 	}
 
+	channelID := msg.ChannelID
 	// Check if thanks detection is allowed in the parent channel
 	if cState.Type.IsThread() {
-		if !isThanksDetectionAllowedInChannel(conf, cState.ParentID) {
-			return
-		}
-	} else {
-		if !isThanksDetectionAllowedInChannel(conf, msg.ChannelID) {
-			return
-		}
+		channelID = cState.ParentID
+	}
+	if !isThanksDetectionAllowedInChannel(conf, channelID) {
+		return
 	}
 
 	who := msg.Mentions[0]


### PR DESCRIPTION
## Problem

When you add channels for 
**Whitelisted channels for giving rep using thanks** 
or 
**Blacklisted channels for giving rep using thanks**
in reputation in `/manage/server_id/reputation` page

Bot still allows in threads in blacklisted channels
Bot doesn't work in threads in whitelisted channels