### PR TITLE
frontend: don't trigger other event handlers if delete action cancelled

### DIFF
--- a/frontend/static/js/spongebob.js
+++ b/frontend/static/js/spongebob.js
@@ -498,7 +498,7 @@ function formSubmissionEvents() {
 		// console.log("aaaaa", evt, evt.preventDefault);
 		if (!confirm("Are you sure you want to do this?")) {
 			evt.preventDefault(true);
-			evt.stopPropagation();
+			evt.stopImmediatePropagation();
 		}
 		// alert("aaa")
 	}
@@ -545,13 +545,13 @@ function formSubmissionEvents() {
 			if (title !== undefined) {
 				if (!confirm("Deleting " + title + ". Are you sure you want to do this?")) {
 					event.preventDefault(true);
-					event.stopPropagation();
+					event.stopImmediatePropagation();
 					return;
 				}
 			} else {
 				if (!confirm("Are you sure you want to do this?")) {
 					event.preventDefault(true);
-					event.stopPropagation();
+					event.stopImmediatePropagation();
 					return;
 				}
 			}


### PR DESCRIPTION
This PR fixes the following bug (thanks to galen for discovery): clicking the delete button beside a custom command response and then cancelling it at the confirmation popup (erroneously) still deletes the response. Screencapture below.

https://github.com/botlabs-gg/yagpdb/assets/56809242/67788466-c0ee-4584-b44b-f130b02c4c4e

An analysis of the issue: the confirmation prompt is triggered when any element with the `btn-danger` class is clicked. If confirmation fails, preventDefault() and stopPropagation() are called, which are typically sufficient to prevent the deletion from going through. But in the case where the deletion is performed in another click event handler -- which is the case for the implementation of deleting custom command responses -- stopPropagation() will (roughly speaking) only prevent event handlers on parent elements from triggering. That is, event handlers registered for the same element will still fire, hence the bug.

Calling stopImmediatePropagation() will correctly stop the event handlers for the same element from triggering.