### PR TITLE
moderation: explicitly separate config functions that access bot process cache

### DIFF
--- a/automod/automod_web.go
+++ b/automod/automod_web.go
@@ -506,7 +506,7 @@ func (p *Plugin) handlePostAutomodUpdateRule(w http.ResponseWriter, r *http.Requ
 		}
 	}
 	if anyMute {
-		conf, err := moderation.GetConfigOrDefault(g.ID)
+		conf, err := moderation.FetchConfig(g.ID)
 		if err != nil || conf.MuteRole == 0 {
 			tx.Rollback()
 			tmpl.AddAlerts(web.ErrorAlert("No mute role set, please configure one."))

--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -27,7 +27,7 @@ import (
 )
 
 func MBaseCmd(cmdData *dcmd.Data, targetID int64) (config *Config, targetUser *discordgo.User, err error) {
-	config, err = GetConfigOrDefault(cmdData.GuildData.GS.ID)
+	config, err = FetchConfig(cmdData.GuildData.GS.ID)
 	if err != nil {
 		return nil, nil, errors.WithMessage(err, "GetConfig")
 	}

--- a/moderation/config.go
+++ b/moderation/config.go
@@ -28,7 +28,7 @@ func SaveConfig(config *Config) error {
 	return nil
 }
 
-func GetConfigOrDefault(guildID int64) (*Config, error) {
+func FetchConfig(guildID int64) (*Config, error) {
 	conf, err := models.FindModerationConfigG(context.Background(), guildID)
 	if err == nil {
 		return configFromModel(conf), nil

--- a/moderation/moderation.go
+++ b/moderation/moderation.go
@@ -61,7 +61,7 @@ const (
 )
 
 func (p *Plugin) UpdateFeatureFlags(guildID int64) ([]string, error) {
-	config, err := GetCachedConfigOrDefault(guildID)
+	config, err := BotCachedGetConfig(guildID)
 	if err != nil {
 		return nil, errors.WithStackIf(err)
 	}

--- a/moderation/plugin_bot.go
+++ b/moderation/plugin_bot.go
@@ -80,10 +80,10 @@ func SaveConfig(config *Config) error {
 	return nil
 }
 
-func GetConfigIfNotSet(guildID int64, config *Config) (*Config, error) {
+func BotCachedGetConfigIfNotSet(guildID int64, config *Config) (*Config, error) {
 	if config == nil {
 		var err error
-		config, err = GetCachedConfigOrDefault(guildID)
+		config, err = BotCachedGetConfig(guildID)
 		if err != nil {
 			return nil, err
 		}
@@ -94,7 +94,7 @@ func GetConfigIfNotSet(guildID int64, config *Config) (*Config, error) {
 
 var configCache = ccache.New(ccache.Configure().MaxSize(15000))
 
-func GetCachedConfigOrDefault(guildID int64) (*Config, error) {
+func BotCachedGetConfig(guildID int64) (*Config, error) {
 	const cacheDuration = 10 * time.Minute
 
 	item, err := configCache.Fetch(cacheKey(guildID), cacheDuration, func() (interface{}, error) {
@@ -182,7 +182,7 @@ func RefreshMuteOverrides(guildID int64, createRole bool) {
 		return // nothing to do
 	}
 
-	config, err := GetCachedConfigOrDefault(guildID)
+	config, err := BotCachedGetConfig(guildID)
 	if err != nil {
 		return
 	}
@@ -266,7 +266,7 @@ func HandleChannelCreateUpdate(evt *eventsystem.EventData) (retry bool, err erro
 		return false, nil
 	}
 
-	config, err := GetCachedConfigOrDefault(channel.GuildID)
+	config, err := BotCachedGetConfig(channel.GuildID)
 	if err != nil {
 		return true, errors.WithStackIf(err)
 	}
@@ -338,7 +338,7 @@ func HandleGuildMemberTimeoutChange(evt *eventsystem.EventData) (retry bool, err
 		return false, nil
 	}
 
-	config, err := GetCachedConfigOrDefault(data.GuildID)
+	config, err := BotCachedGetConfig(data.GuildID)
 	if err != nil {
 		return true, errors.WithStackIf(err)
 	}
@@ -422,7 +422,7 @@ func HandleGuildBanAddRemove(evt *eventsystem.EventData) {
 		return
 	}
 
-	config, err := GetCachedConfigOrDefault(guildID)
+	config, err := BotCachedGetConfig(guildID)
 	if err != nil {
 		logger.WithError(err).WithField("guild", guildID).Error("Failed retrieving config")
 		return
@@ -471,7 +471,7 @@ func HandleGuildBanAddRemove(evt *eventsystem.EventData) {
 func HandleGuildMemberRemove(evt *eventsystem.EventData) (retry bool, err error) {
 	data := evt.GuildMemberRemove()
 
-	config, err := GetCachedConfigOrDefault(data.GuildID)
+	config, err := BotCachedGetConfig(data.GuildID)
 	if err != nil {
 		return true, errors.WithStackIf(err)
 	}
@@ -556,7 +556,7 @@ func LockMemberMuteMW(next eventsystem.HandlerFunc) eventsystem.HandlerFunc {
 func HandleMemberJoin(evt *eventsystem.EventData) (retry bool, err error) {
 	c := evt.GuildMemberAdd()
 
-	config, err := GetCachedConfigOrDefault(c.GuildID)
+	config, err := BotCachedGetConfig(c.GuildID)
 	if err != nil {
 		return true, errors.WithStackIf(err)
 	}
@@ -581,7 +581,7 @@ func HandleGuildMemberUpdate(evt *eventsystem.EventData) (retry bool, err error)
 		return false, nil
 	}
 
-	config, err := GetCachedConfigOrDefault(c.GuildID)
+	config, err := BotCachedGetConfig(c.GuildID)
 	if err != nil {
 		return true, errors.WithStackIf(err)
 	}

--- a/moderation/plugin_bot.go
+++ b/moderation/plugin_bot.go
@@ -82,7 +82,7 @@ func BotCachedGetConfig(guildID int64) (*Config, error) {
 	const cacheDuration = 10 * time.Minute
 
 	item, err := configCache.Fetch(cacheKey(guildID), cacheDuration, func() (interface{}, error) {
-		return GetConfigOrDefault(guildID)
+		return FetchConfig(guildID)
 	})
 	if err != nil {
 		return nil, err

--- a/moderation/plugin_bot.go
+++ b/moderation/plugin_bot.go
@@ -1,7 +1,6 @@
 package moderation
 
 import (
-	"context"
 	"database/sql"
 	"math/rand"
 	"strconv"
@@ -23,7 +22,6 @@ import (
 	"github.com/botlabs-gg/yagpdb/v2/moderation/models"
 	"github.com/karlseguin/ccache"
 	"github.com/mediocregopher/radix/v3"
-	"github.com/volatiletech/sqlboiler/v4/boil"
 )
 
 var (
@@ -66,20 +64,6 @@ func (p *Plugin) BotInit() {
 	pubsub.AddHandler("mod_refresh_mute_override_create_role", HandleRefreshMuteOverridesCreateRole, nil)
 }
 
-func SaveConfig(config *Config) error {
-	err := config.ToModel().UpsertG(context.Background(), true, []string{"guild_id"}, boil.Infer(), boil.Infer())
-	if err != nil {
-		return err
-	}
-	pubsub.Publish("invalidate_moderation_config_cache", config.GuildID, nil)
-
-	if err := featureflags.UpdatePluginFeatureFlags(config.GuildID, &Plugin{}); err != nil {
-		return err
-	}
-	pubsub.Publish("mod_refresh_mute_override", config.GuildID, nil)
-	return nil
-}
-
 func BotCachedGetConfigIfNotSet(guildID int64, config *Config) (*Config, error) {
 	if config == nil {
 		var err error
@@ -112,19 +96,6 @@ func handleInvalidateConfigCache(evt *pubsub.Event) {
 
 func cacheKey(guildID int64) string {
 	return discordgo.StrID(guildID)
-}
-
-func GetConfigOrDefault(guildID int64) (*Config, error) {
-	conf, err := models.FindModerationConfigG(context.Background(), guildID)
-	if err == nil {
-		return configFromModel(conf), nil
-	}
-
-	if err == sql.ErrNoRows {
-		return &Config{GuildID: guildID}, nil
-	}
-
-	return nil, err
 }
 
 type ScheduledUnmuteData struct {

--- a/moderation/plugin_web.go
+++ b/moderation/plugin_web.go
@@ -58,7 +58,7 @@ func HandleModeration(w http.ResponseWriter, r *http.Request) (web.TemplateData,
 	templateData["DefaultTimeoutDuration"] = int(DefaultTimeoutDuration.Minutes())
 
 	if _, ok := templateData["ModConfig"]; !ok {
-		config, err := GetConfigOrDefault(activeGuild.ID)
+		config, err := FetchConfig(activeGuild.ID)
 		if err != nil {
 			return templateData, err
 		}
@@ -114,7 +114,7 @@ func (p *Plugin) LoadServerHomeWidget(w http.ResponseWriter, r *http.Request) (w
 	templateData["WidgetTitle"] = "Moderation"
 	templateData["SettingsPath"] = "/moderation"
 
-	config, err := GetConfigOrDefault(activeGuild.ID)
+	config, err := FetchConfig(activeGuild.ID)
 	if err != nil {
 		return templateData, err
 	}

--- a/moderation/punishments.go
+++ b/moderation/punishments.go
@@ -55,7 +55,7 @@ func getMemberWithFallback(gs *dstate.GuildSet, user *discordgo.User) (ms *dstat
 // Kick or bans someone, uploading a hasebin log, and sending the report message in the action channel
 func punish(config *Config, p Punishment, guildID int64, channel *dstate.ChannelState, message *discordgo.Message, author *discordgo.User, reason string, user *discordgo.User, duration time.Duration, variadicBanDeleteDays ...int) error {
 
-	config, err := GetConfigIfNotSet(guildID, config)
+	config, err := BotCachedGetConfigIfNotSet(guildID, config)
 	if err != nil {
 		return common.ErrWithCaller(err)
 	}
@@ -222,7 +222,7 @@ func KickUser(config *Config, guildID int64, channel *dstate.ChannelState, messa
 			logger.Infof("Recovered from panic: %#v", r)
 		}
 	}()
-	config, err := GetConfigIfNotSet(guildID, config)
+	config, err := BotCachedGetConfigIfNotSet(guildID, config)
 	if err != nil {
 		return common.ErrWithCaller(err)
 	}
@@ -319,7 +319,7 @@ func BanUser(config *Config, guildID int64, channel *dstate.ChannelState, messag
 }
 
 func UnbanUser(config *Config, guildID int64, author *discordgo.User, reason string, user *discordgo.User) (bool, error) {
-	config, err := GetConfigIfNotSet(guildID, config)
+	config, err := BotCachedGetConfigIfNotSet(guildID, config)
 	if err != nil {
 		return false, common.ErrWithCaller(err)
 	}
@@ -374,7 +374,7 @@ func TimeoutUser(config *Config, guildID int64, channel *dstate.ChannelState, me
 }
 
 func RemoveTimeout(config *Config, guildID int64, author *discordgo.User, reason string, user *discordgo.User) error {
-	config, err := GetConfigIfNotSet(guildID, config)
+	config, err := BotCachedGetConfigIfNotSet(guildID, config)
 	if err != nil {
 		return common.ErrWithCaller(err)
 	}
@@ -415,7 +415,7 @@ const (
 // Unmut or mute a user, ignore duration if unmuting
 // TODO: i don't think we need to track mutes in its own database anymore now with the new scheduled event system
 func MuteUnmuteUser(config *Config, mute bool, guildID int64, channel *dstate.ChannelState, message *discordgo.Message, author *discordgo.User, reason string, member *dstate.MemberState, duration int) error {
-	config, err := GetConfigIfNotSet(guildID, config)
+	config, err := BotCachedGetConfigIfNotSet(guildID, config)
 	if err != nil {
 		return common.ErrWithCaller(err)
 	}
@@ -634,7 +634,7 @@ func WarnUser(config *Config, guildID int64, channel *dstate.ChannelState, msg *
 		channelID = channel.ID
 	}
 
-	config, err := GetConfigIfNotSet(guildID, config)
+	config, err := BotCachedGetConfigIfNotSet(guildID, config)
 	if err != nil {
 		return common.ErrWithCaller(err)
 	}


### PR DESCRIPTION
This PR is one of several aiming to mitigate the impact of bugs similar to those introduced in the previous release.

Another issue introduced (again, by me) in the previous release was that the web handlers for both the moderation and notifications packages called `GetCachedConfig` instead of `GetConfig`. `GetCachedConfig` is only meant to called in the bot process; using it in the web process caused the following cache invalidation issue:
1. `GetCachedConfig` in web process creates a config cache on the web process, separate from that maintained on the bot process.
2. When changes to the config are saved via the control panel, a pubsub event indicating that the config cache should be invalidated is fired.
3. However, only the bot process is configured to handle pubsub events, so only the cache on the bot process is invalidated. The cache inadvertently created on the web process, on the other hand, becomes stale and so changes do not reflect on the control panel.

To try to prevent this issue in future, we make the following (automated) renames:
- `GetCachedConfigOrDefault` becomes `BotCachedGetConfig`, following the convention in the `streaming` plugin. The prefix `BotCached` is more easily noticed and its presence in web code should raise a bigger alert during review.
- `GetConfig` becomes `FetchConfig` (again, trying to make it as different from the bot cached variant as possible) and is moved out of plugin_bot.go to config.go.

## Testing strategy

This change is (almost) completely done with automated renaming tools so there is little risk of a copy-paste mistake: the only manual input was moving `GetConfig` and `SaveConfig` from plugin_bot.go to config.go.

I also tested this change locally with the bot and web processes ran separately and verified that the moderation configuration saves properly on the control panel and that the changes reflect on the bot process (for instance, by disabling the `timeout` command on the control panel and then attempting to run the command in Discord.)