### PR TITLE
customcommands: add support for time.Duration multiplication and division

### DIFF
--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -634,9 +634,9 @@ func tmplMult(args ...interface{}) interface{} {
 		return 0
 	}
 
-	switch args[0].(type) {
+	switch a := args[0].(type) {
 	case float32, float64:
-		sumF := ToFloat64(args[0])
+		sumF := ToFloat64(a)
 		for i, v := range args {
 			if i == 0 {
 				continue
@@ -645,8 +645,28 @@ func tmplMult(args ...interface{}) interface{} {
 			sumF *= ToFloat64(v)
 		}
 		return sumF
+	case time.Duration:
+		sumD := a
+		for i, v := range args {
+			if i == 0 {
+				continue
+			}
+
+			sumD *= time.Duration(tmplToInt(v))
+		}
+		return sumD
+	case *time.Duration:
+		sumD := *a
+		for i, v := range args {
+			if i == 0 {
+				continue
+			}
+
+			sumD *= time.Duration(tmplToInt(v))
+		}
+		return sumD
 	default:
-		sumI := tmplToInt(args[0])
+		sumI := tmplToInt(a)
 		for i, v := range args {
 			if i == 0 {
 				continue
@@ -663,9 +683,9 @@ func tmplDiv(args ...interface{}) interface{} {
 		return 0
 	}
 
-	switch args[0].(type) {
+	switch a := args[0].(type) {
 	case float32, float64:
-		sumF := ToFloat64(args[0])
+		sumF := ToFloat64(a)
 		for i, v := range args {
 			if i == 0 {
 				continue
@@ -674,8 +694,28 @@ func tmplDiv(args ...interface{}) interface{} {
 			sumF /= ToFloat64(v)
 		}
 		return sumF
+	case time.Duration:
+		sumD := a
+		for i, v := range args {
+			if i == 0 {
+				continue
+			}
+
+			sumD /= time.Duration(tmplToInt(v))
+		}
+		return sumD
+	case *time.Duration:
+		sumD := *a
+		for i, v := range args {
+			if i == 0 {
+				continue
+			}
+
+			sumD /= time.Duration(tmplToInt(v))
+		}
+		return sumD
 	default:
-		sumI := tmplToInt(args[0])
+		sumI := tmplToInt(a)
 		for i, v := range args {
 			if i == 0 {
 				continue


### PR DESCRIPTION
Multiplying or dividing a `time.Duration` value with an integer currently returns an integer value, not a `time.Duration` value. This greatly limits functionality, and is against go convention which encourages multiplication of `time.Duration` constants.

This pr adds special functionality for `time.Duration` values to properly multiply or divide them with the `mult` and `div` functions and return a `time.Duration` value.

<img width="567" alt="Screenshot 2024-02-25 at 00 33 06" src="https://github.com/botlabs-gg/yagpdb/assets/110698921/ced1c76e-3714-4972-a8b4-5c92760a4cfa">

This is a breaking change, if anyone is currently multiplying time constants and expecting an int64 return of the nanosecond count this will break functionality.