### PR TITLE
templates: permit sorting by struct key

### DIFF
--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -2146,6 +2146,21 @@ func indexContainer(container, key reflect.Value) (reflect.Value, error) {
 			}
 			return v, nil
 		}
+
+	case reflect.Struct:
+		if key.Kind() != reflect.String {
+			return reflect.Value{}, fmt.Errorf("cannot index struct with non-string key")
+		}
+
+		s := key.String()
+		ft, ok := container.Type().FieldByName(s)
+		if !ok {
+			return reflect.Value{}, fmt.Errorf("no field named %q in %s struct", s, container.Type())
+		}
+		if !ft.IsExported() {
+			return reflect.Value{}, fmt.Errorf("field %q of %s struct is not exported", s, container.Type())
+		}
+		return container.FieldByName(s), nil
 	}
 
 	return reflect.Value{}, fmt.Errorf("cannot index value of type %s", container.Type())


### PR DESCRIPTION
As suggested in #dev-discussion, permit the `sort` template function to index (exported) struct fields, so that code like
```
{{ sort .Guild.Roles (sdict "key" "Position") }}
```
just works, instead of erroring with `cannot index value of type discordgo.Role`.

Note that the proposed patch still does not support niladic method calls. Hence, code like `{{ sort $sliceOfTimes (sdict "key" "Hour") }}` remains an error, since `Hour` is a method on `time.Time`, not a field. Ideally, we would lift this restriction and completely align the implementation of the `key` option with field access in templates, such that `{{ sort $xs (sdict "key" "K") }}` corresponds to sorting by `$x.K`. This behavior, however, is much more difficult to implement so is not done in this PR (and it is debatable whether it is worth the added complexity.)