### PR TITLE
customcommands: relax restriction on execCC from command templates

### DIFF
--- a/customcommands/tmplextensions.go
+++ b/customcommands/tmplextensions.go
@@ -176,7 +176,7 @@ func (pa *ParsedArgs) IsSet(index int) interface{} {
 // or schedules a custom command to be run in the future sometime with the provided data placed in .ExecData
 func tmplRunCC(ctx *templates.Context) interface{} {
 	return func(ccID int, channel interface{}, delaySeconds interface{}, data interface{}) (string, error) {
-		if ctx.ExecutedFrom == templates.ExecutedFromCommandTemplate || ctx.ExecutedFrom == templates.ExecutedFromNestedCommandTemplate {
+		if ctx.ExecutedFrom == templates.ExecutedFromNestedCommandTemplate {
 			return "", nil
 		}
 


### PR DESCRIPTION
This PR relaxes a restriction on `execCC` calls from command templates (e.g., moderation DM templates) introduced in #1677. Specifically, we now permit one `execCC` call from command templates as long as it is not nested. This new restriction still resolves the original issue that #1677 set out to address but is less prone to cause breakage in userland. 