### PR TITLE
templates: implement Del method for slices

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -111,9 +111,9 @@ var (
 		"roleAbove":   roleIsAbove,
 		"seq":         sequence,
 
-		"shuffle": shuffle,
-		"verb":    common.RandomVerb,
-		"hash":    tmplSha256,
+		"shuffle":      shuffle,
+		"verb":         common.RandomVerb,
+		"hash":         tmplSha256,
 		"decodeBase64": tmplDecodeBase64,
 		"encodeBase64": tmplEncodeBase64,
 
@@ -955,6 +955,16 @@ func (s Slice) Append(item interface{}) (interface{}, error) {
 		result := reflect.Append(reflect.ValueOf(&s).Elem(), reflect.ValueOf(v))
 		return result.Interface(), nil
 	}
+}
+
+func (s Slice) Del(index int) (interface{}, error) {
+	if index >= len(s) {
+		return nil, errors.New("Index out of bounds.")
+	}
+
+	result := reflect.ValueOf(&s).Elem()
+	result = reflect.AppendSlice(result.Slice(0, index), result.Slice(index+1, result.Len()))
+	return result.Interface(), nil
 }
 
 func (s Slice) Set(index int, item interface{}) (string, error) {


### PR DESCRIPTION
Implement a Del method for custom command slices; to be consistent with
the other methods, this also returns a new slice. The usage is as
follows:

```
{{ (cslice 1 2 3 4 5).Del 2 }}
{{/* returns [1 2 4 5] */}}
```

See the following suggestion on the support server:
https://canary.discord.com/channels/166207328570441728/356486960417734666/764864357917392906

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

----
This is my first time working with the `reflect` package—I figured this
is the way to go, given how the other methods also use `reflect`. Please
let me know if I did something wrong or if there is a better way to do
this.
