### PR TITLE
fix: Clean-up usage of X-Audit-Log-Reason

### DIFF
--- a/lib/discordgo/restapi.go
+++ b/lib/discordgo/restapi.go
@@ -758,6 +758,22 @@ func (s *Session) GuildBanDelete(guildID, userID int64) (err error) {
 	return
 }
 
+// GuildBanDeleteWithReason removes the given user from the guild bans,
+// including sending an audit log reason.
+// guildID    : The ID of a Guild
+// userID     : The ID of a User
+// reason     : The reason for removing the ban
+func (s *Session) GuildBanDeleteWithReason(guildID, userID int64, reason string) (err error) {
+
+	headers := make(map[string]string)
+	if reason != "" {
+		headers["X-Audit-Log-Reason"] = url.PathEscape(reason)
+	}
+
+	_, err = s.RequestWithBucketID("DELETE", EndpointGuildBan(guildID, userID), nil, headers, EndpointGuildBan(guildID, 0))
+	return
+}
+
 // GuildMembers returns a list of members for a guild.
 //
 //	guildID  : The ID of a Guild.

--- a/lib/discordgo/restapi.go
+++ b/lib/discordgo/restapi.go
@@ -846,12 +846,12 @@ func (s *Session) GuildMemberDelete(guildID, userID int64) (err error) {
 // reason    : The reason for the kick
 func (s *Session) GuildMemberDeleteWithReason(guildID, userID int64, reason string) (err error) {
 
-	uri := EndpointGuildMember(guildID, userID)
+	headers := make(map[string]string)
 	if reason != "" {
-		uri += "?reason=" + url.QueryEscape(reason)
+		headers["X-Audit-Log-Reason"] = url.PathEscape(reason)
 	}
 
-	_, err = s.RequestWithBucketID("DELETE", uri, nil, nil, EndpointGuildMember(guildID, 0))
+	_, err = s.RequestWithBucketID("DELETE", EndpointGuildMember(guildID, userID), nil, headers, EndpointGuildMember(guildID, 0))
 	return
 }
 

--- a/lib/discordgo/restapi.go
+++ b/lib/discordgo/restapi.go
@@ -754,8 +754,7 @@ func (s *Session) GuildBanCreateWithReason(guildID, userID int64, reason string,
 // userID    : The ID of a User
 func (s *Session) GuildBanDelete(guildID, userID int64) (err error) {
 
-	_, err = s.RequestWithBucketID("DELETE", EndpointGuildBan(guildID, userID), nil, nil, EndpointGuildBan(guildID, 0))
-	return
+	return s.GuildBanDeleteWithReason(guildID, userID, "")
 }
 
 // GuildBanDeleteWithReason removes the given user from the guild bans,

--- a/moderation/punishments.go
+++ b/moderation/punishments.go
@@ -331,7 +331,7 @@ func UnbanUser(config *Config, guildID int64, author *discordgo.User, reason str
 	// Set a key in redis that marks that this user has appeared in the modlog already
 	common.RedisPool.Do(radix.FlatCmd(nil, "SETEX", RedisKeyUnbannedUser(guildID, user.ID), 30, 2))
 
-	err = common.BotSession.GuildBanDelete(guildID, user.ID)
+	err = common.BotSession.GuildBanDeleteWithReason(guildID, user.ID, reason)
 	if err != nil {
 		notbanned, err := isNotFound(err)
 		return notbanned, err

--- a/moderation/punishments.go
+++ b/moderation/punishments.go
@@ -368,7 +368,13 @@ func RemoveTimeout(config *Config, guildID int64, author *discordgo.User, reason
 	}
 	action := MATimeoutRemoved
 
-	err = common.BotSession.GuildMemberTimeoutWithReason(guildID, user.ID, nil, reason)
+	// Prepends the author's name, if unban wasn't triggered automatically.
+	fullReason := reason
+	if author.ID != common.BotUser.ID {
+		fullReason = author.String() + ": " + reason
+	}
+
+	err = common.BotSession.GuildMemberTimeoutWithReason(guildID, user.ID, nil, fullReason)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It was recently noted that the YAGPDB was not setting an audit log reason, when kicking users via command, or when unbanning users. This first of these, was due to the fact the relevant method was based on an old API design, and hadn't been updated, and the second because the relevant method didn't exist.

This PR fixes both of these issues, by adding the relevant method, as well as updating the existing one to use the `X-Audit-Log-Reason` header, rather than the old query string method.