### PR TITLE
module: fix go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/botlabs-gg/yagpdb/v2
 
-go 1.23
+go 1.23.0
 
 require (
 	emperror.dev/errors v0.8.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/botlabs-gg/yagpdb/v2
 
-go 1.23.0
+go 1.23.3
 
 require (
 	emperror.dev/errors v0.8.1


### PR DESCRIPTION
This solves an issue with go build attempting to automatically update go to a version that doesn’t technically exist.

Signed-off-by: SoggySaussages <vmdmaharaj@gmail.com>