### PR TITLE
AMv2 "Send Alert" effect/functionality

### DIFF
--- a/automod/rulepart.go
+++ b/automod/rulepart.go
@@ -89,6 +89,7 @@ var RulePartMap = map[int]RulePart{
 	312: &RemoveRoleEffect{},
 	313: &SendChannelMessageEffect{},
 	314: &TimeoutUserEffect{},
+	315: &SendModeratorAlertMessageEffect{},
 }
 
 var InverseRulePartMap = make(map[RulePart]int)


### PR DESCRIPTION
The purpose of this is to add an AMv2 effect type that is similar to the "Send alert" option that Discord's builtin AutoMod has. It allows for mod teams to log AMv2 events (with an optional custom message) that may require additional review before an action is taken rather than relying on automatic actions alone.

The reason a custom message was included is to allow mod teams to include extra context or role pings to go along with the alert.

## Examples

Here is an example of what it looks like in the UI:

<img width="555" alt="Screenshot 2024-11-10 at 8 58 37 PM" src="https://github.com/user-attachments/assets/dc3d0d7f-0004-4bab-baf6-8177673f5eb9">
<img width="568" alt="Screenshot 2024-11-10 at 8 58 50 PM" src="https://github.com/user-attachments/assets/fe741ebe-7248-421c-84b9-c31d6c762d7b">

Here is an example of what it looks like when a rule is triggered (custom message left blank):

<img width="327" alt="Screenshot 2024-11-10 at 9 09 14 PM" src="https://github.com/user-attachments/assets/b2607a89-4868-4253-8f5e-5876289e5a60">
