### PR TITLE
customcommands: align frontend length display with backend validation

### DIFF
--- a/customcommands/assets/customcommands-editcmd.html
+++ b/customcommands/assets/customcommands-editcmd.html
@@ -731,17 +731,25 @@
 
     function updateCCLength() {
         const textAreas = document.querySelectorAll('#cc-responses > textarea');
-        const totalLength = Array.from(textAreas).reduce((len, el) => {
+        const totalLength = Array.from(textAreas).reduce((acc, el) => {
+            let len = countCodePoints(el.value);
             // The data received on the backend contains "\r\n" while it is simply "\n" on the JS side.
             // Adjust for this discrepancy by double-counting newline characters.
             const newlines = el.value.match(/\n/g);
-            return len + el.value.length + (newlines ? newlines.length : 0);
+            if (newlines) len += newlines.length;
+
+            return acc + len;
         }, 0);
 
         $('.cc-length-counter')
             .text(totalLength)
             .toggleClass('text-danger', totalLength > {{.MaxCCLength}});
     }
+
+    function countCodePoints(str) {
+        return [...str].length;
+    }
+
     function onCCChanged(textArea) {
        updateCCLength();
     }

--- a/customcommands/assets/customcommands-public.html
+++ b/customcommands/assets/customcommands-public.html
@@ -324,11 +324,13 @@
     var textAreas = document.querySelectorAll("#cc-responses > textarea")
     var combinedLength = 0;
     textAreas.forEach(function (elem) {
-      combinedLength += elem.value.length;
+      let len = countCodePoints(elem.value);
       // The data received on the backend contains "\r\n" while it is simply "\n" on the JS side.
       // Adjust for this discrepancy by double-counting newline characters.
       const newlines = elem.value.match(/\n/g);
-      if (newlines) combinedLength += newlines.length;
+      if (newlines) len += newlines.length;
+
+      combinedLength += len;
     })
 
     var display = document.querySelector(".cc-length-counter")
@@ -340,6 +342,11 @@
       premiumOnlyImport.classList.add("text-danger");
     }
   }
+
+  function countCodePoints(str) {
+    return [...str].length;
+  }
+
   function isTextTrigger(t) {
     return t === "cmd" ||
       t === "prefix" ||


### PR DESCRIPTION
The backend validation for custom command response length checks the number of runes (that is, Unicode code points) in the input:
https://github.com/botlabs-gg/yagpdb/blob/b9dabf9eba7d45c1189b695c55076f3f9669c022/customcommands/customcommands.go#L157

However, the frontend character counter reads the `length` field of the response JavaScript String, which measures UTF-16 code units. The number of Unicode code points is not necessarily equal to the number of UTF-16 code units, occasionally producing a confusing discrepancy between frontend and backend. To demonstrate the issue, create a new custom command and run the following in console:
```js
$('.cc-editor').val('😨'.repeat(5001)); // 😨 is encoded as 2 UTF-16 code units but is one code point
onCCChanged(); 
```
The character counter displays `10002/10000` (seemingly over the limit!) but this custom command can still be saved without error, since the backend validation only sees 5001 runes.

Fix this discrepancy by counting Unicode code points in the frontend as well. 