### PR TITLE
cc: implement new DiagnoseCCTriggers command

### DIFF
--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -285,7 +285,7 @@ var cmdListCommands = &commands.YAGCommand{
 		}
 
 		if hasRead, _ := web.GetUserAccessLevel(data.Author.ID, gWithConnected, common.GetCoreServerConfCached(data.GuildData.GS.ID), web.StaticRoleProvider(roles)); hasRead {
-			ccIDMaybeWithLink = fmt.Sprintf("[%[1]d](%[2]s/customcommands/commands/%[1]d/)", cc.LocalID, web.ManageServerURL(data.GuildData))
+			ccIDMaybeWithLink = fmt.Sprintf("[%d](%s)", cc.LocalID, cmdControlPanelLink(cc))
 		}
 
 		// Every message content-based custom command trigger has a numerical value less than 5
@@ -338,6 +338,10 @@ var cmdListCommands = &commands.YAGCommand{
 		}
 		return msg, nil
 	},
+}
+
+func cmdControlPanelLink(cmd *models.CustomCommand) string {
+	return fmt.Sprintf("%s/customcommands/commands/%d/", web.ManageServerURL(cmd.GuildID), cmd.LocalID)
 }
 
 func FindCommands(ccs []*models.CustomCommand, data *dcmd.Data) (foundCCS []*models.CustomCommand, provided bool) {

--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -59,7 +59,7 @@ func MBaseCmdSecond(cmdData *dcmd.Data, reason string, reasonArgOptional bool, n
 	cmdName := cmdData.Cmd.Trigger.Names[0]
 	oreason = reason
 	if !enabled {
-		return oreason, commands.NewUserErrorf("The **%s** command is disabled on this server. It can be enabled at <%s/moderation>", cmdName, web.ManageServerURL(cmdData.GuildData))
+		return oreason, commands.NewUserErrorf("The **%s** command is disabled on this server. It can be enabled at <%s/moderation>", cmdName, web.ManageServerURL(cmdData.GuildData.GS.ID))
 	}
 
 	if strings.TrimSpace(reason) == "" {
@@ -341,7 +341,7 @@ var ModerationCommands = []*commands.YAGCommand{
 			}
 
 			if config.MuteRole == 0 {
-				return fmt.Sprintf("No mute role selected. Select one at <%s/moderation>", web.ManageServerURL(parsed.GuildData)), nil
+				return fmt.Sprintf("No mute role selected. Select one at <%s/moderation>", web.ManageServerURL(parsed.GuildData.GS.ID)), nil
 			}
 
 			reason := parsed.Args[2].Str()

--- a/reputation/plugin_bot.go
+++ b/reputation/plugin_bot.go
@@ -35,8 +35,8 @@ func (p *Plugin) BotInit() {
 
 var thanksRegex = regexp.MustCompile(`(?i)( |\n|^)(thanks?\pP*|danks|ty|thx|\+rep|\+ ?\<\@[0-9]*\>)( |\n|$)`)
 
-func createRepDisabledError(guild *dcmd.GuildContextData) string {
-	return fmt.Sprintf("**The reputation system is disabled for this server.** Enable it at: <%s/reputation>.", web.ManageServerURL(guild))
+func createRepDisabledError(g *dcmd.GuildContextData) string {
+	return fmt.Sprintf("**The reputation system is disabled for this server.** Enable it at: <%s/reputation>.", web.ManageServerURL(g.GS.ID))
 }
 
 func handleMessageCreate(evt *eventsystem.EventData) {

--- a/rolecommands/menu.go
+++ b/rolecommands/menu.go
@@ -58,7 +58,7 @@ func roleGroupAutocomplete(parsed *dcmd.Data, arg *dcmd.ParsedArg) ([]*discordgo
 
 func cmdFuncRoleMenuCreate(parsed *dcmd.Data) (interface{}, error) {
 	name := parsed.Args[0].Str()
-	panelURL := fmt.Sprintf("%s/rolecommands/", web.ManageServerURL(parsed.GuildData))
+	panelURL := fmt.Sprintf("%s/rolecommands/", web.ManageServerURL(parsed.GuildData.GS.ID))
 	group, err := models.RoleGroups(qm.Where("guild_id=?", parsed.GuildData.GS.ID), qm.Where("name ILIKE ?", name), qm.Load("RoleCommands")).OneG(parsed.Context())
 	if err != nil {
 		if errors.Cause(err) == sql.ErrNoRows {

--- a/tickets/tickets_commands.go
+++ b/tickets/tickets_commands.go
@@ -28,8 +28,8 @@ const InTicketPerms = discordgo.PermissionReadMessageHistory | discordgo.Permiss
 
 var _ commands.CommandProvider = (*Plugin)(nil)
 
-func createTicketsDisabledError(guild *dcmd.GuildContextData) string {
-	return fmt.Sprintf("**The tickets system is disabled for this server.** Enable it at: <%s/tickets/settings>.", web.ManageServerURL(guild))
+func createTicketsDisabledError(g *dcmd.GuildContextData) string {
+	return fmt.Sprintf("**The tickets system is disabled for this server.** Enable it at: <%s/tickets/settings>.", web.ManageServerURL(g.GS.ID))
 }
 
 func (p *Plugin) AddCommands() {

--- a/web/web.go
+++ b/web/web.go
@@ -17,7 +17,6 @@ import (
 	"github.com/botlabs-gg/yagpdb/v2/common/patreon"
 	yagtmpl "github.com/botlabs-gg/yagpdb/v2/common/templates"
 	"github.com/botlabs-gg/yagpdb/v2/frontend"
-	"github.com/botlabs-gg/yagpdb/v2/lib/dcmd"
 	"github.com/botlabs-gg/yagpdb/v2/lib/discordgo"
 	"github.com/botlabs-gg/yagpdb/v2/web/discordblog"
 	"github.com/natefinch/lumberjack"
@@ -134,8 +133,8 @@ func BaseURL() string {
 	return "http://" + common.ConfHost.GetString()
 }
 
-func ManageServerURL(guild *dcmd.GuildContextData) string {
-	return fmt.Sprintf("%s/manage/%d", BaseURL(), guild.GS.ID)
+func ManageServerURL(guildID int64) string {
+	return fmt.Sprintf("%s/manage/%d", BaseURL(), guildID)
 }
 
 func Run() {


### PR DESCRIPTION
Review commit-by-commit.

Add a new debug command, `DiagnoseCCTriggers`, that lists all custom commands triggering on its input and identifies potential issues. The intent is for support members to instruct users to run `DiagnoseCCTriggers` in the event of custom commands not triggering as the user expects; we can also consider adding a note in the documentation and/or control panel pointing to this command where appropriate.

Sample output:
![output from running the DiagnoseCCTriggers command](https://github.com/user-attachments/assets/56952190-699e-4e70-99a3-280d77f80d45)

To implement `DiagnoseCCTriggers`, some light refactoring to enable code reuse was necessary (see first 3 commits.)

In the server, Henri proposed that, instead of a command, a control panel warning could be generated when there are conflicting triggers. Though such a warning would definitely be more discoverable, it is difficult to implement--requiring significantly more code than this PR--and near-impossible to make as robust as a command, so it would not catch all cases.) So we stick with the command here.