### PR TITLE
customcommands: public ccs

### DIFF
--- a/customcommands/assets/customcommands-editcmd.html
+++ b/customcommands/assets/customcommands-editcmd.html
@@ -15,9 +15,14 @@
 <!-- Nav -->
 <div class="row">
     <div class="col">
+        {{$publicAccess := .PublicAccess}}
+        {{$publicDisabled := ""}}
+        {{if $publicAccess}}
+            {{$publicDisabled = "disabled"}}
+        {{end}}
         <!-- Nav tabs -->
         <div class="tabs">
-            <ul class="nav nav-tabs">
+            <ul class="nav nav-tabs public-hidden">
                 <li class="nav-item {{if and (not .CurrentCommandGroup)}}active{{end}}">
                     <a data-partial-load="true" class="nav-link show {{if not .CurrentCommandGroup}}active{{end}}"
                         href="/manage/{{.ActiveGuild.ID}}/customcommands/">Ungrouped</a>
@@ -74,7 +79,7 @@
                                     <div class="col">
                                         <div class="form-group">
                                             <label>Trigger type</label>
-                                            <select class="form-control" id="trigger-type-dropdown" name="type"
+                                            <select class="form-control public-disabled" id="trigger-type-dropdown" name="type"
                                                 onchange="triggerTypeChanged(this)">
 
                                                 <option value="none" {{if eq .CC.TriggerType 10}}selected{{end}}>None
@@ -148,12 +153,14 @@
                                                 <div class="input-group-prepend" id="command-trigger-prepended-prefix">
                                                     <div class="input-group-text">{{.CommandPrefix}}</div>
                                                 </div>
-                                                <input id="trigger" type="text" class="form-control" name="trigger" placeholder="fun"
+                                                <input id="trigger" type="text" class="form-control public-disabled" name="trigger" placeholder="fun"
                                                     value="{{.CC.TextTrigger}}">
                                             </div>
-                                            {{checkbox "case_sensitive" "case_sensitive" "Case Sensitive?" .CC.TextTriggerCaseSensitive}}
+                                            {{checkbox "case_sensitive" "case_sensitive" "Case Sensitive?"
+                                            .CC.TextTriggerCaseSensitive $publicDisabled}}
                                             {{$disabledClass := ""}}
-                                            {{if not .IsGuildPremium}}{{$disabledClass = "disabled"}}{{end}}
+                                            {{if or (not .IsGuildPremium) $publicAccess}}{{$disabledClass =
+                                            "disabled"}}{{end}}
                                             {{checkbox "trigger_on_edit" "trigger_on_edit" "Trigger on message edits too? (Premium Only!)" .CC.TriggerOnEdit $disabledClass}}
                                         </div>
                                     </div>
@@ -163,7 +170,7 @@
                                 <div class="row">
                                     <div class="col-sm-12">
                                         <div class="form-check">
-                                            <input class="form-check-input" type="radio" name="reaction_trigger_mode"
+                                            <input class="form-check-input public-disabled" type="radio" name="reaction_trigger_mode"
                                                 id="reaction-mode-both-{{.CC.LocalID}}" value="0"
                                                 {{if eq .CC.ReactionTriggerMode 0}}checked{{end}}>
                                             <label class="form-check-label" for="reaction-mode-both-{{.CC.LocalID}}">
@@ -171,7 +178,7 @@
                                             </label>
                                         </div>
                                         <div class="form-check">
-                                            <input class="form-check-input" type="radio" name="reaction_trigger_mode"
+                                            <input class="form-check-input public-disabled" type="radio" name="reaction_trigger_mode"
                                                 id="reaction-mode-added-{{.CC.LocalID}}" value="1"
                                                 {{if eq .CC.ReactionTriggerMode 1}}checked{{end}}>
                                             <label class="form-check-label" for="reaction-mode-added-{{.CC.LocalID}}">
@@ -179,7 +186,7 @@
                                             </label>
                                         </div>
                                         <div class="form-check">
-                                            <input class="form-check-input" type="radio" name="reaction_trigger_mode"
+                                            <input class="form-check-input public-disabled" type="radio" name="reaction_trigger_mode"
                                                 id="reaction-mode-removed-{{.CC.LocalID}}" value="2"
                                                 {{if eq .CC.ReactionTriggerMode 2}}checked{{end}}>
                                             <label class="form-check-label" for="reaction-mode-removed-{{.CC.LocalID}}">
@@ -194,14 +201,14 @@
                                     <div class="col-sm-4">
                                         <div class="form-group">
                                             <label>Interval</label>
-                                            <input type="number" min="0" class="form-control" name="time_trigger_interval"
+                                            <input type="number" min="0" class="form-control public-disabled" name="time_trigger_interval"
                                                 placeholder="" value="{{call $dot.GetCCInterval .CC}}">
                                         </div>
                                     </div>
                                     <div class="col-sm-8">
                                         <div class="form-group">
                                             <label>Channel</label>
-                                            <select id="time-trigger-channel" name="context_channel" class="form-control">
+                                            <select id="time-trigger-channel" name="context_channel" class="form-control public-disabled">
                                                 {{textChannelOptions $g.Channels .CC.ContextChannel true "None"}}
                                             </select>
                                         </div>
@@ -211,7 +218,7 @@
                                     <div class="col-sm-6">
                                         <div class="form-group">
                                             <label for="trigger">Excluding hours (UTC)</label><br>
-                                            <select name="time_trigger_excluding_hours" class="multiselect form-control"
+                                            <select name="time_trigger_excluding_hours" class="multiselect form-control public-disabled"
                                                 multiple="multiple" data-plugin-multiselect>
                                                 {{$selectedExclHours := .CC.TimeTriggerExcludingHours}}
                                                 {{range seq 0 24}}<option value="{{.}}"
@@ -223,7 +230,7 @@
                                     <div class="col-sm-6">
                                         <div class="form-group">
                                             <label for="trigger">Excluding weekdays (UTC)</label><br>
-                                            <select name="time_trigger_excluding_days" class="multiselect form-control"
+                                            <select name="time_trigger_excluding_days" class="multiselect form-control public-disabled"
                                                 multiple="multiple" data-plugin-multiselect>
                                                 <option value="1"
                                                     {{if in .CC.TimeTriggerExcludingDays 1}}selected{{end}}>
@@ -256,15 +263,19 @@
                             <div class="col-sm-4">
                                 <div class="form-group">
                                     <label>Name (<span id="name-length">{{len .CC.Name.String}}</span>/100) </label>
-                                    <input type="text" class="form-control" id="name" name="name" placeholder="Enter a name" value="{{if .CC.Name.Valid}}{{.CC.Name.String}}{{end}}">
+                                    <input type="text" class="form-control public-disabled" id="name" name="name" placeholder="Enter a name" value="{{if .CC.Name.Valid}}{{.CC.Name.String}}{{end}}">
                                     <p>An optional name that can be used to identify the command.</p>
                                 </div>
                             </div>
-                             <div class="col-sm-4">
+                             <div class="col-sm-4 public-hidden">
                                 <div class="form-group">
                                     <br/>
                                     <label> Command Enabled?</label>
-                                    {{checkbox "is_enabled" "is_enabled" "Enables or Disables the command" (not .CC.Disabled) }}
+                                    {{checkbox "is_enabled" "is_enabled" "Enables or Disables the command" (not .CC.Disabled)}}
+                                    <label> Public?</label>
+                                    {{checkbox "public" "public" "Allows non-members to view the CC with a link" .CC.Public}}
+                                    <a class="mb-1 mt-1 mr-1 modal-basic btn btn-info btn-md"
+                                        href="#cc-share-modal">Share this Command</a>
                                 </div>
                             </div>
                         </div>
@@ -274,19 +285,31 @@
                                     <label for="responses">Response (<span
                                             class="cc-length-counter">x</span>/10000)</label>
                                     <!-- Use .btn-add for simplicity and let the page loader adjust. -->
-                                    {{range .CC.Responses}}
+                                    {{range $i, $r := .CC.Responses}}
+                                    <button id="copy-response-{{$i}}-button" class="btn btn-quaternary">Copy Text</button>
+                                    <script>
+                                        document.getElementById("copy-response-{{$i}}-button").addEventListener("click", function() {
+                                            copyField("response-{{$i}}", "copy-response-{{$i}}-button");
+                                        }, false);
+                                    </script>
                                     <div class="entry input-group  input-group-sm">
-                                        <textarea class="form-control response-text-area tab-textbox cc-editor" name="responses"
+                                        <textarea id="response-{{$i}}" class="form-control response-text-area
+                                        tab-textbox cc-editor public-hidden" name="responses"
                                             placeholder="Command body here" rows="5"
-                                            oninput="onCCChanged(this)">{{.}}</textarea>
-                                        <span class="input-group-append">
+                                            oninput="onCCChanged(this)">{{$r}}</textarea>
+                                        <span class="input-group-append public-hidden">
                                             <button class="btn btn-success btn-add btn-circle" type="button">
                                                 <i class="fas fa-plus"></i>
                                             </button>
                                         </span>
+                                        {{if $publicAccess}}
+                                        <pre class="m-0"><div class="code
+                                        gotmplmd">{{$r}}</div></pre>
+                                        {{end}}
                                     </div>
                                     {{else}}
                                     <div class="entry input-group  input-group-sm">
+                                        {{if not $publicAccess}}
                                         <textarea class="form-control response-text-area tab-textbox cc-editor" name="responses"
                                             placeholder="Command body here" rows="5"
                                             oninput="onCCChanged(this)"></textarea>
@@ -295,14 +318,17 @@
                                                 <i class="fas fa-plus"></i>
                                             </button>
                                         </span>
+                                        {{else}}
+                                        <p>This command has no responses.</p>
+                                        {{end}}
                                     </div>
                                     {{end}}
-                                    <a class="mb-1 mt-1 mr-1 modal-basic btn btn-info btn-sm"
+                                    <a class="mb-1 mt-1 mr-1 modal-basic btn btn-info btn-sm public-hidden"
                                         href="#cc-help-modal">Info</a>
                                 </div>
                             </div>
                         </div>
-                        <div class="row">
+                        <div class="row public-hidden">
                             <div class="col-sm-6">
                                 <div class="form-group">
                                     <label>Custom command group</label>
@@ -385,7 +411,7 @@
                             </div>
                         </div>
 
-                        <div class="row mt-4">
+                        <div class="row mt-4 public-hidden">
                             <div class="col">
                                 <button type="submit" class="btn btn-success btn-block"
                                     formaction="/manage/{{$guild}}/customcommands/commands/{{.CC.LocalID}}/update"
@@ -398,13 +424,13 @@
                                     formaction="/manage/{{$guild}}/customcommands/commands/{{.CC.LocalID}}/delete">Delete</button>
                             </div>
                         </div>
-                        <div class="row mt-4" id="interval-cc-run-now">
+                        <div class="row mt-4 public-hidden" id="interval-cc-run-now">
                             <div class="col">
                                 <button type="submit" class="btn btn-secondary btn-block" title="This will trigger this custom command immediately"
                                     formaction="/manage/{{$guild}}/customcommands/commands/{{.CC.LocalID}}/update_and_run">Run now</button>
                             </div>
                         </div>
-                        <p class="help-block">Tip: Alt + Shift + S also saves the custom command </p>
+                        <p class="help-block public-hidden">Tip: Alt + Shift + S also saves the custom command </p>
                     </form>
                 </div>
             </div>
@@ -457,6 +483,37 @@
     </section>
 </div>
 
+<div id="cc-share-modal" class="modal-block modal-header-color modal-block-info mfp-hide">
+    <section class="card">
+        <header class="card-header">
+            <h2 class="card-title">Share Custom Command</h2>
+        </header>
+        <div class="card-body">
+            <div class="modal-wrapper">
+                <div class="modal-text">
+                    <p class="help-block">To share custom command #<code>{{.CC.LocalID}}</code>, copy the link below.
+                    </p>
+                    <br>
+                    <input type="text" id="public-link" class="form-control" name="Public Link" value="{{.PublicLink}}" readonly>
+                    <button id="copy-link-button" class="btn btn-quaternary">Copy Text</button>
+                    <script>
+                        document.getElementById("copy-link-button").addEventListener("click", function() {
+                            copyField("public-link", "copy-link-button");
+                        }, false);
+                    </script>
+                </div>
+            </div>
+        </div>
+        <footer class="card-footer">
+            <div class="row">
+                <div class="col-md-12 text-right">
+                    <button class="btn btn-info modal-dismiss">OK</button>
+                </div>
+            </div>
+        </footer>
+    </section>
+</div>
+
 <script src="/static/vendorr/tln/tln.min.js"></script>
 <link rel="stylesheet" href="/static/vendorr/tln/tln.min.css">
 <style>
@@ -464,6 +521,10 @@
         background: #191c21;
     }
 </style>
+
+<script src="/static/vendorr/highlightjs/highlight.pack.js"></script>
+<script src="/static/vendorr/highlightjs/line-numbers.js"></script>
+<link rel="stylesheet" href="/static/vendorr/highlightjs/atom-one-dark.css">
 
 <script type="text/javascript">
     function isTextTrigger(t) {
@@ -515,7 +576,7 @@
             $("#cc-text-trigger-details").removeClass("hidden");
             $("#cc-extra-settings").removeClass("hidden");
 
-            $("#cc-reaction-trigger-details").addClass("hidden")
+            $("#cc-reaction-trigger-details").addClass("hidden");
             $("#cc-time-trigger-details").addClass("hidden");
 
             $("#interval-cc-run-now").addClass("hidden")
@@ -558,6 +619,7 @@
         handleRestrictionChange($("#require-role-mode").prop("checked"), $("#command-roles"), "require-no-roles-warning", requireNoRolesWarning);
         handleRestrictionChange($("#require-channel-mode").prop("checked"), $("#command-channels"), "require-no-channels-warning", requireNoChannelsWarning);
         triggerTypeChanged();
+        publicAccessClasses();
     })
 
     $("#trigger").keyup(function() {
@@ -663,6 +725,87 @@
         }
       } 
     });
+                    
+    function copyField(fieldID, buttonID) {
+                            var copyText = document.getElementById(fieldID);
+                            copyText.select();
+                            copyText.setSelectionRange(0, 99999); // For mobile devices
+                        
+                            navigator.clipboard.writeText(copyText.value);
+                        
+                            var button = document.getElementById(buttonID);
+                            button.innerHTML = "Copied";
+                            button.disabled = true;
+                            setTimeout(() => { button.innerHTML = "Copy Text"; }, 3000);
+                            setTimeout(() => { button.disabled = false; }, 3000);
+                        };
+
+    function publicAccessClasses() {
+        if ({{.PublicAccess}}) {
+            var hideElements = document.getElementsByClassName("public-hidden");
+            for (var i = 0, len = hideElements.length; i < len; i++) {
+                hideElements[i].hidden = true;
+            };
+            var disableElements = document.getElementsByClassName("public-disabled");
+            for (var i = 0, len = disableElements.length; i < len; i++) {
+                disableElements[i].disabled = true;
+            };
+        };
+
+        // Register the custom language for readonly mode
+        // its based off markdown with custom stuff in tags
+        hljs.registerLanguage("gotmplmd", function (hljs) {
+            var KEYWORDS = {
+                keyword:
+                    'for range if else template end',
+                literal:
+                    'true false nil',
+                "built-in":
+                    'gt lt len index{{.HLJSBuiltins}}'
+            };
+
+            return {
+                aliases: ['gomd'],
+                case_insensitive: true,
+                subLanguage: 'markdown',
+                contains: [
+                    hljs.COMMENT(/\{\{\s?\/\*/, /\*\/\s?\}\}/),
+                    {
+                        // open block statement
+                        className: 'template-tag',
+                        begin: /\{\{/, end: /\}\}/,
+                        keywords: KEYWORDS,
+                        contains: [
+                            {
+                                className: 'string',
+                                variants: [
+                                    hljs.QUOTE_STRING_MODE,
+                                    { begin: '\'', end: '[^\\\\]\'' },
+                                    { begin: '`', end: '`' },
+                                ]
+                            },
+                            {
+                                className: 'number',
+                                variants: [
+                                    { begin: hljs.C_NUMBER_RE + '[i]', relevance: 1 },
+                                    hljs.C_NUMBER_MODE
+                                ]
+                            },
+                            {
+                                className: 'name',
+                                begin: /(\.|\$)\w+/,
+                            }
+                        ],
+                    },
+                ]
+            };
+        })
+
+        document.querySelectorAll('div.code').forEach((block) => {
+            hljs.highlightBlock(block);
+            hljs.lineNumbersBlock(block);
+        });
+    };
 </script>
 
 

--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -243,7 +243,7 @@ var cmdListCommands = &commands.YAGCommand{
 		}
 
 		var ccFile *discordgo.File
-		var msg *discordgo.MessageSend
+		msg := &discordgo.MessageSend{Flags: discordgo.MessageFlagsSuppressEmbeds}
 
 		responses := fmt.Sprintf("```\n%s\n```", strings.Join(cc.Responses, "```\n```"))
 		if data.Switches["file"].Value != nil || len(responses) >= 2000 && data.Switches["raw"].Value == nil {
@@ -273,16 +273,13 @@ var cmdListCommands = &commands.YAGCommand{
 			}
 
 			if ccFile != nil {
-				msg = &discordgo.MessageSend{
-					Content: header,
-					Files: []*discordgo.File{
-						ccFile,
-					},
-				}
+				msg.Content = header
+				msg.Files = []*discordgo.File{ccFile}
 				return msg, nil
 			}
 
-			return fmt.Sprintf("%s\n```%s\n%s\n```", header, highlight, strings.Join(cc.Responses, "```\n```")), nil
+			msg.Content = fmt.Sprintf("%s\n```%s\n%s\n```", header, highlight, strings.Join(cc.Responses, "```\n```"))
+			return msg, nil
 		}
 
 		if ccFile != nil {
@@ -293,26 +290,23 @@ var cmdListCommands = &commands.YAGCommand{
 				header = fmt.Sprintf("#%s - Type: `%s` - Group: `%s` - Disabled: `%t`", ccIDWithLink, CommandTriggerType(cc.TriggerType), groupMap[cc.GroupID.Int64], cc.Disabled)
 			}
 
-			msg = &discordgo.MessageSend{
-				Content: header,
-				Files: []*discordgo.File{
-					ccFile,
-				},
-			}
+			msg.Content = header
+			msg.Files = []*discordgo.File{ccFile}
 
 			return msg, nil
 
 		}
 
 		if cc.Name.Valid {
-			return fmt.Sprintf("#%s - Type: `%s` - Name: `%s` - Group: `%s` - Disabled: `%t`\n```%s\n%s\n```",
+			msg.Content = fmt.Sprintf("#%s - Type: `%s` - Name: `%s` - Group: `%s` - Disabled: `%t`\n```%s\n%s\n```",
 				ccIDWithLink, CommandTriggerType(cc.TriggerType), cc.Name.String, groupMap[cc.GroupID.Int64], cc.Disabled,
-				highlight, strings.Join(cc.Responses, "```\n```")), nil
+				highlight, strings.Join(cc.Responses, "```\n```"))
+		} else {
+			msg.Content = fmt.Sprintf("#%s - Type: `%s` - Group: `%s` - Disabled: `%t`\n```%s\n%s\n```",
+				ccIDWithLink, CommandTriggerType(cc.TriggerType), groupMap[cc.GroupID.Int64], cc.Disabled,
+				highlight, strings.Join(cc.Responses, "```\n```"))
 		}
-
-		return fmt.Sprintf("#%s - Type: `%s` - Group: `%s` - Disabled: `%t`\n```%s\n%s\n```",
-			ccIDWithLink, CommandTriggerType(cc.TriggerType), groupMap[cc.GroupID.Int64], cc.Disabled,
-			highlight, strings.Join(cc.Responses, "```\n```")), nil
+		return msg, nil
 	},
 }
 

--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -256,7 +256,35 @@ var cmdListCommands = &commands.YAGCommand{
 			}
 		}
 
-		ccIDWithLink := fmt.Sprintf("[%[1]d](%[2]s/customcommands/commands/%[1]d/)", cc.LocalID, web.ManageServerURL(data.GuildData))
+		ccIDMaybeWithLink := strconv.FormatInt(cc.LocalID, 10)
+
+		// Add public link to the CC if it is public
+		if cc.Public {
+			ccIDMaybeWithLink = fmt.Sprintf("[%[1]d](%[2]s/public/%[3]d/customcommands/commands/%[1]d/)", cc.LocalID, web.BaseURL(), data.GuildData.GS.ID)
+		}
+
+		// Add link to the cc on dashboard if member has read access
+		var member *discordgo.Member
+		if data.TriggerType == dcmd.TriggerTypeSlashCommands {
+			member = data.SlashCommandTriggerData.Interaction.Member
+		} else {
+			member = data.TraditionalTriggerData.Message.Member
+		}
+		roles := member.Roles
+		perms, _ := data.GuildData.GS.GetMemberPermissions(data.ChannelID, data.Author.ID, roles)
+
+		gWithConnected := &common.GuildWithConnected{
+			UserGuild: &discordgo.UserGuild{
+				ID:          data.GuildData.GS.ID,
+				Owner:       data.Author.ID == data.GuildData.GS.OwnerID,
+				Permissions: perms,
+			},
+			Connected: true,
+		}
+
+		if hasRead, _ := web.GetUserAccessLevel(data.Author.ID, gWithConnected, common.GetCoreServerConfCached(data.GuildData.GS.ID), web.StaticRoleProvider(roles)); hasRead {
+			ccIDMaybeWithLink = fmt.Sprintf("[%[1]d](%[2]s/customcommands/commands/%[1]d/)", cc.LocalID, web.ManageServerURL(data.GuildData))
+		}
 
 		// Every text-based custom command trigger has a numerical value less than 5, so this is quite safe to do
 		if cc.TriggerType < 5 {
@@ -265,11 +293,11 @@ var cmdListCommands = &commands.YAGCommand{
 				cc.TextTrigger = `​`
 			}
 			if cc.Name.Valid {
-				header = fmt.Sprintf("#%s - Trigger: `%s` - Type: `%s` - Name: `%s` - Case sensitive trigger: `%t` - Group: `%s` - Disabled: `%t` - onEdit: `%t`",
-					ccIDWithLink, cc.TextTrigger, CommandTriggerType(cc.TriggerType), cc.Name.String, cc.TextTriggerCaseSensitive, groupMap[cc.GroupID.Int64], cc.Disabled, cc.TriggerOnEdit)
+				header = fmt.Sprintf("#%s - Trigger: `%s` - Type: `%s` - Name: `%s` - Case sensitive trigger: `%t` - Group: `%s` - Disabled: `%t` - onEdit: `%t` Public: `%t`",
+					ccIDMaybeWithLink, cc.TextTrigger, CommandTriggerType(cc.TriggerType), cc.Name.String, cc.TextTriggerCaseSensitive, groupMap[cc.GroupID.Int64], cc.Disabled, cc.TriggerOnEdit, cc.Public)
 			} else {
-				header = fmt.Sprintf("#%s - Trigger: `%s` - Type: `%s` - Case sensitive trigger: `%t` - Group: `%s` - Disabled: `%t` - onEdit: `%t`",
-					ccIDWithLink, cc.TextTrigger, CommandTriggerType(cc.TriggerType), cc.TextTriggerCaseSensitive, groupMap[cc.GroupID.Int64], cc.Disabled, cc.TriggerOnEdit)
+				header = fmt.Sprintf("#%s - Trigger: `%s` - Type: `%s` - Case sensitive trigger: `%t` - Group: `%s` - Disabled: `%t` - onEdit: `%t` Public: `%t`",
+					ccIDMaybeWithLink, cc.TextTrigger, CommandTriggerType(cc.TriggerType), cc.TextTriggerCaseSensitive, groupMap[cc.GroupID.Int64], cc.Disabled, cc.TriggerOnEdit, cc.Public)
 			}
 
 			if ccFile != nil {
@@ -285,9 +313,9 @@ var cmdListCommands = &commands.YAGCommand{
 		if ccFile != nil {
 			var header string
 			if cc.Name.Valid {
-				header = fmt.Sprintf("#%s - Type: `%s` - Name: `%s` - Group: `%s` - Disabled: `%t`", ccIDWithLink, CommandTriggerType(cc.TriggerType), cc.Name.String, groupMap[cc.GroupID.Int64], cc.Disabled)
+				header = fmt.Sprintf("#%s - Type: `%s` - Name: `%s` - Group: `%s` - Disabled: `%t` Public: `%t`", ccIDMaybeWithLink, CommandTriggerType(cc.TriggerType), cc.Name.String, groupMap[cc.GroupID.Int64], cc.Disabled, cc.Public)
 			} else {
-				header = fmt.Sprintf("#%s - Type: `%s` - Group: `%s` - Disabled: `%t`", ccIDWithLink, CommandTriggerType(cc.TriggerType), groupMap[cc.GroupID.Int64], cc.Disabled)
+				header = fmt.Sprintf("#%s - Type: `%s` - Group: `%s` - Disabled: `%t` Public: `%t`", ccIDMaybeWithLink, CommandTriggerType(cc.TriggerType), groupMap[cc.GroupID.Int64], cc.Disabled, cc.Public)
 			}
 
 			msg.Content = header
@@ -298,12 +326,12 @@ var cmdListCommands = &commands.YAGCommand{
 		}
 
 		if cc.Name.Valid {
-			msg.Content = fmt.Sprintf("#%s - Type: `%s` - Name: `%s` - Group: `%s` - Disabled: `%t`\n```%s\n%s\n```",
-				ccIDWithLink, CommandTriggerType(cc.TriggerType), cc.Name.String, groupMap[cc.GroupID.Int64], cc.Disabled,
+			msg.Content = fmt.Sprintf("#%s - Type: `%s` - Name: `%s` - Group: `%s` - Disabled: `%t` Public: `%t`\n```%s\n%s\n```",
+				ccIDMaybeWithLink, CommandTriggerType(cc.TriggerType), cc.Name.String, groupMap[cc.GroupID.Int64], cc.Disabled, cc.Public,
 				highlight, strings.Join(cc.Responses, "```\n```"))
 		} else {
-			msg.Content = fmt.Sprintf("#%s - Type: `%s` - Group: `%s` - Disabled: `%t`\n```%s\n%s\n```",
-				ccIDWithLink, CommandTriggerType(cc.TriggerType), groupMap[cc.GroupID.Int64], cc.Disabled,
+			msg.Content = fmt.Sprintf("#%s - Type: `%s` - Group: `%s` - Disabled: `%t` Public: `%t`\n```%s\n%s\n```",
+				ccIDMaybeWithLink, CommandTriggerType(cc.TriggerType), groupMap[cc.GroupID.Int64], cc.Disabled, cc.Public,
 				highlight, strings.Join(cc.Responses, "```\n```"))
 		}
 		return msg, nil
@@ -344,18 +372,18 @@ func StringCommands(ccs []*models.CustomCommand, gMap map[int64]string) string {
 		switch {
 		case cc.TriggerType >= 5:
 			if cc.Name.Valid {
-				out += fmt.Sprintf("`#%3d:` - Type: `%s` - Name: `%s` - Group: `%s` - Disabled: `%t`\n", cc.LocalID, CommandTriggerType(cc.TriggerType).String(), cc.Name.String, gMap[cc.GroupID.Int64], cc.Disabled)
+				out += fmt.Sprintf("`#%3d:` - Type: `%s` - Name: `%s` - Group: `%s` - Disabled: `%t` - Public: `%t`\n", cc.LocalID, CommandTriggerType(cc.TriggerType).String(), cc.Name.String, gMap[cc.GroupID.Int64], cc.Disabled, cc.Public)
 			} else {
-				out += fmt.Sprintf("`#%3d:` - Type: `%s` - Group: `%s` - Disabled: `%t`\n", cc.LocalID, CommandTriggerType(cc.TriggerType).String(), gMap[cc.GroupID.Int64], cc.Disabled)
+				out += fmt.Sprintf("`#%3d:` - Type: `%s` - Group: `%s` - Disabled: `%t` - Public: `%t`\n", cc.LocalID, CommandTriggerType(cc.TriggerType).String(), gMap[cc.GroupID.Int64], cc.Disabled, cc.Public)
 			}
 		default:
 			if cc.TextTrigger == "" {
 				cc.TextTrigger = `​`
 			}
 			if cc.Name.Valid {
-				out += fmt.Sprintf("`#%3d:` - Trigger: `%s` - Type: `%s`  - Name: `%s` - Group: `%s` - Disabled: `%t` - onEdit: `%t`\n", cc.LocalID, cc.TextTrigger, CommandTriggerType(cc.TriggerType).String(), cc.Name.String, gMap[cc.GroupID.Int64], cc.Disabled, cc.TriggerOnEdit)
+				out += fmt.Sprintf("`#%3d:` - Trigger: `%s` - Type: `%s`  - Name: `%s` - Group: `%s` - Disabled: `%t` - onEdit: `%t` - Public: `%t`\n", cc.LocalID, cc.TextTrigger, CommandTriggerType(cc.TriggerType).String(), cc.Name.String, gMap[cc.GroupID.Int64], cc.Disabled, cc.TriggerOnEdit, cc.Public)
 			} else {
-				out += fmt.Sprintf("`#%3d:` - Trigger: `%s` - Type: `%s` - Group: `%s` - Disabled: `%t` - onEdit: `%t`\n", cc.LocalID, cc.TextTrigger, CommandTriggerType(cc.TriggerType).String(), gMap[cc.GroupID.Int64], cc.Disabled, cc.TriggerOnEdit)
+				out += fmt.Sprintf("`#%3d:` - Trigger: `%s` - Type: `%s` - Group: `%s` - Disabled: `%t` - onEdit: `%t` - Public: `%t`\n", cc.LocalID, cc.TextTrigger, CommandTriggerType(cc.TriggerType).String(), gMap[cc.GroupID.Int64], cc.Disabled, cc.TriggerOnEdit, cc.Public)
 			}
 		}
 	}

--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -16,6 +16,7 @@ import (
 	"github.com/botlabs-gg/yagpdb/v2/analytics"
 	"github.com/botlabs-gg/yagpdb/v2/lib/template"
 	"github.com/botlabs-gg/yagpdb/v2/premium"
+	"github.com/botlabs-gg/yagpdb/v2/web"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
@@ -255,6 +256,8 @@ var cmdListCommands = &commands.YAGCommand{
 			}
 		}
 
+		ccIDWithLink := fmt.Sprintf("[%[1]d](%[2]s/customcommands/commands/%[1]d/)", cc.LocalID, web.ManageServerURL(data.GuildData))
+
 		// Every text-based custom command trigger has a numerical value less than 5, so this is quite safe to do
 		if cc.TriggerType < 5 {
 			var header string
@@ -262,11 +265,11 @@ var cmdListCommands = &commands.YAGCommand{
 				cc.TextTrigger = `​`
 			}
 			if cc.Name.Valid {
-				header = fmt.Sprintf("#%d - Trigger: `%s` - Type: `%s` - Name: `%s` - Case sensitive trigger: `%t` - Group: `%s` - Disabled: `%t` - onEdit: `%t`",
-					cc.LocalID, cc.TextTrigger, CommandTriggerType(cc.TriggerType), cc.Name.String, cc.TextTriggerCaseSensitive, groupMap[cc.GroupID.Int64], cc.Disabled, cc.TriggerOnEdit)
+				header = fmt.Sprintf("#%s - Trigger: `%s` - Type: `%s` - Name: `%s` - Case sensitive trigger: `%t` - Group: `%s` - Disabled: `%t` - onEdit: `%t`",
+					ccIDWithLink, cc.TextTrigger, CommandTriggerType(cc.TriggerType), cc.Name.String, cc.TextTriggerCaseSensitive, groupMap[cc.GroupID.Int64], cc.Disabled, cc.TriggerOnEdit)
 			} else {
-				header = fmt.Sprintf("#%d - Trigger: `%s` - Type: `%s` - Case sensitive trigger: `%t` - Group: `%s` - Disabled: `%t` - onEdit: `%t`",
-					cc.LocalID, cc.TextTrigger, CommandTriggerType(cc.TriggerType), cc.TextTriggerCaseSensitive, groupMap[cc.GroupID.Int64], cc.Disabled, cc.TriggerOnEdit)
+				header = fmt.Sprintf("#%s - Trigger: `%s` - Type: `%s` - Case sensitive trigger: `%t` - Group: `%s` - Disabled: `%t` - onEdit: `%t`",
+					ccIDWithLink, cc.TextTrigger, CommandTriggerType(cc.TriggerType), cc.TextTriggerCaseSensitive, groupMap[cc.GroupID.Int64], cc.Disabled, cc.TriggerOnEdit)
 			}
 
 			if ccFile != nil {
@@ -285,9 +288,9 @@ var cmdListCommands = &commands.YAGCommand{
 		if ccFile != nil {
 			var header string
 			if cc.Name.Valid {
-				header = fmt.Sprintf("#%d - Type: `%s` - Name: `%s` - Group: `%s` - Disabled: `%t`", cc.LocalID, CommandTriggerType(cc.TriggerType), cc.Name.String, groupMap[cc.GroupID.Int64], cc.Disabled)
+				header = fmt.Sprintf("#%s - Type: `%s` - Name: `%s` - Group: `%s` - Disabled: `%t`", ccIDWithLink, CommandTriggerType(cc.TriggerType), cc.Name.String, groupMap[cc.GroupID.Int64], cc.Disabled)
 			} else {
-				header = fmt.Sprintf("#%d - Type: `%s` - Group: `%s` - Disabled: `%t`", cc.LocalID, CommandTriggerType(cc.TriggerType), groupMap[cc.GroupID.Int64], cc.Disabled)
+				header = fmt.Sprintf("#%s - Type: `%s` - Group: `%s` - Disabled: `%t`", ccIDWithLink, CommandTriggerType(cc.TriggerType), groupMap[cc.GroupID.Int64], cc.Disabled)
 			}
 
 			msg = &discordgo.MessageSend{
@@ -302,13 +305,13 @@ var cmdListCommands = &commands.YAGCommand{
 		}
 
 		if cc.Name.Valid {
-			return fmt.Sprintf("#%d - Type: `%s` - Name: `%s` - Group: `%s` - Disabled: `%t`\n```%s\n%s\n```",
-				cc.LocalID, CommandTriggerType(cc.TriggerType), cc.Name.String, groupMap[cc.GroupID.Int64], cc.Disabled,
+			return fmt.Sprintf("#%s - Type: `%s` - Name: `%s` - Group: `%s` - Disabled: `%t`\n```%s\n%s\n```",
+				ccIDWithLink, CommandTriggerType(cc.TriggerType), cc.Name.String, groupMap[cc.GroupID.Int64], cc.Disabled,
 				highlight, strings.Join(cc.Responses, "```\n```")), nil
 		}
 
-		return fmt.Sprintf("#%d - Type: `%s` - Group: `%s` - Disabled: `%t`\n```%s\n%s\n```",
-			cc.LocalID, CommandTriggerType(cc.TriggerType), groupMap[cc.GroupID.Int64], cc.Disabled,
+		return fmt.Sprintf("#%s - Type: `%s` - Group: `%s` - Disabled: `%t`\n```%s\n%s\n```",
+			ccIDWithLink, CommandTriggerType(cc.TriggerType), groupMap[cc.GroupID.Int64], cc.Disabled,
 			highlight, strings.Join(cc.Responses, "```\n```")), nil
 	},
 }

--- a/customcommands/customcommands.go
+++ b/customcommands/customcommands.go
@@ -121,6 +121,7 @@ type CustomCommand struct {
 	ID            int64    `json:"id"`
 	Name          string   `json:"name" schema:"name" valid:",0,100"`
 	IsEnabled     bool     `json:"is_enabled" schema:"is_enabled"`
+	Public        bool     `json:"public" schema:"public"`
 
 	ContextChannel int64 `schema:"context_channel" valid:"channel,true"`
 
@@ -193,6 +194,7 @@ func (cc *CustomCommand) ToDBModel() *models.CustomCommand {
 		TriggerType:              int(cc.TriggerType),
 		TextTrigger:              cc.Trigger,
 		TextTriggerCaseSensitive: cc.CaseSensitive,
+		Public:                   cc.Public,
 
 		Channels:              cc.Channels,
 		ChannelsWhitelistMode: cc.RequireChannels,

--- a/customcommands/models/custom_commands.go
+++ b/customcommands/models/custom_commands.go
@@ -50,6 +50,7 @@ type CustomCommand struct {
 	Disabled                  bool              `boil:"disabled" json:"disabled" toml:"disabled" yaml:"disabled"`
 	Name                      null.String       `boil:"name" json:"name,omitempty" toml:"name" yaml:"name,omitempty"`
 	TriggerOnEdit             bool              `boil:"trigger_on_edit" json:"trigger_on_edit" toml:"trigger_on_edit" yaml:"trigger_on_edit"`
+	Public                    bool              `boil:"public" json:"public" toml:"public" yaml:"public"`
 
 	R *customCommandR `boil:"-" json:"-" toml:"-" yaml:"-"`
 	L customCommandL  `boil:"-" json:"-" toml:"-" yaml:"-"`
@@ -81,6 +82,7 @@ var CustomCommandColumns = struct {
 	Disabled                  string
 	Name                      string
 	TriggerOnEdit             string
+	Public                    string
 }{
 	LocalID:                   "local_id",
 	GuildID:                   "guild_id",
@@ -107,6 +109,7 @@ var CustomCommandColumns = struct {
 	Disabled:                  "disabled",
 	Name:                      "name",
 	TriggerOnEdit:             "trigger_on_edit",
+	Public:                    "public",
 }
 
 // Generated where
@@ -268,6 +271,7 @@ var CustomCommandWhere = struct {
 	Disabled                  whereHelperbool
 	Name                      whereHelpernull_String
 	TriggerOnEdit             whereHelperbool
+	Public                    whereHelperbool
 }{
 	LocalID:                   whereHelperint64{field: "\"custom_commands\".\"local_id\""},
 	GuildID:                   whereHelperint64{field: "\"custom_commands\".\"guild_id\""},
@@ -294,6 +298,7 @@ var CustomCommandWhere = struct {
 	Disabled:                  whereHelperbool{field: "\"custom_commands\".\"disabled\""},
 	Name:                      whereHelpernull_String{field: "\"custom_commands\".\"name\""},
 	TriggerOnEdit:             whereHelperbool{field: "\"custom_commands\".\"trigger_on_edit\""},
+	Public:                    whereHelperbool{field: "\"custom_commands\".\"public\""},
 }
 
 // CustomCommandRels is where relationship names are stored.
@@ -317,9 +322,9 @@ func (*customCommandR) NewStruct() *customCommandR {
 type customCommandL struct{}
 
 var (
-	customCommandAllColumns            = []string{"local_id", "guild_id", "group_id", "trigger_type", "text_trigger", "text_trigger_case_sensitive", "time_trigger_interval", "time_trigger_excluding_days", "time_trigger_excluding_hours", "last_run", "next_run", "responses", "channels", "channels_whitelist_mode", "roles", "roles_whitelist_mode", "context_channel", "reaction_trigger_mode", "last_error", "last_error_time", "run_count", "show_errors", "disabled", "name", "trigger_on_edit"}
+	customCommandAllColumns            = []string{"local_id", "guild_id", "group_id", "trigger_type", "text_trigger", "text_trigger_case_sensitive", "time_trigger_interval", "time_trigger_excluding_days", "time_trigger_excluding_hours", "last_run", "next_run", "responses", "channels", "channels_whitelist_mode", "roles", "roles_whitelist_mode", "context_channel", "reaction_trigger_mode", "last_error", "last_error_time", "run_count", "show_errors", "disabled", "name", "trigger_on_edit", "public"}
 	customCommandColumnsWithoutDefault = []string{"local_id", "guild_id", "group_id", "trigger_type", "text_trigger", "text_trigger_case_sensitive", "time_trigger_interval", "time_trigger_excluding_days", "time_trigger_excluding_hours", "last_run", "next_run", "responses", "channels", "channels_whitelist_mode", "roles", "roles_whitelist_mode", "last_error_time", "name"}
-	customCommandColumnsWithDefault    = []string{"context_channel", "reaction_trigger_mode", "last_error", "run_count", "show_errors", "disabled", "trigger_on_edit"}
+	customCommandColumnsWithDefault    = []string{"context_channel", "reaction_trigger_mode", "last_error", "run_count", "show_errors", "disabled", "trigger_on_edit", "public"}
 	customCommandPrimaryKeyColumns     = []string{"guild_id", "local_id"}
 )
 

--- a/customcommands/schema.go
+++ b/customcommands/schema.go
@@ -84,4 +84,6 @@ CREATE INDEX IF NOT EXISTS templates_user_database_combined_idx ON templates_use
 CREATE INDEX IF NOT EXISTS templates_user_database_expires_idx ON templates_user_database (expires_at);
 `, `
 ALTER TABLE custom_commands ADD COLUMN IF NOT EXISTS name TEXT;
+`, `
+ALTER TABLE custom_commands ADD COLUMN IF NOT EXISTS public BOOLEAN NOT NULL DEFAULT false;
 `}


### PR DESCRIPTION
This PR grants the ability to share individual CCs via a public link. To share a CC you must enable sharing via the Publicity toggle on the panel, and share the public link with another user. This is facilitated by the Share Command modal on the cc edit page, allowing you to copy the public link.

When visiting the public link, you will get err=noaccess if the cc is not public, and sent to homepage if ID is invalid. If you have view perms for the server, it redirects you to regular edit page.

If you reach the public page you will get a stripped version of the command edit page with all inputs disabled, guild-specific info like command group, run count, and restrictions omitted. It is also syntax highlighted responses and a Copy button to copy the code of each response. This copy text button is available on the regular edit page as well.

The CustomCommands command will return the public link masked in the CC ID if the CC is public, or the link to its edit page if the user has read access. It functions as normal if neither of these are true.

![public_end](https://github.com/botlabs-gg/yagpdb/assets/110698921/141ffd5f-8986-49e0-9e41-806fbdc75c23)
<img width="653" alt="share_custom_command" src="https://github.com/botlabs-gg/yagpdb/assets/110698921/6dde7306-f621-4fb2-97cc-86efce899fbc">
<img width="657" alt="publicity_toggle" src="https://github.com/botlabs-gg/yagpdb/assets/110698921/e708a8e7-06bf-4d87-a97f-a9575bab8e16">

Signed-off-by SoggySaussages <vmdmaharaj@gmail.com>