### PR TITLE
Adds with/without message attachments conditions (Suggestion 2208)

### DIFF
--- a/automod/conditions.go
+++ b/automod/conditions.go
@@ -581,6 +581,55 @@ func (mc *MessageEditedCondition) MergeDuplicates(data []interface{}) interface{
 	return data[0] // no point in having duplicates of this
 }
 
+var _ Condition = (*MessageAttachmentCondition)(nil)
+
+type MessageAttachmentCondition struct {
+	HasAttachments bool // If true we are only matching on messages with attachments
+}
+
+func (mc *MessageAttachmentCondition) Kind() RulePartType {
+	return RulePartCondition
+}
+
+func (mc *MessageAttachmentCondition) DataType() interface{} {
+	return nil
+}
+
+func (mc *MessageAttachmentCondition) Name() string {
+	if mc.HasAttachments {
+		return "Message with attachments"
+	}
+	return "Message without attachments"
+}
+
+func (mc *MessageAttachmentCondition) Description() string {
+	if mc.HasAttachments {
+		return "Only examine messages that have attachments"
+	}
+	return "Only examine messages that don't have attachments"
+}
+
+func (mc *MessageAttachmentCondition) UserSettings() []*SettingDef {
+	return []*SettingDef{}
+}
+
+func (mc *MessageAttachmentCondition) IsMet(data *TriggeredRuleData, settings interface{}) (bool, error) {
+	if data.Message == nil {
+		// pass the condition if no message is found
+		return true, nil
+	}
+
+	if contains := len(data.Message.Attachments) > 0; mc.HasAttachments {
+		return contains, nil
+	} else {
+		return !contains, nil
+	}
+}
+
+func (mc *MessageAttachmentCondition) MergeDuplicates(data []interface{}) interface{} {
+	return data[0]
+}
+
 /////////////////////////////////////////////////////////////////
 
 var _ Condition = (*ThreadCondition)(nil)

--- a/automod/rulepart.go
+++ b/automod/rulepart.go
@@ -69,6 +69,8 @@ var RulePartMap = map[int]RulePart{
 	214: &MessageEditedCondition{NewMessage: false},
 	215: &ThreadCondition{true},
 	216: &ThreadCondition{false},
+	217: &MessageAttachmentCondition{true},
+	218: &MessageAttachmentCondition{false},
 
 	// Effects 3xx
 	300: &DeleteMessageEffect{},


### PR DESCRIPTION
This update adds 2 new AMv2 conditions: message with attachments and message without attachments.

<img width="319" alt="Screenshot 2024-06-11 at 3 07 51 PM" src="https://github.com/botlabs-gg/yagpdb/assets/8399235/0a34cf8e-1809-41e2-a639-8c74d3d975cd">

# Use Case

Allows for situations where you want to trigger on new or edited messages only if they do (or don't) contain attachments. Example provided in the suggestion was "allow the trigger `Message with less than x characters` to prevent spam without affecting attachment only messages."