### PR TITLE
dstate: fully populate member struct

### DIFF
--- a/lib/dstate/interface.go
+++ b/lib/dstate/interface.go
@@ -381,6 +381,8 @@ func (ms *MemberState) DgoMember() *discordgo.Member {
 		Roles:                      ms.Member.Roles,
 		User:                       &ms.User,
 		Pending:                    ms.Member.Pending,
+		PremiumSince:               ms.Member.PremiumSince,
+		Flags:                      ms.Member.Flags,
 		CommunicationDisabledUntil: ms.Member.CommunicationDisabledUntil,
 	}
 


### PR DESCRIPTION
Please note that this patch is ~~entirely~~ partially untested on my part, 
because I lack a member boosting the server ~~and one with flags set.~~ I have
reasonably high confidence that this will work, but I cannot guarantee
it.

Fully populate the discordgo.Member struct in ms.DgoMember(); prior to
this change, this function did not set PremiumSince nor Flags, thereby
rendering these fields effectively useless in custom commands.

They are present everywhere else, and are documented in our custom
command documentation as available, so it appears as if these fields
have been left out by accident, rather than on purpose.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
