### PR TITLE
lib/discordgo: add application ID to message struct

### DIFF
--- a/lib/discordgo/message.go
+++ b/lib/discordgo/message.go
@@ -162,6 +162,8 @@ type Message struct {
 	Flags MessageFlags `json:"flags"`
 
 	Activity *MessageActivity `json:"activity"`
+
+	ApplicationID int64 `json:"application_id,string"`
 }
 
 type MessageSnapshot struct {


### PR DESCRIPTION
Add the ApplicationID field to the Message struct.
If the message is an interaction- or application-owned webhook, this is
the ID of the application.

This is a suggestion from the support server:
https://canary.discord.com/channels/166207328570441728/525535451839463424/1300943054428962856

Signed-off-by: Galen CC <galen8183@gmail.com>
