### PR TITLE
customcommands: populate ctx.Msg in evalcc

### DIFF
--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -156,6 +156,7 @@ var cmdEvalCommand = &commands.YAGCommand{
 		channel := data.GuildData.CS
 		ctx := templates.NewContext(data.GuildData.GS, channel, data.GuildData.MS)
 		ctx.ExecutedFrom = templates.ExecutedFromEvalCC
+		ctx.Msg = data.TraditionalTriggerData.Message
 
 		// use stripped message content instead of parsed arg data to avoid dcmd
 		// from misinterpreting backslashes and losing spaces in input; see


### PR DESCRIPTION
Populate templates.Context's Msg field with a copy of the triggering
message that launched evalcc.

This bug was caught via my own testing; I was looking to launch replog
via exec and used evalcc for that — it did not work. The reason is, that
the exec (and by extension the execAdmin) logic make a copy of
templates.Context.Msg, which was never populated.

By populating it, we ensure that the exec logic has a message to work
with and thusly cooporate as expected with restricted inbuilt commands
like replog.

This is defintely a bug, given how evalcc is supposed to behave *almost
like* a normal custom command.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
