### PR TITLE
make tmplGetChannel return threads too

### DIFF
--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -938,7 +938,7 @@ func (c *Context) tmplGetChannel(channel interface{}) (*CtxChannel, error) {
 		return nil, nil // dont send an error , a nil output would indicate invalid/unknown channel
 	}
 
-	cstate := c.GS.GetChannel(cID)
+	cstate := c.GS.GetChannelOrThread(cID)
 
 	if cstate == nil {
 		return nil, errors.New("channel not in state")


### PR DESCRIPTION
QOL improvement, otherwise you need to do a stupid check to see if the the channel was a thread or not, this can get difficult if things need to be done in a non-triggering channel or the channel-id is coming from db. 