### PR TITLE
Update tickets_commands.go: fix typo

### DIFF
--- a/tickets/tickets_commands.go
+++ b/tickets/tickets_commands.go
@@ -441,7 +441,7 @@ func createLogs(gs *dstate.GuildSet, conf *models.TicketConfig, ticket *models.T
 			// download attachments
 		OUTER:
 			for _, att := range msg.Attachments {
-				msg.Content += fmt.Sprintf("(attatchment: %s)", att.Filename)
+				msg.Content += fmt.Sprintf("(attachment: %s)", att.Filename)
 
 				totalAttachmentSize += att.Size
 				if totalAttachmentSize > 500000000 {


### PR DESCRIPTION
fix typo `attatchment` -> `attachment`
I'm a mod in a server that uses tickets heavily for moderation and often puts screenshots in them. Seeing this typo just bothers me all the time I'm backreading ticket logs