### PR TITLE
keylock: make KeyLock generic and improve documentation

### DIFF
--- a/common/keylock/keylock_test.go
+++ b/common/keylock/keylock_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestKeyLock(t *testing.T) {
-	locker := NewKeyLock()
+	locker := NewKeyLock[int]()
 
 	h := locker.Lock(1, time.Second, time.Minute)
 
@@ -25,7 +25,7 @@ func TestKeyLock(t *testing.T) {
 }
 
 func BenchmarkKeyLock(b *testing.B) {
-	locker := NewKeyLock()
+	locker := NewKeyLock[int]()
 
 	for i := 0; i < b.N; i++ {
 		h := locker.Lock(1, time.Minute, time.Minute)

--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -43,7 +43,7 @@ import (
 )
 
 var (
-	CCExecLock        = keylock.NewKeyLock()
+	CCExecLock        = keylock.NewKeyLock[CCExecKey]()
 	DelayedCCRunLimit = multiratelimit.NewMultiRatelimiter(0.1, 10)
 	CCMaxDataLimit    = 1000000 // 1 MB max
 )


### PR DESCRIPTION
This PR improves the type safety of the `common/keylock` package by making `KeyLock` generic over the key type (previously `interface{}`), which also slightly improves performance*. For context, I was looking over `common/keylock` to see whether we could replace the muted user lock in https://github.com/botlabs-gg/yagpdb/blob/master/moderation/mutelock.go with a `KeyLock`, given the two pieces of code implement largely the same thing. (It turns out we can, but I'll defer this change to a later PR once the sqlboiler changes to the `moderation` plugin are complete.)

*`benchstat` results:
```
goos: linux
goarch: amd64
pkg: github.com/botlabs-gg/yagpdb/v2/common/keylock
cpu: 11th Gen Intel(R) Core(TM) i9-11900T @ 1.50GHz
           │   old.txt    │               new.txt               │
           │    sec/op    │   sec/op     vs base                │
KeyLock-16   140.9n ± 10%   115.2n ± 1%  -18.23% (p=0.000 n=10
```
(Though the benchmark is not at all representative of a typical use scenario, it does prove that the map access performance has improved as a result of no longer using `interface{}` keys. In any case, the main goal of this PR is type safety; better performance is a happy consequence.)