### PR TITLE
notifications: explicitly separate config functions that access bot process cache

### DIFF
--- a/notifications/config.go
+++ b/notifications/config.go
@@ -24,7 +24,7 @@ func SaveConfig(config *Config) error {
 	return nil
 }
 
-func GetConfigOrDefault(guildID int64) (*Config, error) {
+func FetchConfig(guildID int64) (*Config, error) {
 	conf, err := models.FindGeneralNotificationConfigG(context.Background(), guildID)
 	if err == nil {
 		return configFromModel(conf), nil

--- a/notifications/plugin_bot.go
+++ b/notifications/plugin_bot.go
@@ -1,8 +1,6 @@
 package notifications
 
 import (
-	"context"
-	"database/sql"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -17,9 +15,7 @@ import (
 	"github.com/botlabs-gg/yagpdb/v2/common/templates"
 	"github.com/botlabs-gg/yagpdb/v2/lib/discordgo"
 	"github.com/botlabs-gg/yagpdb/v2/lib/dstate"
-	"github.com/botlabs-gg/yagpdb/v2/notifications/models"
 	"github.com/karlseguin/ccache"
-	"github.com/volatiletech/sqlboiler/v4/boil"
 )
 
 var _ bot.BotInitHandler = (*Plugin)(nil)
@@ -33,15 +29,6 @@ func (p *Plugin) BotInit() {
 }
 
 var configCache = ccache.New(ccache.Configure().MaxSize(15000))
-
-func SaveConfig(config *Config) error {
-	err := config.ToModel().UpsertG(context.Background(), true, []string{"guild_id"}, boil.Infer(), boil.Infer())
-	if err != nil {
-		return err
-	}
-	pubsub.Publish("invalidate_notifications_config_cache", config.GuildID, nil)
-	return nil
-}
 
 func BotCachedGetConfig(guildID int64) (*Config, error) {
 	const cacheDuration = 10 * time.Minute
@@ -61,22 +48,6 @@ func handleInvalidateConfigCache(evt *pubsub.Event) {
 
 func cacheKey(guildID int64) string {
 	return discordgo.StrID(guildID)
-}
-
-func GetConfigOrDefault(guildID int64) (*Config, error) {
-	conf, err := models.FindGeneralNotificationConfigG(context.Background(), guildID)
-	if err == nil {
-		return configFromModel(conf), nil
-	}
-
-	if err == sql.ErrNoRows {
-		return &Config{
-			JoinServerMsgs: []string{"<@{{.User.ID}}> Joined!"},
-			LeaveMsgs:      []string{"**{{.User.Username}}** Left... :'("},
-		}, nil
-	}
-
-	return nil, err
 }
 
 func HandleGuildMemberAdd(evtData *eventsystem.EventData) (retry bool, err error) {

--- a/notifications/plugin_bot.go
+++ b/notifications/plugin_bot.go
@@ -34,7 +34,7 @@ func BotCachedGetConfig(guildID int64) (*Config, error) {
 	const cacheDuration = 10 * time.Minute
 
 	item, err := configCache.Fetch(cacheKey(guildID), cacheDuration, func() (interface{}, error) {
-		return GetConfigOrDefault(guildID)
+		return FetchConfig(guildID)
 	})
 	if err != nil {
 		return nil, err

--- a/notifications/plugin_bot.go
+++ b/notifications/plugin_bot.go
@@ -43,7 +43,7 @@ func SaveConfig(config *Config) error {
 	return nil
 }
 
-func GetCachedConfigOrDefault(guildID int64) (*Config, error) {
+func BotCachedGetConfig(guildID int64) (*Config, error) {
 	const cacheDuration = 10 * time.Minute
 
 	item, err := configCache.Fetch(cacheKey(guildID), cacheDuration, func() (interface{}, error) {
@@ -82,7 +82,7 @@ func GetConfigOrDefault(guildID int64) (*Config, error) {
 func HandleGuildMemberAdd(evtData *eventsystem.EventData) (retry bool, err error) {
 	evt := evtData.GuildMemberAdd()
 
-	config, err := GetCachedConfigOrDefault(evt.GuildID)
+	config, err := BotCachedGetConfig(evt.GuildID)
 	if err != nil {
 		return true, errors.WithStackIf(err)
 	}
@@ -144,7 +144,7 @@ func HandleGuildMemberAdd(evtData *eventsystem.EventData) (retry bool, err error
 func HandleGuildMemberRemove(evt *eventsystem.EventData) (retry bool, err error) {
 	memberRemove := evt.GuildMemberRemove()
 
-	config, err := GetCachedConfigOrDefault(memberRemove.GuildID)
+	config, err := BotCachedGetConfig(memberRemove.GuildID)
 	if err != nil {
 		return true, errors.WithStackIf(err)
 	}
@@ -286,7 +286,7 @@ func HandleChannelUpdate(evt *eventsystem.EventData) (retry bool, err error) {
 		return
 	}
 
-	config, err := GetCachedConfigOrDefault(cu.GuildID)
+	config, err := BotCachedGetConfig(cu.GuildID)
 	if err != nil {
 		return true, errors.WithStackIf(err)
 	}

--- a/notifications/plugin_web.go
+++ b/notifications/plugin_web.go
@@ -44,7 +44,7 @@ func HandleNotificationsGet(w http.ResponseWriter, r *http.Request) interface{} 
 	if ok {
 		templateData["NotifyConfig"] = formConfig
 	} else {
-		conf, err := GetConfigOrDefault(activeGuild.ID)
+		conf, err := FetchConfig(activeGuild.ID)
 		if err != nil {
 			web.CtxLogger(r.Context()).WithError(err).Error("failed retrieving config")
 		}
@@ -81,7 +81,7 @@ func (p *Plugin) LoadServerHomeWidget(w http.ResponseWriter, r *http.Request) (w
 	templateData["WidgetTitle"] = "General notifications"
 	templateData["SettingsPath"] = "/notifications/general"
 
-	config, err := GetConfigOrDefault(ag.ID)
+	config, err := FetchConfig(ag.ID)
 	if err != nil {
 		return templateData, err
 	}


### PR DESCRIPTION
This PR is a one-to-one mirror of #1696 for the notifcations package. Please read the description of that PR for details.