### PR TITLE
customcommands: thread editing functions

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -659,14 +659,19 @@ func baseContextFuncs(c *Context) {
 	c.addContextFunc("getThread", c.tmplGetThread)
 
 	// thread functions
+	c.addContextFunc("addThreadMember", c.tmplThreadMemberAdd)
+	c.addContextFunc("closeThread", c.tmplCloseThread)
 	c.addContextFunc("createThread", c.tmplCreateThread)
 	c.addContextFunc("deleteThread", c.tmplDeleteThread)
-	c.addContextFunc("addThreadMember", c.tmplThreadMemberAdd)
+	c.addContextFunc("editThread", c.tmplEditThread)
+	c.addContextFunc("openThread", c.tmplOpenThread)
 	c.addContextFunc("removeThreadMember", c.tmplThreadMemberRemove)
 
 	// forum functions
 	c.addContextFunc("createForumPost", c.tmplCreateForumPost)
 	c.addContextFunc("deleteForumPost", c.tmplDeleteThread)
+	c.addContextFunc("pinForumPost", c.tmplPinForumPost(false))
+	c.addContextFunc("unpinForumPost", c.tmplPinForumPost(true))
 
 	c.addContextFunc("currentUserAgeHuman", c.tmplCurrentUserAgeHuman)
 	c.addContextFunc("currentUserAgeMinutes", c.tmplCurrentUserAgeMinutes)

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -1820,10 +1820,8 @@ func processThreadArgs(newThread bool, parent *dstate.ChannelState, values ...in
 		case "invitable":
 			val, ok := val.(bool)
 			if ok {
-				if val {
-					invitable := val
-					c.Invitable = &invitable
-				}
+				invitable := val
+				c.Invitable = &invitable
 				continue
 			}
 			return c, errors.New("'invitable' must be a boolean")

--- a/common/templates/structs.go
+++ b/common/templates/structs.go
@@ -27,8 +27,11 @@ type CtxChannel struct {
 	ParentID             int64                            `json:"parent_id"`
 	OwnerID              int64                            `json:"owner_id"`
 
-	AvailableTags []discordgo.ForumTag `json:"available_tags"`
-	AppliedTags   []int64              `json:"applied_tags"`
+	AvailableTags []discordgo.ForumTag   `json:"available_tags"`
+	AppliedTags   []int64                `json:"applied_tags"`
+	Flags         discordgo.ChannelFlags `json:"flags"`
+	Archived      bool                   `json:"archived"`
+	Locked        bool                   `json:"locked"`
 }
 
 func (c *CtxChannel) Mention() (string, error) {
@@ -49,7 +52,7 @@ func CtxChannelFromCS(cs *dstate.ChannelState) *CtxChannel {
 		ID:                   cs.ID,
 		IsPrivate:            cs.IsPrivate(),
 		IsThread:             cs.Type.IsThread(),
-		IsForum:              cs.Type.IsForum(),
+		IsForum:              cs.Type == discordgo.ChannelTypeGuildForum,
 		GuildID:              cs.GuildID,
 		Name:                 cs.Name,
 		Type:                 cs.Type,
@@ -62,6 +65,9 @@ func CtxChannelFromCS(cs *dstate.ChannelState) *CtxChannel {
 		OwnerID:              cs.OwnerID,
 		AvailableTags:        cs.AvailableTags,
 		AppliedTags:          cs.AppliedTags,
+		Flags:                cs.Flags,
+		Archived:             cs.Archived,
+		Locked:               cs.Locked,
 	}
 
 	return ctxChannel

--- a/lib/dstate/helpers.go
+++ b/lib/dstate/helpers.go
@@ -161,6 +161,7 @@ func ChannelStateFromDgo(c *discordgo.Channel) ChannelState {
 		NSFW:                          c.NSFW,
 		Position:                      c.Position,
 		Bitrate:                       c.Bitrate,
+		Flags:                         c.Flags,
 		OwnerID:                       c.OwnerID,
 		AvailableTags:                 c.AvailableTags,
 		AppliedTags:                   c.AppliedTags,
@@ -168,6 +169,10 @@ func ChannelStateFromDgo(c *discordgo.Channel) ChannelState {
 		DefaultThreadRateLimitPerUser: c.DefaultThreadRateLimitPerUser,
 		DefaultSortOrder:              c.DefaultSortOrder,
 		DefaultForumLayout:            c.DefaultForumLayout,
+		Archived:                      c.Archived,
+		AutoArchiveDuration:           c.AutoArchiveDuration,
+		Locked:                        c.Locked,
+		Invitable:                     c.Invitable,
 	}
 }
 

--- a/lib/dstate/interface.go
+++ b/lib/dstate/interface.go
@@ -259,13 +259,18 @@ type ChannelState struct {
 	UserLimit        int                       `json:"user_limit"`
 	ParentID         int64                     `json:"parent_id,string"`
 	RateLimitPerUser int                       `json:"rate_limit_per_user"`
+	Flags            discordgo.ChannelFlags    `json:"flags"`
 	OwnerID          int64                     `json:"owner_id,string"`
 	ThreadMetadata   *discordgo.ThreadMetadata `json:"thread_metadata"`
 
 	PermissionOverwrites []discordgo.PermissionOverwrite `json:"permission_overwrites"`
 
-	AvailableTags []discordgo.ForumTag `json:"available_tags"`
-	AppliedTags   []int64              `json:"applied_tags"`
+	AvailableTags       []discordgo.ForumTag `json:"available_tags"`
+	AppliedTags         []int64              `json:"applied_tags"`
+	Archived            bool                 `json:"archived"`
+	AutoArchiveDuration int                  `json:"auto_archive_duration,omitempty"`
+	Locked              bool                 `json:"locked"`
+	Invitable           bool                 `json:"invitable"`
 
 	DefaultReactionEmoji          discordgo.ForumDefaultReaction `json:"default_reaction_emoji"`
 	DefaultThreadRateLimitPerUser int                            `json:"default_thread_rate_limit_per_user"`


### PR DESCRIPTION
Continue forum and thread support for custom commands. This PR focusses on editing existing threads, closing, locking, opening again, slow mode, auto-archive, invitability, and forum pinning and editing tags.

### New functions
|**Function**| **Description**|
|-| -|
|`closeThread` thread (flag)| Closes the specified thread, or the current thread if set to `nil`. `flag` part is a _bool_ and if set as **true** (**false** is optional) locks the thread as well as closing it.|
|`editThread` thread (values)| Edits the specified thread, or the current thread if set to `nil`. `values` must be key-value pairs of which parameters to edit. Available values:`slowmode` - provide length in seconds of slowmode; `auto_archive_duration` - provide duration in hours, must be either `60`, `1440`, `4320`, or `10080`; `invitable` - boolean, set to true to allow non-moderators to add members to the thread (only available for private threads) `tags` - either name of one tag, or slice of tag names. Overwrites the current tags (only available for forum posts).|
|`openThread` thread| Opens and unlocks the specified thread, or the current thread if set to `nil`.|
|`pinForumPost` thread| Pins the specified thread, or the current thread if set to `nil` in the parent forum channel.|
|`unpinForumPost` thread| Unpins the specified thread, or the current thread if set to `nil`  from the parent forum channel.|