### PR TITLE
cleared up owner and bot only commands

### DIFF
--- a/stdcommands/cleardm/cleardm.go
+++ b/stdcommands/cleardm/cleardm.go
@@ -16,7 +16,7 @@ var Command = &commands.YAGCommand{
 	CmdCategory:          commands.CategoryDebug,
 	HideFromCommandsPage: true,
 	Name:                 "cleardm",
-	Description:          "clears the DM chat with a user, owner only command.",
+	Description:          "clears the DM chat with a user, bot owner only command.",
 	HideFromHelp:         true,
 	RequiredArgs:         1,
 	Arguments: []*dcmd.ArgDef{

--- a/stdcommands/topcommands/topcommands.go
+++ b/stdcommands/topcommands/topcommands.go
@@ -14,7 +14,7 @@ var Command = &commands.YAGCommand{
 	Cooldown:     2,
 	CmdCategory:  commands.CategoryDebug,
 	Name:         "topcommands",
-	Description:  "Shows command usage stats",
+	Description:  "Shows command usage stats. Bot Admin Only.",
 	HideFromHelp: true,
 	Arguments: []*dcmd.ArgDef{
 		{Name: "hours", Type: dcmd.Int, Default: 1},


### PR DESCRIPTION
updated the `cleardm` command description to match the other Bot Owner only commands.
updated the `topcommands` command description to include `Bot Admin Only` in the description.