### PR TITLE
lib/discordgo: properly add ThreadMetadata

### DIFF
--- a/common/templates/structs.go
+++ b/common/templates/structs.go
@@ -27,11 +27,10 @@ type CtxChannel struct {
 	ParentID             int64                            `json:"parent_id"`
 	OwnerID              int64                            `json:"owner_id"`
 
-	AvailableTags []discordgo.ForumTag   `json:"available_tags"`
-	AppliedTags   []int64                `json:"applied_tags"`
-	Flags         discordgo.ChannelFlags `json:"flags"`
-	Archived      bool                   `json:"archived"`
-	Locked        bool                   `json:"locked"`
+	AvailableTags  []discordgo.ForumTag      `json:"available_tags"`
+	AppliedTags    []int64                   `json:"applied_tags"`
+	Flags          discordgo.ChannelFlags    `json:"flags"`
+	ThreadMetadata *discordgo.ThreadMetadata `json:"thread_metadata,omitempty"`
 }
 
 func (c *CtxChannel) Mention() (string, error) {
@@ -66,8 +65,7 @@ func CtxChannelFromCS(cs *dstate.ChannelState) *CtxChannel {
 		AvailableTags:        cs.AvailableTags,
 		AppliedTags:          cs.AppliedTags,
 		Flags:                cs.Flags,
-		Archived:             cs.Archived,
-		Locked:               cs.Locked,
+		ThreadMetadata:       cs.ThreadMetadata,
 	}
 
 	return ctxChannel

--- a/lib/discordgo/structs.go
+++ b/lib/discordgo/structs.go
@@ -294,18 +294,6 @@ type Channel struct {
 	// The default forum layout view used to display posts in forum channels.
 	// Defaults to ForumLayoutNotSet, which indicates a layout view has not been set by a channel admin.
 	DefaultForumLayout ForumLayout `json:"default_forum_layout"`
-
-	// whether the thread is archived
-	Archived bool `json:"archived"`
-
-	// the thread will stop showing in the channel list after auto_archive_duration minutes of inactivity, can be set to: 60, 1440, 4320, 10080
-	AutoArchiveDuration AutoArchiveDuration `json:"auto_archive_duration,omitempty"`
-
-	// whether the thread is locked; when a thread is locked, only users with MANAGE_THREADS can unarchive it
-	Locked bool `json:"locked"`
-
-	// whether non-moderators can add other non-moderators to a thread; only available on private threads
-	Invitable bool `json:"invitable"`
 }
 
 func (c *Channel) GetChannelID() int64 {

--- a/lib/dstate/helpers.go
+++ b/lib/dstate/helpers.go
@@ -169,10 +169,7 @@ func ChannelStateFromDgo(c *discordgo.Channel) ChannelState {
 		DefaultThreadRateLimitPerUser: c.DefaultThreadRateLimitPerUser,
 		DefaultSortOrder:              c.DefaultSortOrder,
 		DefaultForumLayout:            c.DefaultForumLayout,
-		Archived:                      c.Archived,
-		AutoArchiveDuration:           c.AutoArchiveDuration,
-		Locked:                        c.Locked,
-		Invitable:                     c.Invitable,
+		ThreadMetadata:                c.ThreadMetadata,
 	}
 }
 

--- a/lib/dstate/interface.go
+++ b/lib/dstate/interface.go
@@ -262,16 +262,12 @@ type ChannelState struct {
 	RateLimitPerUser int                       `json:"rate_limit_per_user"`
 	Flags            discordgo.ChannelFlags    `json:"flags"`
 	OwnerID          int64                     `json:"owner_id,string"`
-	ThreadMetadata   *discordgo.ThreadMetadata `json:"thread_metadata"`
+	ThreadMetadata   *discordgo.ThreadMetadata `json:"thread_metadata,omitempty"`
 
 	PermissionOverwrites []discordgo.PermissionOverwrite `json:"permission_overwrites"`
 
-	AvailableTags       []discordgo.ForumTag          `json:"available_tags"`
-	AppliedTags         []int64                       `json:"applied_tags"`
-	Archived            bool                          `json:"archived"`
-	AutoArchiveDuration discordgo.AutoArchiveDuration `json:"auto_archive_duration,omitempty"`
-	Locked              bool                          `json:"locked"`
-	Invitable           bool                          `json:"invitable"`
+	AvailableTags []discordgo.ForumTag `json:"available_tags"`
+	AppliedTags   []int64              `json:"applied_tags"`
 
 	DefaultReactionEmoji          discordgo.ForumDefaultReaction `json:"default_reaction_emoji"`
 	DefaultThreadRateLimitPerUser int                            `json:"default_thread_rate_limit_per_user"`


### PR DESCRIPTION
Add the `ThreadMetadata` properly to `discordgo.Channel`, that is,
remove the flattened duplicate entries from said struct and instead keep
just `discordgo.ThreadMetadata`.

As a consequence, this cascades to dstate as well as common/templates,
which were modified to reflect that change; as an added bonus, this now
properly represents the channel structure as defined by Discord, rather
than a custom flattened one.

BREAKING CHANGE:

`.Channel.{Locked,Archived}` will be moved to `.Channel.ThreadMetadata.*`.
Migrate by adding that additional layer to your accessing of these
fields. Reports indicate this hasn't worked properly anyway, therefore
this breakage should be acceptable.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
