### PR TITLE
Disable custom command groups (Suggestion #2224)

### DIFF
--- a/customcommands/assets/customcommands-editcmd.html
+++ b/customcommands/assets/customcommands-editcmd.html
@@ -28,7 +28,7 @@
                     class="nav-item {{if $dot.CurrentCommandGroup}}{{if eq $dot.CurrentCommandGroup.ID .ID}}active{{end}}{{end}}">
                     <a data-partial-load="true"
                         class="nav-link show {{if $dot.CurrentCommandGroup}}{{if eq $dot.CurrentCommandGroup.ID .ID}}active{{end}}{{end}}"
-                        href="/manage/{{$dot.ActiveGuild.ID}}/customcommands/groups/{{.ID}}">{{.Name}}</a>
+                        href="/manage/{{$dot.ActiveGuild.ID}}/customcommands/groups/{{.ID}}">{{.Name}}{{if .Disabled}} <code>Disabled</code>{{end}}</a>
                 </li>
                 {{end}}
                 <li class="nav-item">

--- a/customcommands/assets/customcommands.html
+++ b/customcommands/assets/customcommands.html
@@ -108,7 +108,7 @@
                                 </div>
                                 <div class="form-group">
                                     <label>Group disabled</label><br>
-                                    {{checkbox "disabled" "disabled" "Enables or Disables the group" .CurrentCommandGroup.Disabled }}
+                                    {{checkbox "disabled" "disabled" "Enables or Disables the group" .CurrentCommandGroup.Disabled}}
                                 </div>
                                 <div class="form-group">
                                     <button type="submit"

--- a/customcommands/assets/customcommands.html
+++ b/customcommands/assets/customcommands.html
@@ -47,7 +47,7 @@
                     class="nav-item {{if $dot.CurrentCommandGroup}}{{if eq $dot.CurrentCommandGroup.ID .ID}}active{{end}}{{end}}">
                     <a data-partial-load="true"
                         class="nav-link show {{if $dot.CurrentCommandGroup}}{{if eq $dot.CurrentCommandGroup.ID .ID}}active{{end}}{{end}}"
-                        href="/manage/{{$dot.ActiveGuild.ID}}/customcommands/groups/{{.ID}}">{{.Name}}</a>
+                        href="/manage/{{$dot.ActiveGuild.ID}}/customcommands/groups/{{.ID}}">{{.Name}}{{if .Disabled}} <code>Disabled</code>{{end}}</a>
                 </li>
                 {{end}}
                 <li class="nav-item">
@@ -105,6 +105,10 @@
                                         name="BlacklistChannels">
                                         {{textChannelOptionsMulti .ActiveGuild.Channels .CurrentCommandGroup.IgnoreChannels }}
                                     </select>
+                                </div>
+                                <div class="form-group">
+                                    <label>Group disabled</label><br>
+                                    {{checkbox "disabled" "disabled" "Enables or Disables the group" .CurrentCommandGroup.Disabled }}
                                 </div>
                                 <div class="form-group">
                                     <button type="submit"

--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -400,8 +400,17 @@ func handleDelayedRunCC(evt *schEventsModels.ScheduledEvent, data interface{}) (
 		return false, errors.WrapIf(err, "find_command")
 	}
 
+	groups, err := getDisabledGroups(context.Background(), evt.GuildID)
+	if err != nil {
+		return false, errors.WrapIf(err, "Failed retrieving custom command groups")
+	}
+
 	if cmd.Disabled {
 		return false, errors.New("custom command is disabled")
+	}
+
+	if groups[cmd.GroupID.Int64] {
+		return false, errors.New("custom command group is disabled")
 	}
 
 	if !DelayedCCRunLimit.AllowN(DelayedRunLimitKey{GuildID: evt.GuildID, ChannelID: dataCast.ChannelID}, time.Now(), 1) {
@@ -470,8 +479,17 @@ func handleNextRunScheduledEVent(evt *schEventsModels.ScheduledEvent, data inter
 		return false, errors.WrapIf(err, "find_command")
 	}
 
+	groups, err := getDisabledGroups(context.Background(), evt.GuildID)
+	if err != nil {
+		return false, errors.WrapIf(err, "Failed retrieving custom command groups")
+	}
+	
 	if cmd.Disabled {
 		return false, errors.New("custom command is disabled")
+	}
+
+	if groups[cmd.GroupID.Int64] {
+		return false, errors.New("custom command group is disabled")
 	}
 
 	if time.Until(cmd.NextRun.Time) > time.Second*5 {
@@ -828,6 +846,21 @@ type TriggeredCC struct {
 	Args     []string
 }
 
+func getDisabledGroups(ctx context.Context, guildID int64) (map[int64]bool, error) {
+	gr, err := models.CustomCommandGroups(qm.Where("guild_id=?", guildID)).AllG(ctx)
+	if err != nil {
+		return nil, err
+	}
+	groups := make(map[int64]bool)
+
+	for _, group := range gr {
+		if group.Disabled {
+			groups[int64(group.ID)] = true
+		}
+	}
+	return groups, nil
+}
+
 func findMessageTriggerCustomCommands(ctx context.Context, cs *dstate.ChannelState, ms *dstate.MemberState, evt *eventsystem.EventData, msg *discordgo.Message) (matches []*TriggeredCC, err error) {
 	cmds, err := BotCachedGetCommandsWithMessageTriggers(cs.GuildID, ctx)
 	if err != nil {
@@ -839,14 +872,18 @@ func findMessageTriggerCustomCommands(ctx context.Context, cs *dstate.ChannelSta
 		return nil, errors.WrapIf(err, "GetCommandPrefix")
 	}
 
+	groups, err := getDisabledGroups(ctx, cs.GuildID)
+	if err != nil {
+		return nil, errors.WrapIf(err, "Failed retrieving custom command groups")
+	}
+
 	var matched []*TriggeredCC
 	for _, cmd := range cmds {
-		if cmd.Disabled || !CmdRunsInChannel(cmd, common.ChannelOrThreadParentID(cs)) || !CmdRunsForUser(cmd, ms) {
+		if cmd.Disabled || !CmdRunsInChannel(cmd, common.ChannelOrThreadParentID(cs)) || !CmdRunsForUser(cmd, ms) || groups[cmd.GroupID.Int64] {
 			continue
 		}
 
 		if didMatch, stripped, args := CheckMatch(prefix, cmd, msg.Content); didMatch {
-
 			matched = append(matched, &TriggeredCC{
 				CC:       cmd,
 				Args:     args,
@@ -875,9 +912,14 @@ func findReactionTriggerCustomCommands(ctx context.Context, cs *dstate.ChannelSt
 		return nil, nil, errors.WrapIf(err, "BotCachedGetCommandsWithReactionTriggers")
 	}
 
+	groups, err := getDisabledGroups(ctx, cs.GuildID)
+	if err != nil {
+		return nil, nil, errors.WrapIf(err, "Failed retrieving custom command groups")
+	}
+
 	var matched []*TriggeredCC
 	for _, cmd := range cmds {
-		if cmd.Disabled || !CmdRunsInChannel(cmd, common.ChannelOrThreadParentID(cs)) {
+		if cmd.Disabled || !CmdRunsInChannel(cmd, common.ChannelOrThreadParentID(cs)) || groups[cmd.GroupID.Int64] {
 			continue
 		}
 
@@ -933,9 +975,14 @@ func findComponentOrModalTriggerCustomCommands(ctx context.Context, cs *dstate.C
 		return nil, errors.WrapIf(err, "BotCachedGetCommandsWithComponentTriggers")
 	}
 
+	groups, err := getDisabledGroups(ctx, cs.GuildID)
+	if err != nil {
+		return nil, errors.WrapIf(err, "Failed retrieving custom command groups")
+	}
+
 	var matched []*TriggeredCC
 	for _, cmd := range cmds {
-		if cmd.Disabled || !CmdRunsInChannel(cmd, common.ChannelOrThreadParentID(cs)) {
+		if cmd.Disabled || !CmdRunsInChannel(cmd, common.ChannelOrThreadParentID(cs)) || groups[cmd.GroupID.Int64] {
 			continue
 		}
 

--- a/customcommands/models/custom_command_groups.go
+++ b/customcommands/models/custom_command_groups.go
@@ -31,6 +31,7 @@ type CustomCommandGroup struct {
 	IgnoreChannels    types.Int64Array `boil:"ignore_channels" json:"ignore_channels,omitempty" toml:"ignore_channels" yaml:"ignore_channels,omitempty"`
 	WhitelistRoles    types.Int64Array `boil:"whitelist_roles" json:"whitelist_roles,omitempty" toml:"whitelist_roles" yaml:"whitelist_roles,omitempty"`
 	WhitelistChannels types.Int64Array `boil:"whitelist_channels" json:"whitelist_channels,omitempty" toml:"whitelist_channels" yaml:"whitelist_channels,omitempty"`
+	Disabled          bool             `boil:"disabled" json:"disabled" toml:"disabled" yaml:"disabled"`
 
 	R *customCommandGroupR `boil:"-" json:"-" toml:"-" yaml:"-"`
 	L customCommandGroupL  `boil:"-" json:"-" toml:"-" yaml:"-"`
@@ -44,6 +45,7 @@ var CustomCommandGroupColumns = struct {
 	IgnoreChannels    string
 	WhitelistRoles    string
 	WhitelistChannels string
+	Disabled          string
 }{
 	ID:                "id",
 	GuildID:           "guild_id",
@@ -52,6 +54,7 @@ var CustomCommandGroupColumns = struct {
 	IgnoreChannels:    "ignore_channels",
 	WhitelistRoles:    "whitelist_roles",
 	WhitelistChannels: "whitelist_channels",
+	Disabled:          "disabled",
 }
 
 var CustomCommandGroupTableColumns = struct {
@@ -62,6 +65,7 @@ var CustomCommandGroupTableColumns = struct {
 	IgnoreChannels    string
 	WhitelistRoles    string
 	WhitelistChannels string
+	Disabled          string
 }{
 	ID:                "custom_command_groups.id",
 	GuildID:           "custom_command_groups.guild_id",
@@ -70,6 +74,7 @@ var CustomCommandGroupTableColumns = struct {
 	IgnoreChannels:    "custom_command_groups.ignore_channels",
 	WhitelistRoles:    "custom_command_groups.whitelist_roles",
 	WhitelistChannels: "custom_command_groups.whitelist_channels",
+	Disabled:          "custom_command_groups.disabled",
 }
 
 // Generated where
@@ -148,6 +153,15 @@ func (w whereHelpertypes_Int64Array) GTE(x types.Int64Array) qm.QueryMod {
 func (w whereHelpertypes_Int64Array) IsNull() qm.QueryMod    { return qmhelper.WhereIsNull(w.field) }
 func (w whereHelpertypes_Int64Array) IsNotNull() qm.QueryMod { return qmhelper.WhereIsNotNull(w.field) }
 
+type whereHelperbool struct{ field string }
+
+func (w whereHelperbool) EQ(x bool) qm.QueryMod  { return qmhelper.Where(w.field, qmhelper.EQ, x) }
+func (w whereHelperbool) NEQ(x bool) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.NEQ, x) }
+func (w whereHelperbool) LT(x bool) qm.QueryMod  { return qmhelper.Where(w.field, qmhelper.LT, x) }
+func (w whereHelperbool) LTE(x bool) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.LTE, x) }
+func (w whereHelperbool) GT(x bool) qm.QueryMod  { return qmhelper.Where(w.field, qmhelper.GT, x) }
+func (w whereHelperbool) GTE(x bool) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.GTE, x) }
+
 var CustomCommandGroupWhere = struct {
 	ID                whereHelperint64
 	GuildID           whereHelperint64
@@ -156,6 +170,7 @@ var CustomCommandGroupWhere = struct {
 	IgnoreChannels    whereHelpertypes_Int64Array
 	WhitelistRoles    whereHelpertypes_Int64Array
 	WhitelistChannels whereHelpertypes_Int64Array
+	Disabled          whereHelperbool
 }{
 	ID:                whereHelperint64{field: "\"custom_command_groups\".\"id\""},
 	GuildID:           whereHelperint64{field: "\"custom_command_groups\".\"guild_id\""},
@@ -164,6 +179,7 @@ var CustomCommandGroupWhere = struct {
 	IgnoreChannels:    whereHelpertypes_Int64Array{field: "\"custom_command_groups\".\"ignore_channels\""},
 	WhitelistRoles:    whereHelpertypes_Int64Array{field: "\"custom_command_groups\".\"whitelist_roles\""},
 	WhitelistChannels: whereHelpertypes_Int64Array{field: "\"custom_command_groups\".\"whitelist_channels\""},
+	Disabled:          whereHelperbool{field: "\"custom_command_groups\".\"disabled\""},
 }
 
 // CustomCommandGroupRels is where relationship names are stored.
@@ -194,9 +210,9 @@ func (r *customCommandGroupR) GetGroupCustomCommands() CustomCommandSlice {
 type customCommandGroupL struct{}
 
 var (
-	customCommandGroupAllColumns            = []string{"id", "guild_id", "name", "ignore_roles", "ignore_channels", "whitelist_roles", "whitelist_channels"}
+	customCommandGroupAllColumns            = []string{"id", "guild_id", "name", "ignore_roles", "ignore_channels", "whitelist_roles", "whitelist_channels", "disabled"}
 	customCommandGroupColumnsWithoutDefault = []string{"guild_id", "name"}
-	customCommandGroupColumnsWithDefault    = []string{"id", "ignore_roles", "ignore_channels", "whitelist_roles", "whitelist_channels"}
+	customCommandGroupColumnsWithDefault    = []string{"id", "ignore_roles", "ignore_channels", "whitelist_roles", "whitelist_channels", "disabled"}
 	customCommandGroupPrimaryKeyColumns     = []string{"id"}
 	customCommandGroupGeneratedColumns      = []string{}
 )

--- a/customcommands/models/custom_commands.go
+++ b/customcommands/models/custom_commands.go
@@ -49,10 +49,10 @@ type CustomCommand struct {
 	ShowErrors                bool              `boil:"show_errors" json:"show_errors" toml:"show_errors" yaml:"show_errors"`
 	Disabled                  bool              `boil:"disabled" json:"disabled" toml:"disabled" yaml:"disabled"`
 	TriggerOnEdit             bool              `boil:"trigger_on_edit" json:"trigger_on_edit" toml:"trigger_on_edit" yaml:"trigger_on_edit"`
-	Name                      null.String       `boil:"name" json:"name,omitempty" toml:"name" yaml:"name,omitempty"`
-	Public                    bool              `boil:"public" json:"public" toml:"public" yaml:"public"`
 	PublicID                  string            `boil:"public_id" json:"public_id" toml:"public_id" yaml:"public_id"`
 	ImportCount               int               `boil:"import_count" json:"import_count" toml:"import_count" yaml:"import_count"`
+	Name                      null.String       `boil:"name" json:"name,omitempty" toml:"name" yaml:"name,omitempty"`
+	Public                    bool              `boil:"public" json:"public" toml:"public" yaml:"public"`
 
 	R *customCommandR `boil:"-" json:"-" toml:"-" yaml:"-"`
 	L customCommandL  `boil:"-" json:"-" toml:"-" yaml:"-"`
@@ -83,10 +83,10 @@ var CustomCommandColumns = struct {
 	ShowErrors                string
 	Disabled                  string
 	TriggerOnEdit             string
-	Name                      string
-	Public                    string
 	PublicID                  string
 	ImportCount               string
+	Name                      string
+	Public                    string
 }{
 	LocalID:                   "local_id",
 	GuildID:                   "guild_id",
@@ -112,10 +112,70 @@ var CustomCommandColumns = struct {
 	ShowErrors:                "show_errors",
 	Disabled:                  "disabled",
 	TriggerOnEdit:             "trigger_on_edit",
-	Name:                      "name",
-	Public:                    "public",
 	PublicID:                  "public_id",
 	ImportCount:               "import_count",
+	Name:                      "name",
+	Public:                    "public",
+}
+
+var CustomCommandTableColumns = struct {
+	LocalID                   string
+	GuildID                   string
+	GroupID                   string
+	TriggerType               string
+	TextTrigger               string
+	TextTriggerCaseSensitive  string
+	TimeTriggerInterval       string
+	TimeTriggerExcludingDays  string
+	TimeTriggerExcludingHours string
+	LastRun                   string
+	NextRun                   string
+	Responses                 string
+	Channels                  string
+	ChannelsWhitelistMode     string
+	Roles                     string
+	RolesWhitelistMode        string
+	ContextChannel            string
+	ReactionTriggerMode       string
+	LastError                 string
+	LastErrorTime             string
+	RunCount                  string
+	ShowErrors                string
+	Disabled                  string
+	TriggerOnEdit             string
+	PublicID                  string
+	ImportCount               string
+	Name                      string
+	Public                    string
+}{
+	LocalID:                   "custom_commands.local_id",
+	GuildID:                   "custom_commands.guild_id",
+	GroupID:                   "custom_commands.group_id",
+	TriggerType:               "custom_commands.trigger_type",
+	TextTrigger:               "custom_commands.text_trigger",
+	TextTriggerCaseSensitive:  "custom_commands.text_trigger_case_sensitive",
+	TimeTriggerInterval:       "custom_commands.time_trigger_interval",
+	TimeTriggerExcludingDays:  "custom_commands.time_trigger_excluding_days",
+	TimeTriggerExcludingHours: "custom_commands.time_trigger_excluding_hours",
+	LastRun:                   "custom_commands.last_run",
+	NextRun:                   "custom_commands.next_run",
+	Responses:                 "custom_commands.responses",
+	Channels:                  "custom_commands.channels",
+	ChannelsWhitelistMode:     "custom_commands.channels_whitelist_mode",
+	Roles:                     "custom_commands.roles",
+	RolesWhitelistMode:        "custom_commands.roles_whitelist_mode",
+	ContextChannel:            "custom_commands.context_channel",
+	ReactionTriggerMode:       "custom_commands.reaction_trigger_mode",
+	LastError:                 "custom_commands.last_error",
+	LastErrorTime:             "custom_commands.last_error_time",
+	RunCount:                  "custom_commands.run_count",
+	ShowErrors:                "custom_commands.show_errors",
+	Disabled:                  "custom_commands.disabled",
+	TriggerOnEdit:             "custom_commands.trigger_on_edit",
+	PublicID:                  "custom_commands.public_id",
+	ImportCount:               "custom_commands.import_count",
+	Name:                      "custom_commands.name",
+	Public:                    "custom_commands.public",
 }
 
 // Generated where
@@ -180,15 +240,6 @@ func (w whereHelperint) NIN(slice []int) qm.QueryMod {
 	}
 	return qm.WhereNotIn(fmt.Sprintf("%s NOT IN ?", w.field), values...)
 }
-
-type whereHelperbool struct{ field string }
-
-func (w whereHelperbool) EQ(x bool) qm.QueryMod  { return qmhelper.Where(w.field, qmhelper.EQ, x) }
-func (w whereHelperbool) NEQ(x bool) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.NEQ, x) }
-func (w whereHelperbool) LT(x bool) qm.QueryMod  { return qmhelper.Where(w.field, qmhelper.LT, x) }
-func (w whereHelperbool) LTE(x bool) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.LTE, x) }
-func (w whereHelperbool) GT(x bool) qm.QueryMod  { return qmhelper.Where(w.field, qmhelper.GT, x) }
-func (w whereHelperbool) GTE(x bool) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.GTE, x) }
 
 type whereHelpernull_Time struct{ field string }
 
@@ -333,10 +384,10 @@ var CustomCommandWhere = struct {
 	ShowErrors                whereHelperbool
 	Disabled                  whereHelperbool
 	TriggerOnEdit             whereHelperbool
-	Name                      whereHelpernull_String
-	Public                    whereHelperbool
 	PublicID                  whereHelperstring
 	ImportCount               whereHelperint
+	Name                      whereHelpernull_String
+	Public                    whereHelperbool
 }{
 	LocalID:                   whereHelperint64{field: "\"custom_commands\".\"local_id\""},
 	GuildID:                   whereHelperint64{field: "\"custom_commands\".\"guild_id\""},
@@ -362,10 +413,10 @@ var CustomCommandWhere = struct {
 	ShowErrors:                whereHelperbool{field: "\"custom_commands\".\"show_errors\""},
 	Disabled:                  whereHelperbool{field: "\"custom_commands\".\"disabled\""},
 	TriggerOnEdit:             whereHelperbool{field: "\"custom_commands\".\"trigger_on_edit\""},
-	Name:                      whereHelpernull_String{field: "\"custom_commands\".\"name\""},
-	Public:                    whereHelperbool{field: "\"custom_commands\".\"public\""},
 	PublicID:                  whereHelperstring{field: "\"custom_commands\".\"public_id\""},
 	ImportCount:               whereHelperint{field: "\"custom_commands\".\"import_count\""},
+	Name:                      whereHelpernull_String{field: "\"custom_commands\".\"name\""},
+	Public:                    whereHelperbool{field: "\"custom_commands\".\"public\""},
 }
 
 // CustomCommandRels is where relationship names are stored.
@@ -396,9 +447,9 @@ func (r *customCommandR) GetGroup() *CustomCommandGroup {
 type customCommandL struct{}
 
 var (
-	customCommandAllColumns            = []string{"local_id", "guild_id", "group_id", "trigger_type", "text_trigger", "text_trigger_case_sensitive", "time_trigger_interval", "time_trigger_excluding_days", "time_trigger_excluding_hours", "last_run", "next_run", "responses", "channels", "channels_whitelist_mode", "roles", "roles_whitelist_mode", "context_channel", "reaction_trigger_mode", "last_error", "last_error_time", "run_count", "show_errors", "disabled", "trigger_on_edit", "name", "public", "public_id", "import_count"}
+	customCommandAllColumns            = []string{"local_id", "guild_id", "group_id", "trigger_type", "text_trigger", "text_trigger_case_sensitive", "time_trigger_interval", "time_trigger_excluding_days", "time_trigger_excluding_hours", "last_run", "next_run", "responses", "channels", "channels_whitelist_mode", "roles", "roles_whitelist_mode", "context_channel", "reaction_trigger_mode", "last_error", "last_error_time", "run_count", "show_errors", "disabled", "trigger_on_edit", "public_id", "import_count", "name", "public"}
 	customCommandColumnsWithoutDefault = []string{"local_id", "guild_id", "trigger_type", "text_trigger", "text_trigger_case_sensitive", "time_trigger_interval", "time_trigger_excluding_days", "time_trigger_excluding_hours", "responses", "channels_whitelist_mode", "roles_whitelist_mode"}
-	customCommandColumnsWithDefault    = []string{"group_id", "last_run", "next_run", "channels", "roles", "context_channel", "reaction_trigger_mode", "last_error", "last_error_time", "run_count", "show_errors", "disabled", "trigger_on_edit", "name", "public", "public_id", "import_count"}
+	customCommandColumnsWithDefault    = []string{"group_id", "last_run", "next_run", "channels", "roles", "context_channel", "reaction_trigger_mode", "last_error", "last_error_time", "run_count", "show_errors", "disabled", "trigger_on_edit", "public_id", "import_count", "name", "public"}
 	customCommandPrimaryKeyColumns     = []string{"guild_id", "local_id"}
 	customCommandGeneratedColumns      = []string{}
 )

--- a/customcommands/schema.go
+++ b/customcommands/schema.go
@@ -92,4 +92,6 @@ CREATE INDEX IF NOT EXISTS templates_user_database_expires_idx ON templates_user
 ALTER TABLE custom_commands ADD COLUMN IF NOT EXISTS name TEXT;
 `, `
 ALTER TABLE custom_commands ADD COLUMN IF NOT EXISTS public BOOLEAN NOT NULL DEFAULT false;
+`, `
+ALTER TABLE custom_command_groups ADD COLUMN IF NOT EXISTS disabled BOOLEAN NOT NULL DEFAULT false;
 `}

--- a/customcommands/tmplextensions.go
+++ b/customcommands/tmplextensions.go
@@ -180,9 +180,18 @@ func tmplRunCC(ctx *templates.Context) interface{} {
 			return "", templates.ErrTooManyCalls
 		}
 
-		cmd, err := models.FindCustomCommandG(context.Background(), ctx.GS.ID, int64(ccID))
+		// cmd, err := models.FindCustomCommandG(context.Background(), ctx.GS.ID, int64(ccID))
+		// if err != nil {
+		// 	return "", errors.New("Couldn't find custom command")
+		// }
+
+		cmd, err := models.CustomCommands(qm.Where("guild_id = ? AND local_id = ?", ctx.GS.ID, ccID), qm.Load("Group")).OneG(context.Background())
 		if err != nil {
 			return "", errors.New("Couldn't find custom command")
+		}
+
+		if cmd.R.Group != nil && cmd.R.Group.Disabled {
+			return "", errors.New("custom command group is disabled")
 		}
 
 		if cmd.Disabled {
@@ -275,9 +284,18 @@ func tmplScheduleUniqueCC(ctx *templates.Context) interface{} {
 			return "", templates.ErrTooManyCalls
 		}
 
-		cmd, err := models.FindCustomCommandG(context.Background(), ctx.GS.ID, int64(ccID))
+		// cmd, err := models.FindCustomCommandG(context.Background(), ctx.GS.ID, int64(ccID))
+		// if err != nil {
+		// 	return "", errors.New("Couldn't find custom command")
+		// }
+
+		cmd, err := models.CustomCommands(qm.Where("guild_id = ? AND local_id = ?", ctx.GS.ID, ccID), qm.Load("Group")).OneG(context.Background())
 		if err != nil {
 			return "", errors.New("Couldn't find custom command")
+		}
+
+		if cmd.R.Group != nil && cmd.R.Group.Disabled {
+			return "", errors.New("custom command group is disabled")
 		}
 
 		if cmd.Disabled {

--- a/customcommands/tmplextensions.go
+++ b/customcommands/tmplextensions.go
@@ -180,11 +180,6 @@ func tmplRunCC(ctx *templates.Context) interface{} {
 			return "", templates.ErrTooManyCalls
 		}
 
-		// cmd, err := models.FindCustomCommandG(context.Background(), ctx.GS.ID, int64(ccID))
-		// if err != nil {
-		// 	return "", errors.New("Couldn't find custom command")
-		// }
-
 		cmd, err := models.CustomCommands(qm.Where("guild_id = ? AND local_id = ?", ctx.GS.ID, ccID), qm.Load("Group")).OneG(context.Background())
 		if err != nil {
 			return "", errors.New("Couldn't find custom command")
@@ -283,11 +278,6 @@ func tmplScheduleUniqueCC(ctx *templates.Context) interface{} {
 		if ctx.IncreaseCheckCallCounterPremium("runcc", 1, 10) {
 			return "", templates.ErrTooManyCalls
 		}
-
-		// cmd, err := models.FindCustomCommandG(context.Background(), ctx.GS.ID, int64(ccID))
-		// if err != nil {
-		// 	return "", errors.New("Couldn't find custom command")
-		// }
 
 		cmd, err := models.CustomCommands(qm.Where("guild_id = ? AND local_id = ?", ctx.GS.ID, ccID), qm.Load("Group")).OneG(context.Background())
 		if err != nil {

--- a/customcommands/web.go
+++ b/customcommands/web.go
@@ -644,18 +644,12 @@ func handleRunCommandNow(w http.ResponseWriter, r *http.Request) (web.TemplateDa
 	}
 
 	// only interval commands can be ran from the dashboard currently
-	cmd, err := models.CustomCommands(qm.Where("guild_id = ? AND local_id = ? AND trigger_type = 5", activeGuild.ID, cmdID)).OneG(context.Background())
+	cmd, err := models.CustomCommands(qm.Where("guild_id = ? AND local_id = ? AND trigger_type = 5", activeGuild.ID, cmdID), qm.Load("Group")).OneG(context.Background())
 	if err != nil {
 		return templateData, err
 	}
 
-	groups, err := getDisabledGroups(context.Background(), activeGuild.ID)
-	if err != nil {
-		templateData.AddAlerts(web.ErrorAlert("Failed retrieving custom command groups"))
-		return templateData, nil
-	}
-
-	if groups[cmd.GroupID.Int64] {
+	if cmd.GroupID.Int64 != 0 && cmd.R.Group.Disabled {
 		templateData.AddAlerts(web.ErrorAlert("This command group is disabled, cannot run a command from disabled group."))
 		return templateData, nil
 	}

--- a/customcommands/web.go
+++ b/customcommands/web.go
@@ -649,7 +649,7 @@ func handleRunCommandNow(w http.ResponseWriter, r *http.Request) (web.TemplateDa
 		return templateData, err
 	}
 
-	if cmd.GroupID.Int64 != 0 && cmd.R.Group.Disabled {
+	if cmd.R.Group != nil && cmd.R.Group.Disabled {
 		templateData.AddAlerts(web.ErrorAlert("This command group is disabled, cannot run a command from disabled group."))
 		return templateData, nil
 	}


### PR DESCRIPTION
# What's changed?

- Small warning if the command group is disabled
- A switch for disabling the custom commang group

[Suggestion #2224](https://discord.com/channels/166207328570441728/356486960417734666/1246836065872908298)

# Screenshots
![image](https://github.com/botlabs-gg/yagpdb/assets/58076174/2c9570fa-ef18-4acf-8fe0-ff56c47d56d8)
![screenshot 2](https://github.com/botlabs-gg/yagpdb/assets/58076174/0dc1f405-4a60-4744-92cd-9d38e3ef759c)
