### PR TITLE
stdcommands/se: don't clear out title when editing

### DIFF
--- a/stdcommands/simpleembed/simpleembed.go
+++ b/stdcommands/simpleembed/simpleembed.go
@@ -24,7 +24,7 @@ var Command = &commands.YAGCommand{
 		{Name: "message", Help: "Optional message ID to edit", Type: dcmd.BigInt},
 		{Name: "content", Help: "Text content for the message", Type: dcmd.String},
 
-		{Name: "title", Type: dcmd.String, Default: ""},
+		{Name: "title", Type: dcmd.String},
 		{Name: "desc", Type: dcmd.String, Help: "Text in the 'description' field"},
 		{Name: "color", Help: "Either hex code or name", Type: dcmd.String},
 		{Name: "url", Help: "Url of this embed", Type: dcmd.String},


### PR DESCRIPTION
Don't clear out the embed title when editing it via `simpleembed`.
Because we provide an empty default value for the title field, it is set
to that if no "new" title is given when using this command to edit said
embed.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
