### PR TITLE
Added optional args `auto_archive_duration` and `invitable` to createThread

### DIFF
--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -1371,7 +1371,7 @@ func (c *Context) AddThreadToGuildSet(t *dstate.ChannelState) {
 	c.GS = &gsCopy
 }
 
-func (c *Context) tmplCreateThread(channel, msgID, name interface{}, private ...interface{}) (*CtxChannel, error) {
+func (c *Context) tmplCreateThread(channel, msgID, name interface{}, optionals ...interface{}) (*CtxChannel, error) {
 
 	if c.IncreaseCheckCallCounterPremium("create_thread", 1, 1) {
 		return nil, ErrTooManyCalls
@@ -1387,27 +1387,43 @@ func (c *Context) tmplCreateThread(channel, msgID, name interface{}, private ...
 		return nil, errors.New("channel not in state")
 	}
 
+	start := &discordgo.ThreadStart{
+		Name:                ToString(name),
+		Type:                discordgo.ChannelTypeGuildPublicThread,
+		AutoArchiveDuration: 10080, // 7 days
+		Invitable:           false,
+	}
 	mID := ToInt64(msgID)
-
-	threadType := discordgo.ChannelTypeGuildPublicThread
-	if len(private) > 0 {
-		switch v := private[0].(type) {
-		case bool:
-			if v {
-				threadType = discordgo.ChannelTypeGuildPrivateThread
+	for index, opt := range optionals {
+		switch index {
+		case 0:
+			switch opt := opt.(type) {
+			case bool:
+				if opt {
+					start.Type = discordgo.ChannelTypeGuildPrivateThread
+				}
+			default:
+				return nil, errors.New("createThread 'private' must be a boolean")
+			}
+		case 1:
+			duration := tmplToInt(opt)
+			if duration < 60 || duration > 10080 {
+				return nil, errors.New("createThread 'auto_archive_duration' must be and integer between 60 and 10080")
+			}
+		case 2:
+			switch opt := opt.(type) {
+			case bool:
+				if opt {
+					start.Invitable = true
+				}
+			default:
+				return nil, errors.New("createThread 'invitable' must be a boolean")
 			}
 		}
 	}
 
-	start := &discordgo.ThreadStart{
-		Name: ToString(name),
-		//AutoArchiveDuration: 10080, // 7 days
-		Type:      threadType,
-		Invitable: false,
-	}
-
 	var ctxThread *discordgo.Channel
-	var err error = nil
+	var err error
 	if mID > 0 {
 		ctxThread, err = common.BotSession.MessageThreadStartComplex(cID, mID, start)
 	} else {
@@ -1513,7 +1529,7 @@ func ConvertTagNameToId(c *dstate.ChannelState, tagName string) int64 {
 
 func ProcessOptionalForumPostArgs(c *dstate.ChannelState, values ...interface{}) (int, []int64, error) {
 
-	if values == nil || len(values) == 0 {
+	if len(values) == 0 {
 		return c.DefaultThreadRateLimitPerUser, nil, nil
 	}
 

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -1419,6 +1419,8 @@ func (c *Context) tmplCreateThread(channel, msgID, name interface{}, optionals .
 			default:
 				return nil, errors.New("createThread 'invitable' must be a boolean")
 			}
+		default:
+			return nil, errors.New("createThread: Too many arguments")
 		}
 	}
 

--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -155,10 +155,7 @@ func StructToSdict(value interface{}) (SDict, error) {
 
 func CreateSlice(values ...interface{}) (Slice, error) {
 	slice := make([]interface{}, len(values))
-	for i := 0; i < len(values); i++ {
-		slice[i] = values[i]
-	}
-
+	copy(slice, values)
 	return Slice(slice), nil
 }
 
@@ -406,11 +403,11 @@ func parseAllowedMentions(Data interface{}) (*discordgo.AllowedMentions, error) 
 			var parseSlice Slice
 			conv, err := parseSlice.AppendSlice(v)
 			if err != nil {
-				return nil, fmt.Errorf(`Allowed Mentions Parsing: invalid datatype passed to "%s", accepts a slice of snowflakes only`, k)
+				return nil, fmt.Errorf(`allowed Mentions Parsing: invalid datatype passed to "%s", accepts a slice of snowflakes only`, k)
 			}
 			for _, elem := range conv.(Slice) {
 				if (ToInt64(elem)) == 0 {
-					return nil, fmt.Errorf(`Allowed Mentions Parsing: "%s" IDSlice: invalid ID passed -`+fmt.Sprint(elem), k)
+					return nil, fmt.Errorf(`allowed Mentions Parsing: "%s" IDSlice: invalid ID passed -`+fmt.Sprint(elem), k)
 				}
 				newslice = append(newslice, ToInt64(elem))
 			}


### PR DESCRIPTION
function signature is now: 
```
createThread channel messageID name (private) (auto_archive_duration) (invitable)
```


Example Usage
```
{{createThread nil nil "Test Thread" true 61 true}}
```