### PR TITLE
schemamigration: skip executing ALTER COLUMN SET NOT NULL queries when possible

### DIFF
--- a/common/schemamigration.go
+++ b/common/schemamigration.go
@@ -11,7 +11,7 @@ var (
 	createTableRegex          = regexp.MustCompile(`(?i)create table if not exists ([0-9a-z_]*) *\(`)
 	alterTableAddColumnRegex  = regexp.MustCompile(`(?i)alter table ([0-9a-z_]*) add column if not exists "?([0-9a-z_]*)"?`)
 	addIndexRegex             = regexp.MustCompile(`(?i)create (unique )?index if not exists ([0-9a-z_]*) on ([0-9a-z_]*)`)
-	addNotNullConstraintRegex = regexp.MustCompile(`(?i)alter table ([0-9a-z_]*) alter column "?([0-9a-z_]+)"? set not null`)
+	addNotNullConstraintRegex = regexp.MustCompile(`(?i)alter table ([0-9a-z_]*) alter column "?([0-9a-z_]*)"? set not null`)
 )
 
 type DBSchema struct {


### PR DESCRIPTION
## Context

YAGPDB currently uses a bespoke database migration system that works as follows. For each database migration (called a "schema" internally), we try to classify (by testing a set of regexes against the SQL) the migration as doing one of the following:
- creating a new table,
- adding a new column to a table, or
- adding a new index on a column.

If the migration is not recognized as any of the above types, it is run. Otherwise, to avoid gratuitously executing migrations, we check some database metadata to see if the migration is necessary. For instance, if the migration is creating a table, then we query `information_schema.tables` to see if the table already exists. If so, the query is skipped.

This process is somewhat effective: it successfully detects (and thus skips) most migrations that have already been run, with some exceptions.

## The change

As discussed in #dev-discussion, in an upcoming set of PRs, we plan to migrate existing code away from `gorm` to `sqlboiler`. Unfortunately, almost all tables created with `gorm` are currently missing `NOT NULL` constraints on all columns (see #1652.) Therefore we will need to run a large number of migrations of the type

```
ALTER TABLE ... ALTER COLUMN ... SET NOT NULL;
```

Currently this type of query is not recognized by the migration system and so will always be executed. In preparation for the aforementioned series of changes switching away from `gorm` (which will require many more migrations of this type), **this PR therefore lets the migration system recognize `ALTER TABLE ... ALTER COLUMN ... SET NOT NULL` queries and skip running them if possible.**