### PR TITLE
web: optimize offline shard checker

### DIFF
--- a/frontend/templates/cp_main.html
+++ b/frontend/templates/cp_main.html
@@ -169,19 +169,19 @@ $(function(){
 
     {{if .ActiveGuild}}
         async function runShardOfflineChecker() {
-            let wasOffline = await checkShardOffline();
+            let wasOnline = await checkGuildShardOnline();
             let shardCheckerRunning = sessionStorage.getItem('isShardOfflineCheckerRunning');
             if (shardCheckerRunning === 'true') {
               return;
             }
             sessionStorage.setItem('isShardOfflineCheckerRunning', 'true');
             setInterval(async () => {
-                const currentlyOffline = await checkShardOffline();
+                const currentlyOnline = await checkGuildShardOnline();
 
                 // To prevent spurious warnings during routine shard reconnections,
                 // only show an alert if a shard appears to be offline for two
                 // checks in a row.
-                if (wasOffline && currentlyOffline) {
+                if (!wasOnline && !currentlyOnline) {
                     upsertAlert(
                         "The shard the bot is on for your server is currently offline; some functionality may not work as expected. \
                         Join the support server for more information if this issue persists."
@@ -190,14 +190,13 @@ $(function(){
                     $("#shard-problems-warning").remove();
                 }
 
-                wasOffline = currentlyOffline;
+                wasOnline = currentlyOnline;
             }, 15_000);
         }
 
-        async function checkShardOffline() {
-            const data = await fetch("/status.json").then((resp) => resp.json());
-            const shardId = Number(BigInt("{{.ActiveGuild.ID}}") >> BigInt(22)) % data.total_shards;
-            return data.offline_shards && data.offline_shards.includes(shardId);
+        async function checkGuildShardOnline() {
+            const status = await fetch("/api/{{.ActiveGuild.ID}}/status.json").then((resp) => resp.json());
+            return status.shard_online;
         }
 
         function upsertAlert(msg) {
@@ -208,8 +207,7 @@ $(function(){
             }
         }
 
-        // Computing the shard number requires BigInt support.
-        if (typeof BigInt !== "undefined") runShardOfflineChecker();
+        runShardOfflineChecker();
     {{end}}
 })
 </script>

--- a/frontend/templates/cp_main.html
+++ b/frontend/templates/cp_main.html
@@ -168,14 +168,13 @@ $(function(){
     });
 
     {{if .ActiveGuild}}
-        async function runShardOfflineChecker() {
-            let wasOnline = await checkGuildShardOnline();
-            let shardCheckerRunning = sessionStorage.getItem('isShardOfflineCheckerRunning');
-            if (shardCheckerRunning === 'true') {
-              return;
+        async function startShardOfflineChecker() {
+            if (typeof window.offlineShardCheckerInterval !== 'undefined') {
+                clearInterval(window.offlineShardCheckerInterval);
             }
-            sessionStorage.setItem('isShardOfflineCheckerRunning', 'true');
-            setInterval(async () => {
+
+            let wasOnline = await checkGuildShardOnline();
+            window.offlineShardCheckerInterval = setInterval(async () => {
                 const currentlyOnline = await checkGuildShardOnline();
 
                 // To prevent spurious warnings during routine shard reconnections,
@@ -207,7 +206,7 @@ $(function(){
             }
         }
 
-        runShardOfflineChecker();
+        startShardOfflineChecker();
     {{end}}
 })
 </script>

--- a/web/handlers_general.go
+++ b/web/handlers_general.go
@@ -289,6 +289,23 @@ func HandleStatusJSON(w http.ResponseWriter, r *http.Request) interface{} {
 	return status
 }
 
+type GuildStatus struct {
+	ShardOnline bool `json:"shard_online"`
+}
+
+// HandleGuildStatusJSON handles GET /api/:server/status.json
+func HandleGuildStatusJSON(w http.ResponseWriter, r *http.Request) interface{} {
+	g := r.Context().Value(common.ContextKeyCurrentGuild).(*dstate.GuildSet)
+	status, err := getFullBotStatus()
+	if err != nil {
+		return err
+	}
+
+	shard := int(g.ID>>22) % status.TotalShards
+	isOffline := common.ContainsIntSlice(status.OfflineShards, shard)
+	return GuildStatus{ShardOnline: !isOffline}
+}
+
 type HostStatus struct {
 	Name string
 

--- a/web/web.go
+++ b/web/web.go
@@ -293,6 +293,7 @@ func setupRoutes() *goji.Mux {
 	RootMux.Handle(pat.Get("/api/:server/*"), ServerPublicAPIMux)
 
 	ServerPublicAPIMux.Handle(pat.Get("/channelperms/:channel"), RequireActiveServer(APIHandler(HandleChannelPermissions)))
+	ServerPublicAPIMux.Handle(pat.Get("/status.json"), RequireActiveServer(APIHandler(HandleGuildStatusJSON)))
 
 	// Server selection has its own handler
 	RootMux.Handle(pat.Get("/manage"), SelectServerHomePageHandler)


### PR DESCRIPTION
Review commit-by-commit.

This PR makes the following changes:
1. Add and use a per-guild status endpoint, `/api/:server/status.json`, that returns `{"shard_online": true/false}`. Switching to this endpoint decreases the data sent over the network from ~400 kB to ~20 B (a 10000x reduction.)
2. Introduce a more robust fix to the 'spawning one interval per page' issue, superceding https://github.com/botlabs-gg/yagpdb/commit/b9dabf9eba7d45c1189b695c55076f3f9669c022. The problem with https://github.com/botlabs-gg/yagpdb/commit/b9dabf9eba7d45c1189b695c55076f3f9669c022 is that it uses `sessionStorage`, which is not cleared on refresh. But this is overkill: we actually *need* the offline shard checker to run upon refresh, since the old intervals are cancelled on refresh. To see the issue, open the control panel, refresh, and then use devtools to verify that the queries to `/status.json` completely stop after applying https://github.com/botlabs-gg/yagpdb/commit/b9dabf9eba7d45c1189b695c55076f3f9669c022. That is, after a refresh, the offline shard checker *never* runs until one switches to a new tab—the warning is broken.

     To fix this, we instead store the timer ID returned by `setinterval` on the `window` object. If there is an existing interval, cancel it before starting the new one (the idea here is similar in spirit to https://github.com/botlabs-gg/yagpdb/commit/f19ccaa0b57cf43e9ec27b1a4d5e1dcdc34a3115, which fixed a similar issue.) This ensures that one and only one checker is running at a given time (whereas the previous fix meant that sometimes the checker never runs at all.) Of course, though I checked that this still fixes the original issue myself via FF devtools, some additional testing is appreciated.