### PR TITLE
decodeBase64, encodeBase64 and sha256 for yagpdb custom commands

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -743,6 +743,10 @@ func baseContextFuncs(c *Context) {
 	c.addContextFunc("onlineCountBots", c.tmplOnlineCountBots)
 
 	c.addContextFunc("sort", c.tmplSort)
+
+	c.addContextFunc("encodeBase64", c.tmplEncodeBase64)
+	c.addContextFunc("decodeBase64", c.tmplDecodeBase64)
+	c.addContextFunc("sha256", c.tmplSha256)
 }
 
 type limitedWriter struct {

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"crypto/sha256"
+	"encoding/base64"
 
 	"github.com/botlabs-gg/yagpdb/v2/bot"
 	"github.com/botlabs-gg/yagpdb/v2/common"
@@ -2421,4 +2423,25 @@ func (c *Context) validateDurationDelay(in interface{}) time.Duration {
 	default:
 		return ToDuration(t)
 	}
+}
+
+func (c *Context) tmplDecodeBase64(str string) (string, error) {
+	raw, err := base64.StdEncoding.DecodeString(str)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+func (c *Context) tmplEncodeBase64(str string) string {
+	return base64.StdEncoding.EncodeToString([]byte(str))
+}
+
+func (c *Context) tmplSha256(str string) string {
+    hash := sha256.New()
+    hash.Write([]byte(str))
+
+    sha256 := base64.URLEncoding.EncodeToString(hash.Sum(nil))
+
+	return sha256
 }


### PR DESCRIPTION
# Examples of usage
```go
{{sha256 "i hate ducks"}}
```
```go
{{encodeBase64 "i hate ducks"}}
```
```go
{{decodeBase64 "i hate ducks"}}
```
![screenshot](https://github.com/botlabs-gg/yagpdb/assets/58076174/e2409cb4-41f4-4893-91c6-75103ddcaaec)

# Why?
I wanted to create some cool commands with passwords etc.