### PR TITLE
cc: do not show unsaved popup on database page

### DIFF
--- a/customcommands/assets/customcommands-database.html
+++ b/customcommands/assets/customcommands-database.html
@@ -33,7 +33,7 @@
                 <p>
                     <strong>Warning:</strong> Deleting a database entry is permanent and cannot be undone.
                 </p>
-                <form>
+                <form class="no-unsaved-popup">
                     <div class="form-row">
                         <div class="form-group col">
                             <label>Search By</label>

--- a/frontend/static/js/spongebob.js
+++ b/frontend/static/js/spongebob.js
@@ -600,6 +600,7 @@ function serializeForm(form) {
 function yagInitUnsavedForms(selectorPrefix) {
 	let unsavedForms = $(selectorPrefix + "form")
 	unsavedForms.each(function (i, rawElem) {
+		if (rawElem.classList.contains("no-unsaved-popup")) return;
 		trackForm(rawElem);
 	});
 }


### PR DESCRIPTION
Currently, if you change any of the search parameters on the custom command database page, the unsaved changes popup shows up (and clicking save confusingly redirects you to the home page.) The reason, of course, is that--unlike many other forms on the control panel--the search form is not meant to be POSTed to. Hide the unsaved popup for the search form to avoid any confusion.