### PR TITLE
poll,wyr: obey response autodeletion set via command overrides

### DIFF
--- a/lib/dcmd/data.go
+++ b/lib/dcmd/data.go
@@ -87,6 +87,8 @@ func (d *Data) SendFollowupMessage(reply interface{}, allowedMentions discordgo.
 	switch t := reply.(type) {
 	case Response:
 		return t.Send(d)
+	case ManualResponse:
+		return t.Messages, nil
 	case string:
 		if t != "" {
 			return SplitSendMessage(d, t, allowedMentions)

--- a/lib/dcmd/response.go
+++ b/lib/dcmd/response.go
@@ -62,6 +62,19 @@ func (t *TemporaryResponse) Send(data *Data) ([]*discordgo.Message, error) {
 	return msgs, nil
 }
 
+// ManualResponse is a marker indicating that the command responses have
+// already sent manually; dcmd need not do anything.
+type ManualResponse struct {
+	Messages []*discordgo.Message
+}
+
+// MarkManualResponse indicates to dcmd that the command has already responded
+// to the command manually with the given messages, and that dcmd need not do
+// anything further.
+func MarkManualResponse(responses []*discordgo.Message) ManualResponse {
+	return ManualResponse{responses}
+}
+
 // SplitSendMessage uses SplitString to make sure each message is within 2k characters and splits at last newline before that (if possible)
 func SplitSendMessage(data *Data, contents string, allowedMentions discordgo.AllowedMentions) ([]*discordgo.Message, error) {
 	result := make([]*discordgo.Message, 0, 1)

--- a/stdcommands/poll/poll.go
+++ b/stdcommands/poll/poll.go
@@ -81,5 +81,5 @@ func createPoll(data *dcmd.Data) (interface{}, error) {
 	for i := range options {
 		common.BotSession.MessageReactionAdd(pollMsg.ChannelID, pollMsg.ID, pollReactions[i])
 	}
-	return nil, nil
+	return dcmd.MarkManualResponse([]*discordgo.Message{pollMsg}), nil
 }

--- a/stdcommands/wouldyourather/wouldyourather.go
+++ b/stdcommands/wouldyourather/wouldyourather.go
@@ -54,11 +54,7 @@ var Command = &commands.YAGCommand{
 		}
 
 		common.BotSession.MessageReactionAdd(data.ChannelID, msg.ID, "🇦")
-		err = common.BotSession.MessageReactionAdd(data.ChannelID, msg.ID, "🇧")
-		if err != nil {
-			return nil, err
-		}
-
-		return nil, nil
+		common.BotSession.MessageReactionAdd(data.ChannelID, msg.ID, "🇧")
+		return dcmd.MarkManualResponse([]*discordgo.Message{msg}), nil
 	},
 }


### PR DESCRIPTION
Related to #1671. This PR allows poll and wyr responses to be autodeleted after a delay via command overrides. Previously, the command system had no knowledge of responses to these commands (which are sent manually since reactions need to be added), so autodeletion did not work.