### PR TITLE
Fully qualify image references to docker.io

### DIFF
--- a/yagpdb_docker/Dockerfile
+++ b/yagpdb_docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.1 AS builder
+FROM docker.io/golang:1.23.1 AS builder
 
 WORKDIR /appbuild/yagpdb
 COPY go.mod go.sum ./
@@ -11,7 +11,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -v -ldflags "-X github.com/botlabs-gg/yagp
 
 
 
-FROM alpine:latest
+FROM docker.io/alpine:latest
 
 WORKDIR /app
 VOLUME ["/app/soundboard", "/app/cert"]

--- a/yagpdb_docker/Dockerfile.debug
+++ b/yagpdb_docker/Dockerfile.debug
@@ -1,4 +1,4 @@
-FROM golang:1.23.1-alpine
+FROM docker.io/golang:1.23.1-alpine
 # Dependencies: ca-certificates for client TLS, tzdata for timezone and ffmpeg for soundboard support
 RUN apk --no-cache add ca-certificates ffmpeg tzdata
 RUN CGO_ENABLED=0 go install -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv@latest

--- a/yagpdb_docker/docker-compose.debug.yml
+++ b/yagpdb_docker/docker-compose.debug.yml
@@ -34,7 +34,7 @@ services:
       - "seccomp:unconfined"
 
   redis:
-    image: redis
+    image: docker.io/redis
     restart: unless-stopped
     networks:
       - default
@@ -42,7 +42,7 @@ services:
       - redis:/data
 
   db:
-    image: postgres:11
+    image: docker.io/postgres:11
     restart: unless-stopped
     volumes:
       - db:/var/lib/postgresql/data

--- a/yagpdb_docker/docker-compose.dev.yml
+++ b/yagpdb_docker/docker-compose.dev.yml
@@ -36,7 +36,7 @@ services:
       - app.env
 
   redis:
-    image: redis
+    image: docker.io/redis
     restart: unless-stopped
     networks:
       - default
@@ -44,7 +44,7 @@ services:
       - redis:/data
 
   db:
-    image: postgres:11
+    image: docker.io/postgres:11
     restart: unless-stopped
     volumes:
       - db:/var/lib/postgresql/data

--- a/yagpdb_docker/docker-compose.proxied.yml
+++ b/yagpdb_docker/docker-compose.proxied.yml
@@ -36,7 +36,7 @@ services:
       - app.env
 
   redis:
-    image: redis
+    image: docker.io/redis
     restart: unless-stopped
     networks:
       - default
@@ -44,7 +44,7 @@ services:
       - redis:/data
 
   db:
-    image: postgres:11
+    image: docker.io/postgres:11
     restart: unless-stopped
     volumes:
       - db:/var/lib/postgresql/data

--- a/yagpdb_docker/docker-compose.proxy.yml
+++ b/yagpdb_docker/docker-compose.proxy.yml
@@ -12,7 +12,7 @@ networks:
 
 services:
   proxy:
-    image: jwilder/nginx-proxy
+    image: docker.io/jwilder/nginx-proxy
     restart: unless-stopped
     ports:
       - "80:80"
@@ -31,7 +31,7 @@ services:
       - proxy-tier
 
   letsencrypt-companion:
-    image: jrcs/letsencrypt-nginx-proxy-companion
+    image: docker.io/jrcs/letsencrypt-nginx-proxy-companion
     restart: unless-stopped
     volumes:
       - proxy_certs:/etc/nginx/certs

--- a/yagpdb_docker/docker-compose.yml
+++ b/yagpdb_docker/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - app.env
 
   redis:
-    image: redis
+    image: docker.io/redis
     restart: unless-stopped
     networks:
       - default
@@ -48,7 +48,7 @@ services:
       - redis:/data
 
   db:
-    image: postgres:11
+    image: docker.io/postgres:11
     restart: unless-stopped
     volumes:
       - db:/var/lib/postgresql/data


### PR DESCRIPTION
Hi, I've been self hosting the bot with podman instead of docker for a while, it doesn't automatically pull images from docker.io so I thought to fully qualify the image references. This has no effect on docker but allows podman to seamlessly build / pull the images