### PR TITLE
reminders: verify that member can run `remindme` in target channel

### DIFF
--- a/commands/util.go
+++ b/commands/util.go
@@ -154,10 +154,9 @@ func CommonContainerNotFoundHandler(container *dcmd.Container, fixedMessage stri
 	return func(data *dcmd.Data) (interface{}, error) {
 		// Only show stuff if atleast 1 of the commands in the container is enabled
 		if data.GuildData != nil {
-			cParentID := data.GuildData.CS.ParentID
 			ms := data.GuildData.MS
 
-			channelOverrides, err := GetOverridesForChannel(data.ChannelID, cParentID, data.GuildData.GS.ID)
+			channelOverrides, err := GetOverridesForChannel(data.GuildData.CS, data.GuildData.GS)
 			if err != nil {
 				logger.WithError(err).WithField("guild", data.GuildData.GS.ID).Error("failed retrieving command overrides")
 				return nil, nil

--- a/commands/yagcommmand.go
+++ b/commands/yagcommmand.go
@@ -437,16 +437,8 @@ func (yc *YAGCommand) checkCanExecuteCommand(data *dcmd.Data) (canExecute bool, 
 				return false, nil, nil, nil
 			}
 		}
-		channel_id := data.GuildData.CS.ID
-		parent_id := data.GuildData.CS.ParentID
-		// in case the channel is a thread, get the parent channel from parent id and check for the overrides
-		if data.GuildData.CS.Type.IsThread() {
-			channel := data.GuildData.GS.GetChannel(parent_id)
-			channel_id = channel.ID
-			parent_id = channel.ParentID
-		}
 
-		settings, err = yc.GetSettings(data.ContainerChain, channel_id, parent_id, guild.ID)
+		settings, err = yc.GetSettings(data.ContainerChain, data.GuildData.CS, guild)
 		if err != nil {
 			resp = &CanExecuteError{
 				Type:    ReasonError,
@@ -721,9 +713,14 @@ type CommandSettings struct {
 	IgnoreRoles   []int64
 }
 
-func GetOverridesForChannel(channelID, channelParentID, guildID int64) ([]*models.CommandsChannelsOverride, error) {
+func GetOverridesForChannel(cs *dstate.ChannelState, guild *dstate.GuildSet) ([]*models.CommandsChannelsOverride, error) {
+	if cs.Type.IsThread() {
+		// Look for overrides from the parent channel, not the thread.
+		cs = guild.GetChannel(cs.ParentID)
+	}
+
 	// Fetch the overrides from the database, we treat the global settings as an override for simplicity
-	channelOverrides, err := models.CommandsChannelsOverrides(qm.Where("(? = ANY (channels) OR global=true OR ? = ANY (channel_categories)) AND guild_id=?", channelID, channelParentID, guildID), qm.Load("CommandsCommandOverrides")).AllG(context.Background())
+	channelOverrides, err := models.CommandsChannelsOverrides(qm.Where("(? = ANY (channels) OR global=true OR ? = ANY (channel_categories)) AND guild_id=?", cs.ID, cs.ParentID, guild.ID), qm.Load("CommandsCommandOverrides")).AllG(context.Background())
 	if err != nil {
 		return nil, err
 	}
@@ -732,23 +729,23 @@ func GetOverridesForChannel(channelID, channelParentID, guildID int64) ([]*model
 }
 
 // GetSettings returns the settings from the command, generated from the servers channel and command overrides
-func (cs *YAGCommand) GetSettings(containerChain []*dcmd.Container, channelID, channelParentID, guildID int64) (settings *CommandSettings, err error) {
+func (yc *YAGCommand) GetSettings(containerChain []*dcmd.Container, cs *dstate.ChannelState, guild *dstate.GuildSet) (settings *CommandSettings, err error) {
 
 	// Fetch the overrides from the database, we treat the global settings as an override for simplicity
-	channelOverrides, err := GetOverridesForChannel(channelID, channelParentID, guildID)
+	channelOverrides, err := GetOverridesForChannel(cs, guild)
 	if err != nil {
 		err = errors.WithMessage(err, "GetOverridesForChannel")
 		return
 	}
 
-	return cs.GetSettingsWithLoadedOverrides(containerChain, guildID, channelOverrides)
+	return yc.GetSettingsWithLoadedOverrides(containerChain, guild.ID, channelOverrides)
 }
 
-func (cs *YAGCommand) GetSettingsWithLoadedOverrides(containerChain []*dcmd.Container, guildID int64, channelOverrides []*models.CommandsChannelsOverride) (settings *CommandSettings, err error) {
+func (yc *YAGCommand) GetSettingsWithLoadedOverrides(containerChain []*dcmd.Container, guildID int64, channelOverrides []*models.CommandsChannelsOverride) (settings *CommandSettings, err error) {
 	settings = &CommandSettings{}
 
 	// Some commands have custom places to toggle their enabled status
-	ce, err := cs.customEnabled(guildID)
+	ce, err := yc.customEnabled(guildID)
 	if err != nil {
 		err = errors.WithMessage(err, "customEnabled")
 		return
@@ -758,7 +755,7 @@ func (cs *YAGCommand) GetSettingsWithLoadedOverrides(containerChain []*dcmd.Cont
 		return
 	}
 
-	if cs.HideFromCommandsPage {
+	if yc.HideFromCommandsPage {
 		settings.Enabled = true
 		return
 	}
@@ -780,7 +777,7 @@ func (cs *YAGCommand) GetSettingsWithLoadedOverrides(containerChain []*dcmd.Cont
 		}
 	}
 
-	cmdFullName := cs.Name
+	cmdFullName := yc.Name
 	if len(containerChain) > 1 {
 		lastContainer := containerChain[len(containerChain)-1]
 		cmdFullName = lastContainer.Names[0] + " " + cmdFullName
@@ -788,12 +785,12 @@ func (cs *YAGCommand) GetSettingsWithLoadedOverrides(containerChain []*dcmd.Cont
 
 	// Assign the global settings, if existing
 	if global != nil {
-		cs.fillSettings(cmdFullName, global, settings)
+		yc.fillSettings(cmdFullName, global, settings)
 	}
 
 	// Assign the channel override, if existing
 	if channelOverride != nil {
-		cs.fillSettings(cmdFullName, channelOverride, settings)
+		yc.fillSettings(cmdFullName, channelOverride, settings)
 	}
 
 	return


### PR DESCRIPTION
Previously, if a member used `remindme ... -channel #foo` and `remindme` was disabled via command/channel overrides in channel `#foo`, the command would still go through as long as the member had send message permissions in `#foo`. This PR fixes `remindme` to check command overrides as well.