### PR TITLE
tickets: let yag manage own tickets

### DIFF
--- a/tickets/tickets_commands.go
+++ b/tickets/tickets_commands.go
@@ -644,7 +644,7 @@ func createTicketChannel(conf *models.TicketConfig, gs *dstate.GuildSet, authorI
 		{
 			Type:  discordgo.PermissionOverwriteTypeMember,
 			ID:    common.BotUser.ID,
-			Allow: InTicketPerms,
+			Allow: InTicketPerms | PermissionManageChannels,
 		},
 	}
 

--- a/tickets/tickets_commands.go
+++ b/tickets/tickets_commands.go
@@ -644,7 +644,7 @@ func createTicketChannel(conf *models.TicketConfig, gs *dstate.GuildSet, authorI
 		{
 			Type:  discordgo.PermissionOverwriteTypeMember,
 			ID:    common.BotUser.ID,
-			Allow: InTicketPerms | PermissionManageChannels,
+			Allow: InTicketPerms | discordgo.PermissionManageChannels,
 		},
 	}
 


### PR DESCRIPTION
In the specific use case where
a) The bot does not have manage channel permissions assigned by a role
b) The bot is given manage channel permission in the ticket category
The bot is able to create tickets, but not close them. This is a simple fix which permits the bot to manage the tickets it creates. 

Signed-off-by: SoggySaussages <vmdmaharaj@gmail.com>