### PR TITLE
cc/interactions: add support for deleting responses and followups

### DIFF
--- a/automod/effects.go
+++ b/automod/effects.go
@@ -865,7 +865,7 @@ func (send *SendChannelMessageEffect) Apply(ctxData *TriggeredRuleData, settings
 		return err
 	}
 	if settingsCast.Duration > 0 && message != nil {
-		templates.MaybeScheduledDeleteMessage(ctxData.GS.ID, logChannel, message.ID, settingsCast.Duration)
+		templates.MaybeScheduledDeleteMessage(ctxData.GS.ID, logChannel, message.ID, settingsCast.Duration, "")
 	}
 	return nil
 }

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -792,7 +792,7 @@ func (c *Context) tmplDelMessage(channel, msgID interface{}, args ...interface{}
 		dur = 86400
 	}
 
-	MaybeScheduledDeleteMessage(c.GS.ID, cID, mID, dur)
+	MaybeScheduledDeleteMessage(c.GS.ID, cID, mID, dur, "")
 
 	return ""
 }

--- a/common/templates/context_interactions.go
+++ b/common/templates/context_interactions.go
@@ -13,7 +13,7 @@ import (
 )
 
 func interactionContextFuncs(c *Context) {
-	c.addContextFunc("deleteResponse", c.tmplDeleteInteractionResponse)
+	c.addContextFunc("deleteInteractionResponse", c.tmplDeleteInteractionResponse)
 	c.addContextFunc("editResponse", c.tmplEditInteractionResponse(true))
 	c.addContextFunc("editResponseNoEscape", c.tmplEditInteractionResponse(false))
 	c.addContextFunc("ephemeralResponse", c.tmplEphemeralResponse)

--- a/common/templates/context_interactions.go
+++ b/common/templates/context_interactions.go
@@ -466,30 +466,28 @@ func validateActionRowsCustomIDs(rows *[]discordgo.MessageComponent) error {
 	return nil
 }
 
-func (c *Context) tmplDeleteInteractionResponse() func(interactionToken, msgID interface{}, delaySeconds ...interface{}) (interface{}, error) {
-	return func(interactionToken, msgID interface{}, delaySeconds ...interface{}) (interface{}, error) {
-		if c.IncreaseCheckGenericAPICall() {
-			return "", ErrTooManyAPICalls
-		}
-
-		_, token := c.tokenArg(interactionToken)
-		if token == "" {
-			return "", errors.New("invalid interaction token")
-		}
-
-		dur := 10
-		if len(delaySeconds) > 0 {
-			dur = int(ToInt64(delaySeconds[0]))
-		}
-
-		// MaybeScheduledDeleteMessage limits delete delays for interaction
-		// responses/followups to 10 seconds, so no need to do it here too
-
-		// guild/channel IDs irrelevant when deleting responses or followups
-		MaybeScheduledDeleteMessage(0, 0, ToInt64(msgID), dur, token)
-
-		return "", nil
+func (c *Context) tmplDeleteInteractionResponse(interactionToken, msgID interface{}, delaySeconds ...interface{}) (interface{}, error) {
+	if c.IncreaseCheckGenericAPICall() {
+		return "", ErrTooManyAPICalls
 	}
+
+	_, token := c.tokenArg(interactionToken)
+	if token == "" {
+		return "", errors.New("invalid interaction token")
+	}
+
+	dur := 10
+	if len(delaySeconds) > 0 {
+		dur = int(ToInt64(delaySeconds[0]))
+	}
+
+	// MaybeScheduledDeleteMessage limits delete delays for interaction
+	// responses/followups to 10 seconds, so no need to do it here too
+
+	// guild/channel IDs irrelevant when deleting responses or followups
+	MaybeScheduledDeleteMessage(0, 0, ToInt64(msgID), dur, token)
+
+	return "", nil
 }
 
 func (c *Context) tmplEditInteractionResponse(filterSpecialMentions bool) func(interactionToken, msgID, msg interface{}) (interface{}, error) {

--- a/notifications/plugin_bot.go
+++ b/notifications/plugin_bot.go
@@ -204,7 +204,7 @@ func sendTemplate(gs *dstate.GuildSet, cs *dstate.ChannelState, tmpl string, ms 
 		if len(ctx.CurrentFrame.AddResponseReactionNames) > 0 || ctx.CurrentFrame.DelResponse || ctx.CurrentFrame.PublishResponse {
 			m, err = common.BotSession.ChannelMessageSendComplex(cs.ID, ctx.MessageSend(msg))
 			if err == nil && ctx.CurrentFrame.DelResponse {
-				templates.MaybeScheduledDeleteMessage(gs.ID, cs.ID, m.ID, ctx.CurrentFrame.DelResponseDelay)
+				templates.MaybeScheduledDeleteMessage(gs.ID, cs.ID, m.ID, ctx.CurrentFrame.DelResponseDelay, "")
 			}
 		} else {
 			send := ctx.MessageSend("")

--- a/streaming/bot.go
+++ b/streaming/bot.go
@@ -454,7 +454,7 @@ func SendStreamingAnnouncement(config *Config, guild *dstate.GuildSet, ms *dstat
 		return
 	}
 	if ctx.CurrentFrame.DelResponse {
-		templates.MaybeScheduledDeleteMessage(guild.ID, config.AnnounceChannel, m.ID, ctx.CurrentFrame.DelResponseDelay)
+		templates.MaybeScheduledDeleteMessage(guild.ID, config.AnnounceChannel, m.ID, ctx.CurrentFrame.DelResponseDelay, "")
 	}
 
 	if ctx.CurrentFrame.PublishResponse {


### PR DESCRIPTION
Previously there was no support for deleting responses or followups
since `deleteMessage` was sufficient for all available use cases. Since
then Discord has added support for deletion of ephemeral messages which
may only be deleted by directly deleting the response or followup. This
PR adds that functionality.

Add a context func to delete interaction responses or followups.
Necessary for deletion of ephemeral messages.

| **Function**                                         | **Description**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
|------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `deleteResponse` interactionToken messageID (delay)  | Deletes one of the bot’s responses to an interaction. `interactionToken` must be a valid token or `nil` to target the triggering interaction. `messageID` must be a valid message ID of a followup message, or `nil` to target the original interaction response. `delay` is optional and defaults to 10 seconds, which is also the maximum delay this function supports. For longer delays, consider using `execCC` if you are trying to delete an ephemeral response, or `deleteMessage` if you are trying to delete a regular response. |

Signed-off-by: SoggySaussages <vmdmaharaj@gmail.com>