### PR TITLE
commands/tmplexec: also return `*discordgo.MessageSend`

### DIFF
--- a/commands/tmplexec.go
+++ b/commands/tmplexec.go
@@ -252,6 +252,8 @@ func execCmd(tmplCtx *templates.Context, dryRun bool, m *discordgo.MessageCreate
 		return v, nil
 	case []*discordgo.MessageEmbed:
 		return v, nil
+	case *discordgo.MessageSend:
+		return v, nil
 	}
 
 	return "", nil


### PR DESCRIPTION
Also return `*discordgo.MessageSend` after executing a command via a
fake message.

Commit 97b021dd6815 ("customcommands: link to ccs in cc command ") via
PR #1624 introduced a side effect where constructs such as
`{{ exec "cc" "1" }}` no longer worked, thus resulting in breakage.

This patch does *not* fully restore the former state, however seeing as
the aforementioned commit broke things in a very subtle way it seems
acceptable to introduce a new, different behaviour.
Admittedly, with the current state of in-built commands responding with
all sorts of things that may or may not be writable to a CC variable,
this only confuses things further, but at least it is working again(TM).

At some point in the future we could consider sorting these
"inconsistencies" out and making it "just werk" with custom commands. In
light of the currently ongoing migration from GORM to sqlboiler, this
undertaking does not seem too far-fetched.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
