### PR TITLE
Make integer divide by zero a catchable error

### DIFF
--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -901,7 +901,7 @@ func tmplMult(args ...interface{}) interface{} {
 
 func tmplDiv(args ...interface{}) (interface{}, error) {
 	if len(args) < 1 {
-		return 0
+		return 0, nil
 	}
 
 	switch args[0].(type) {

--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -921,7 +921,7 @@ func tmplDiv(args ...interface{}) (interface{}, error) {
 			if i == 0 {
 				continue
 			}
-			if v == 0 {
+			if tmplToInt(v) == 0 {
 				return 0, errors.New("integer divide by zero")
 			}
 

--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -899,7 +899,7 @@ func tmplMult(args ...interface{}) interface{} {
 	}
 }
 
-func tmplDiv(args ...interface{}) interface{} {
+func tmplDiv(args ...interface{}) (interface{}, error) {
 	if len(args) < 1 {
 		return 0
 	}
@@ -914,17 +914,20 @@ func tmplDiv(args ...interface{}) interface{} {
 
 			sumF /= ToFloat64(v)
 		}
-		return sumF
+		return sumF, nil
 	default:
 		sumI := tmplToInt(args[0])
 		for i, v := range args {
 			if i == 0 {
 				continue
 			}
+			if v == 0 {
+				return 0, errors.New("integer divide by zero")
+			}
 
 			sumI /= tmplToInt(v)
 		}
-		return sumI
+		return sumI, nil
 	}
 }
 


### PR DESCRIPTION
Runtime errors bypass {{catch}} and are generally unexpected.