### PR TITLE
tickets: improve Missing Access error message

### DIFF
--- a/tickets/tickets_commands.go
+++ b/tickets/tickets_commands.go
@@ -223,7 +223,7 @@ func (p *Plugin) AddCommands() {
 			// create the logs, download the attachments
 			err := createLogs(parsed.GuildData.GS, conf, currentTicket.Ticket, isAdminsOnly)
 			if err != nil {
-				return nil, err
+				return "Cannot send transcript to ticket logs channel, refusing to close ticket.", err
 			}
 
 			TicketLog(conf, parsed.GuildData.GS.ID, parsed.Author, &discordgo.MessageEmbed{


### PR DESCRIPTION
Improve the "Missing Access" error message when trying to send a
ticket's transcript and/or images to the ticket logs channel.

Currently, the bot simply responds with a quite generic "Missing Access"
error, which, whilst technically correct, isn't exactly helpful.
Therefore, send a proper error instead that explains what went wrong and
that we're refusing to close the ticket for exactly that reason.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
