### PR TITLE
web: simple fixes and enhancements to cc and yt

### DIFF
--- a/customcommands/assets/customcommands-public.html
+++ b/customcommands/assets/customcommands-public.html
@@ -79,6 +79,15 @@
                           <p id="trigger-desc-reaction">
                             The command will trigger on the specified reaction events.
                           </p>
+                          {{else if eq .CC.TriggerType 7}}
+                          <p id="trigger-desc-component">
+                              The command will run when a component (a button or a select menu) whose
+                              custom ID matches the given regex is used. BETA FEATURE.
+                          </p>
+                          {{else if eq .CC.TriggerType 8}}
+                          <p id="trigger-desc-modal">
+                              The command will run when a modal whose custom ID matches the given regex is submitted. BETA FEATURE.
+                          </p>
                           {{end}}
                         </div>
                       </div>
@@ -86,12 +95,16 @@
                   </div>
                 </div>
               </div>
-              {{if eq .CC.TriggerType 0 1 2 3 4}}
+              {{if eq .CC.TriggerType 0 1 2 3 4 7 8}}
               <div id="cc-text-trigger-details" class="col-lg-8">
                 <div class="row">
                   <div class="col-lg-12">
                     <div class="form-group">
-                      <label>Trigger (<span id="trigger-length">{{len .CC.TextTrigger}}</span>/1000)</label>
+                      {{if eq .CC.TriggerType 0 1 2 3 4}}
+                      <label id="cc-message-trigger-label">Trigger (<span id="trigger-length">{{len .CC.TextTrigger}}</span>/1000)</label>
+                      {{else}}
+                      <label id="cc-customid-trigger-label">Component Custom ID Regex (<span id="trigger-length">{{len .CC.TextTrigger}}</span>/1000)</label>
+                      {{end}}
                       <div class="input-group mb-2">
                         <div class="input-group-prepend" id="command-trigger-prepended-prefix">
                           <div class="input-group-text">{{.CommandPrefix}}</div>

--- a/customcommands/assets/customcommands-public.html
+++ b/customcommands/assets/customcommands-public.html
@@ -19,7 +19,7 @@
             <li class="text-danger" hidden id="trigger-warning"></li>
           </ul>
           {{$dot := .}}
-          <form id="main-form" class="form-horizontal">
+          <form id="main-form" class="form-horizontal no-unsaved-popup">
             <h2 class="card-title">
               {{index .CCTriggerTypes .CC.TriggerType}}{{if and (ne .CC.TriggerType 5) (ne .CC.TriggerType 6)}}:
               <span class="cc-text-trigger-span">{{.CC.TextTrigger}}</span>{{else if ne .CC.TriggerType 6}}:

--- a/youtube/assets/youtube.html
+++ b/youtube/assets/youtube.html
@@ -69,13 +69,19 @@
                             {{textChannelOptions .ActiveGuild.Channels nil false ""}}
                         </select>
                     </div>
-                    {{checkbox "MentionEveryone" "new-mention-everyone" `Mention Everyone` false}}
-                    <div class="form-group">
-                       <div>
-                        <select id="roles" class="multiselect form-control" multiple="multiple" name="MentionRoles" data-plugin-multiselect>
-                            {{roleOptionsMulti .ActiveGuild.Roles nil nil}}
-                        </select>
-                        <label for="roles">Mention Roles</label>
+                    <div class="custom-announcement-disables">
+                        <span class="custom-announcement-popover">
+                            {{checkbox "MentionEveryone" "new-mention-everyone" `Mention Everyone` false}}
+                        </span>
+                    </div>
+                    <div class="form-group custom-announcement-disables">
+                        <div>
+                            <span class="custom-announcement-popover">
+                            <select id="roles" class="multiselect form-control" multiple="multiple" name="MentionRoles" data-plugin-multiselect>
+                                {{roleOptionsMulti .ActiveGuild.Roles nil nil}}
+                            </select>
+                            <label for="roles">Mention Roles</label>
+                            </span>
                         </div>
                     </div>
                     {{checkbox "PublishLivestream" "new-publish-livestream" `Publish Livestreams` true}}
@@ -157,14 +163,18 @@
                                 {{textChannelOptions $dot.ActiveGuild.Channels .ChannelID false ""}}
                             </select>
                         </td>
-                        <td class="yt-tbl-column">
+                        <td class="yt-tbl-column custom-announcement-disables">
+                            <span class="custom-announcement-popover">
                             {{checkbox "MentionEveryone" (joinStr "" "mention-everyone-" .ID) `Mention everyone` .MentionEveryone (joinStr "" `form="sub-item-` .ID `"`)}}
+                            </span>
                         </td>
-                        <td class="yt-tbl-column">
-                              <select form="sub-item-{{.ID}}" name="MentionRoles" class="multiselect form-control" multiple="multiple"
-                                id="mention-roles" data-plugin-multiselect>
-                                {{roleOptionsMulti $dot.ActiveGuild.Roles nil .MentionRoles }}
+                        <td class="yt-tbl-column custom-announcement-disables">
+                            <span class="custom-announcement-popover">
+                            <select form="sub-item-{{.ID}}" name="MentionRoles" class="multiselect form-control" multiple="multiple"
+                              id="mention-roles" data-plugin-multiselect>
+                              {{roleOptionsMulti $dot.ActiveGuild.Roles nil .MentionRoles }}
                             </select>
+                            </span>
                         </td>
                         <td class="yt-tbl-column">
                             {{checkbox "PublishLivestream" (joinStr "" "publish-livestream-" .ID) `Publish Livestreams` .PublishLivestream (joinStr "" `form="sub-item-` .ID `"`)}}
@@ -229,5 +239,50 @@
             saveButton.classList.remove("btn-disabled")
         }
     }
+
+    function enablePopovers() {
+        var popoverEls = document.body.getElementsByClassName("custom-announcement-popover");
+        for (var i = 0; i < popoverEls.length; i++) {
+            popoverEls[i].classList.add("popover-trigger");
+            popoverEls[i].setAttribute("data-toggle", "popover");
+            popoverEls[i].setAttribute("data-placement", "top");
+            popoverEls[i].setAttribute("data-content", "Disabled when \"Custom Announcement\" is enabled.");
+            popoverEls[i].setAttribute("data-trigger", "hover");
+        };
+    }
+
+    function disablePopovers() {
+        var popoverEls = document.body.getElementsByClassName("custom-announcement-popover");
+        for (var i = 0; i < popoverEls.length; i++) {
+            popoverEls[i].classList.remove("popover-trigger");
+            popoverEls[i].removeAttribute("data-toggle");
+            popoverEls[i].removeAttribute("data-placement");
+            popoverEls[i].removeAttribute("data-content");
+            popoverEls[i].removeAttribute("data-trigger");
+        };
+    }
+    
+    // Disables inputs and enable popovers
+    function DisableMentions() {
+        var disable = $('#yt-announcement-enabled:checked').val();
+            if (disable) {
+                enablePopovers();
+            } else {
+                disablePopovers();
+            }
+        var inputs = document.body.getElementsByClassName("custom-announcement-disables");
+        for (var i = 0; i < inputs.length; i++) {
+            if (disable) {
+                $(inputs[i]).find(":input").prop("disabled", true);
+            } else {
+                $(inputs[i]).find(":input").prop("disabled", false);
+            }
+        }
+    }
+
+    DisableMentions();
+
+    var announcementCheckbox = document.getElementById('yt-announcement-enabled');
+    announcementCheckbox.addEventListener('change', (event) => { DisableMentions(); });
 </script>
 {{template "cp_footer" .}} {{end}}


### PR DESCRIPTION
### YouTube Custom Announcements
Custom announcements override mention everyone and mention roles. To
prevent confusion, this disables these config options when custom
announcement is enabled, and adds a popover explaining why.

<img width="354" alt="Screenshot 2024-08-27 at 02 09 25" src="https://github.com/user-attachments/assets/71c15762-4519-4945-9e3a-955ea610f736">

Known issue:
Popovers can't seem to be enabled and disabled, despite rendering and working as intended. When I try to use `$(popovers[i]).popover('disable')` (or enable) i get `.popovers is not defined`. Current workaround is removing and re-adding all the attributes whenever the toggle is switched on or off, but this doesn't take effect until after a save. Working theory is that this could be solved with a jQuery version bump.

### CC Import Page
- Implements PR #1716 to block unsaved changes popup on public page,
which when clicked leads to a no access error. Dependant on said PR
being merged successfully.
- Fix the import webpage to display component and modal trigger details
and trigger description.

Signed-off-by: SoggySaussages <vmdmaharaj@gmail.com>