### PR TITLE
automod: recover from panics in applying effects

### DIFF
--- a/automod/automod_bot.go
+++ b/automod/automod_bot.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"sort"
 	"time"
 
@@ -471,6 +472,13 @@ func (p *Plugin) RulesetRulesTriggeredCondsPassed(ruleset *ParsedRuleset, trigge
 
 		for _, effect := range rule.Effects {
 			go func(fx *ParsedPart, ctx *TriggeredRuleData) {
+				defer func() {
+					if r := recover(); r != nil {
+						stack := string(debug.Stack())
+						logger.Errorf("recovered from panic applying automod effect\n%v\n%v", r, stack)
+					}
+				}()
+
 				err := fx.Part.(Effect).Apply(ctx, fx.ParsedSettings)
 				if err != nil {
 					logger.WithError(err).WithField("guild", ruleset.RSModel.GuildID).WithField("part", fx.Part.Name()).Error("failed applying automod effect")

--- a/automod_legacy/bot.go
+++ b/automod_legacy/bot.go
@@ -1,6 +1,7 @@
 package automod_legacy
 
 import (
+	"runtime/debug"
 	"time"
 
 	"github.com/botlabs-gg/yagpdb/v2/analytics"
@@ -150,6 +151,13 @@ func CheckMessage(evt *eventsystem.EventData, m *discordgo.Message) bool {
 	}
 
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				stack := string(debug.Stack())
+				logger.Errorf("recovered from panic applying basic automod punishment\n%v\n%v", r, stack)
+			}
+		}()
+
 		switch highestPunish {
 		case PunishNone:
 			err = moderation.WarnUser(nil, cs.GuildID, cs, m, common.BotUser, &member.User, "Automoderator: "+punishMsg)

--- a/moderation/punishments.go
+++ b/moderation/punishments.go
@@ -217,11 +217,6 @@ func sendPunishDM(config *Config, dmMsg string, action ModlogAction, gs *dstate.
 }
 
 func KickUser(config *Config, guildID int64, channel *dstate.ChannelState, message *discordgo.Message, author *discordgo.User, reason string, user *discordgo.User, del int) error {
-	defer func() {
-		if r := recover(); r != nil {
-			logger.Infof("Recovered from panic: %#v", r)
-		}
-	}()
 	config, err := GetConfigIfNotSet(guildID, config)
 	if err != nil {
 		return common.ErrWithCaller(err)


### PR DESCRIPTION
This PR is one of several aiming to mitigate the impact of bugs similar to those introduced in the previous release.

The most pressing issue was the inadvertent removal of a nil guard in `KickUser` by me in #1659, which caused panics which were difficult to track down. To make these easier to debug in future (and to prevent complete bot crashes), in this PR we recover and log a stacktrace for panics in applying advanced automod effects and basic automod punishments. This supercedes the temporary bandaid recover added directly to `KickUser` in https://github.com/botlabs-gg/yagpdb/commit/f9602a1bb41ea1e86e2c6dfb06b8dd69998dba69.

For reference, I compiled a version of the bot with the nil pointer bug re-added (but with this patch applied as well.) Instead of crashing, the following is logged instead:
```
ERRO recovered from panic applying automod effect
runtime error: invalid memory address or nil pointer dereference
goroutine 379 [running]:
runtime/debug.Stack()
        /usr/local/go/src/runtime/debug/stack.go:24 +0x5e
github.com/botlabs-gg/yagpdb/v2/automod.(*Plugin).RulesetRulesTriggeredCondsPassed.func1.1()
        /REDACTED/yagpdb/automod/automod_bot.go:477 +0x38
panic({0x14a1cc0?, 0x492e600?})
        /usr/local/go/src/runtime/panic.go:770 +0x132
github.com/botlabs-gg/yagpdb/v2/moderation.KickUser(0x7ffa19f13270?, 0xad7ea432382000a, 0x0, 0x0, 0xc0000f8480, {0xc001908de0, 0x18}, 0xc00065ea00, 0xffffffffffffffff)
         /REDACTED/yagpdb/moderation/punishments.go:236 +0xf1
github.com/botlabs-gg/yagpdb/v2/automod.(*KickUserEffect).Apply(0x4931210?, 0xc0003f7860, {0x13b8c20?, 0xc000399dd0?})
         /REDACTED/yagpdb/automod/effects.go:272 +0xb2
github.com/botlabs-gg/yagpdb/v2/automod.(*Plugin).RulesetRulesTriggeredCondsPassed.func1(0xc00053bf00, 0xc0003f7860?)
         /REDACTED/yagpdb/automod/automod_bot.go:482 +0xf2
created by github.com/botlabs-gg/yagpdb/v2/automod.(*Plugin).RulesetRulesTriggeredCondsPassed in goroutine 473
        /REDACTED/yagpdb/automod/automod_bot.go:474 +0xd68  p=automod_v2 stck="automod.(*Plugin).RulesetRulesTriggeredCondsPassed.func1.1:automod_bot.go:478"
```
which points directly to the problematic line.