### PR TITLE
frontend: add documentation link to homepage

### DIFF
--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -59,7 +59,10 @@
         <li class="nav-item active">
           <a class="nav-link" href="/premium">Premium</a>
         </li>
-         <li class="nav-item active">
+        <li class="nav-item active">
+          <a class="nav-link" href="https://help.yagpdb.xyz">Documentation</a>
+        </li>
+        <li class="nav-item active">
           <a class="nav-link" target="_blank" href="https://discord.gg/4udtcA5">Support</a>
         </li>
       </ul>


### PR DESCRIPTION
Add a link to the help center to the homepage navbar header.

This is a suggestion in the support server:
https://canary.discord.com/channels/166207328570441728/356486960417734666/1289566686298636360

Signed-off-by: Galen CC <galen8183@gmail.com>
