### PR TITLE
cmd: always ephemeral cmd override

### DIFF
--- a/commands/assets/commands.html
+++ b/commands/assets/commands.html
@@ -259,7 +259,7 @@
         </div>
         <div class="form-group col-md-5">
             {{$alwaysEphemeral := false}}
-            {{if .Override}}{{$commandsEnabled = .Override.AlwaysEphemeral}}{{end}}
+            {{if .Override}}{{$alwaysEphemeral = .Override.AlwaysEphemeral}}{{end}}
             {{if not .Override.Global}}
                 {{checkbox "AlwaysEphemeral" (joinStr "" "always-ephemeral-" .Override.ID) "Slash command responses always ephemeral?" .Override.AlwaysEphemeral}}
             {{else}}
@@ -394,7 +394,7 @@
                         {{$aeID := ""}}
                         {{if .Override}}{{$aeID = joinStr "" "cmd-override-always-ephemeral-" .Override.ID}}{{else}}{{$id = joinStr "" "cmd-override-always-ephemeral-" .Parent.ID "-new"}}{{end}}
     
-                        {{$alwaysEphemeral := true}}
+                        {{$alwaysEphemeral := false}}
                         {{if .Override}}{{$alwaysEphemeral = .Override.AlwaysEphemeral}}{{end}}
     
                         {{checkbox "AlwaysEphemeral" $aeID "Slash command responses always ephemeral?" $alwaysEphemeral}}

--- a/commands/assets/commands.html
+++ b/commands/assets/commands.html
@@ -261,7 +261,7 @@
             {{$alwaysEphemeral := false}}
             {{if .Override}}{{$alwaysEphemeral = .Override.AlwaysEphemeral}}{{end}}
             {{if not .Override.Global}}
-                {{checkbox "AlwaysEphemeral" (joinStr "" "always-ephemeral-" .Override.ID) "Slash command responses always ephemeral?" .Override.AlwaysEphemeral}}
+                {{checkbox "AlwaysEphemeral" (joinStr "" "always-ephemeral-" .Override.ID) "Slash command responses always ephemeral?" $alwaysEphemeral}}
             {{else}}
                 <div class="form-group d-flex align-items-center">
                     <input type="checkbox" class="tgl tgl-flat" name="AlwaysEphemeral" id="always-ephemeral-global"
@@ -390,15 +390,13 @@
                                 name="AutodeleteResponseDelay">
                         </div>
                     </div>
-                    <div class="form-group col-md-5">
-                        {{$aeID := ""}}
-                        {{if .Override}}{{$aeID = joinStr "" "cmd-override-always-ephemeral-" .Override.ID}}{{else}}{{$id = joinStr "" "cmd-override-always-ephemeral-" .Parent.ID "-new"}}{{end}}
-    
-                        {{$alwaysEphemeral := false}}
-                        {{if .Override}}{{$alwaysEphemeral = .Override.AlwaysEphemeral}}{{end}}
-    
-                        {{checkbox "AlwaysEphemeral" $aeID "Slash command responses always ephemeral?" $alwaysEphemeral}}
-                    </div>
+                    {{$aeID := ""}}
+                    {{if .Override}}{{$aeID = joinStr "" "cmd-override-always-ephemeral-" .Override.ID}}{{else}}{{$id = joinStr "" "cmd-override-always-ephemeral-" .Parent.ID "-new"}}{{end}}
+
+                    {{$alwaysEphemeral := false}}
+                    {{if .Override}}{{$alwaysEphemeral = .Override.AlwaysEphemeral}}{{end}}
+
+                    {{checkbox "AlwaysEphemeral" $aeID "Slash command responses always ephemeral?" $alwaysEphemeral}}
                 </div>
                 <div class="form-row">
                     <div class="form-group col-md-6">

--- a/commands/assets/commands.html
+++ b/commands/assets/commands.html
@@ -257,6 +257,9 @@
                     name="AutodeleteResponseDelay">
             </div>
         </div>
+        <div class="form-group col-md-5">
+            {{checkbox "AlwaysEphemeral" (joinStr "" "always-ephemeral-" .Override.ID) "Slash command responses always ephemeral?" .Override.AlwaysEphemeral}}
+        </div>
     </div>
     {{if .Override}}
     <button type="submit" class="btn btn-success" value="Save" data-async-form-alertsonly>Save channel
@@ -375,6 +378,9 @@
                                 value="{{if .Override}}{{.Override.AutodeleteResponseDelay}}{{else}}10{{end}}"
                                 name="AutodeleteResponseDelay">
                         </div>
+                    </div>
+                    <div class="form-group col-md-5">
+                        {{checkbox "AlwaysEphemeral" (joinStr "" "always-ephemeral-" .Override.ID) "Slash command responses always ephemeral?" .Override.AlwaysEphemeral}}
                     </div>
                 </div>
                 <div class="form-row">

--- a/commands/assets/commands.html
+++ b/commands/assets/commands.html
@@ -257,20 +257,18 @@
                     name="AutodeleteResponseDelay">
             </div>
         </div>
-        <div class="form-group col-md-5">
-            {{$alwaysEphemeral := false}}
-            {{if .Override}}{{$alwaysEphemeral = .Override.AlwaysEphemeral}}{{end}}
-            {{if not .Override.Global}}
-                {{checkbox "AlwaysEphemeral" (joinStr "" "always-ephemeral-" .Override.ID) "Slash command responses always ephemeral?" $alwaysEphemeral}}
-            {{else}}
-                <div class="form-group d-flex align-items-center">
-                    <input type="checkbox" class="tgl tgl-flat" name="AlwaysEphemeral" id="always-ephemeral-global"
-                        {{if $alwaysEphemeral}} checked{{end}}>
-                    <label for="always-ephemeral-global" class="tgl-btn mb-2"></label>
-                    <span class="ml-2 mb-2">Slash command responses always ephemeral?</span>
-                </div>
-            {{end}}
-        </div>
+        {{$alwaysEphemeral := false}}
+        {{if .Override}}{{$alwaysEphemeral = .Override.AlwaysEphemeral}}{{end}}
+        {{if not .Override.Global}}
+            {{checkbox "AlwaysEphemeral" (joinStr "" "always-ephemeral-" .Override.ID) "Slash command responses always ephemeral?" $alwaysEphemeral}}
+        {{else}}
+            <div class="form-group d-flex align-items-center">
+                <input type="checkbox" class="tgl tgl-flat" name="AlwaysEphemeral" id="always-ephemeral-global"
+                    {{if $alwaysEphemeral}} checked{{end}}>
+                <label for="always-ephemeral-global" class="tgl-btn mb-2"></label>
+                <span class="ml-2 mb-2">Slash command responses always ephemeral?</span>
+            </div>
+        {{end}}
     </div>
     {{if .Override}}
     <button type="submit" class="btn btn-success" value="Save" data-async-form-alertsonly>Save channel

--- a/commands/assets/commands.html
+++ b/commands/assets/commands.html
@@ -258,7 +258,18 @@
             </div>
         </div>
         <div class="form-group col-md-5">
-            {{checkbox "AlwaysEphemeral" (joinStr "" "always-ephemeral-" .Override.ID) "Slash command responses always ephemeral?" .Override.AlwaysEphemeral}}
+            {{$alwaysEphemeral := false}}
+            {{if .Override}}{{$commandsEnabled = .Override.AlwaysEphemeral}}{{end}}
+            {{if not .Override.Global}}
+                {{checkbox "AlwaysEphemeral" (joinStr "" "always-ephemeral-" .Override.ID) "Slash command responses always ephemeral?" .Override.AlwaysEphemeral}}
+            {{else}}
+                <div class="form-group d-flex align-items-center">
+                    <input type="checkbox" class="tgl tgl-flat" name="AlwaysEphemeral" id="always-ephemeral-global"
+                        {{if $alwaysEphemeral}} checked{{end}}>
+                    <label for="always-ephemeral-global" class="tgl-btn mb-2"></label>
+                    <span class="ml-2 mb-2">Slash command responses always ephemeral?</span>
+                </div>
+            {{end}}
         </div>
     </div>
     {{if .Override}}
@@ -380,7 +391,13 @@
                         </div>
                     </div>
                     <div class="form-group col-md-5">
-                        {{checkbox "AlwaysEphemeral" (joinStr "" "always-ephemeral-" .Override.ID) "Slash command responses always ephemeral?" .Override.AlwaysEphemeral}}
+                        {{$aeID := ""}}
+                        {{if .Override}}{{$aeID = joinStr "" "cmd-override-always-ephemeral-" .Override.ID}}{{else}}{{$id = joinStr "" "cmd-override-always-ephemeral-" .Parent.ID "-new"}}{{end}}
+    
+                        {{$alwaysEphemeral := true}}
+                        {{if .Override}}{{$alwaysEphemeral = .Override.AlwaysEphemeral}}{{end}}
+    
+                        {{checkbox "AlwaysEphemeral" $aeID "Slash command responses always ephemeral?" $alwaysEphemeral}}
                     </div>
                 </div>
                 <div class="form-row">

--- a/commands/models/commands_channels_overrides.go
+++ b/commands/models/commands_channels_overrides.go
@@ -30,6 +30,7 @@ type CommandsChannelsOverride struct {
 	ChannelCategories       types.Int64Array `boil:"channel_categories" json:"channel_categories,omitempty" toml:"channel_categories" yaml:"channel_categories,omitempty"`
 	Global                  bool             `boil:"global" json:"global" toml:"global" yaml:"global"`
 	CommandsEnabled         bool             `boil:"commands_enabled" json:"commands_enabled" toml:"commands_enabled" yaml:"commands_enabled"`
+	AlwaysEphemeral         bool             `boil:"always_ephemeral" json:"always_ephemeral" toml:"always_ephemeral" yaml:"always_ephemeral"`
 	AutodeleteResponse      bool             `boil:"autodelete_response" json:"autodelete_response" toml:"autodelete_response" yaml:"autodelete_response"`
 	AutodeleteTrigger       bool             `boil:"autodelete_trigger" json:"autodelete_trigger" toml:"autodelete_trigger" yaml:"autodelete_trigger"`
 	AutodeleteResponseDelay int              `boil:"autodelete_response_delay" json:"autodelete_response_delay" toml:"autodelete_response_delay" yaml:"autodelete_response_delay"`
@@ -48,6 +49,7 @@ var CommandsChannelsOverrideColumns = struct {
 	ChannelCategories       string
 	Global                  string
 	CommandsEnabled         string
+	AlwaysEphemeral         string
 	AutodeleteResponse      string
 	AutodeleteTrigger       string
 	AutodeleteResponseDelay string
@@ -61,6 +63,7 @@ var CommandsChannelsOverrideColumns = struct {
 	ChannelCategories:       "channel_categories",
 	Global:                  "global",
 	CommandsEnabled:         "commands_enabled",
+	AlwaysEphemeral:         "always_ephemeral",
 	AutodeleteResponse:      "autodelete_response",
 	AutodeleteTrigger:       "autodelete_trigger",
 	AutodeleteResponseDelay: "autodelete_response_delay",
@@ -76,6 +79,7 @@ var CommandsChannelsOverrideTableColumns = struct {
 	ChannelCategories       string
 	Global                  string
 	CommandsEnabled         string
+	AlwaysEphemeral         string
 	AutodeleteResponse      string
 	AutodeleteTrigger       string
 	AutodeleteResponseDelay string
@@ -89,6 +93,7 @@ var CommandsChannelsOverrideTableColumns = struct {
 	ChannelCategories:       "commands_channels_overrides.channel_categories",
 	Global:                  "commands_channels_overrides.global",
 	CommandsEnabled:         "commands_channels_overrides.commands_enabled",
+	AlwaysEphemeral:         "commands_channels_overrides.always_ephemeral",
 	AutodeleteResponse:      "commands_channels_overrides.autodelete_response",
 	AutodeleteTrigger:       "commands_channels_overrides.autodelete_trigger",
 	AutodeleteResponseDelay: "commands_channels_overrides.autodelete_response_delay",
@@ -185,6 +190,7 @@ var CommandsChannelsOverrideWhere = struct {
 	ChannelCategories       whereHelpertypes_Int64Array
 	Global                  whereHelperbool
 	CommandsEnabled         whereHelperbool
+	AlwaysEphemeral         whereHelperbool
 	AutodeleteResponse      whereHelperbool
 	AutodeleteTrigger       whereHelperbool
 	AutodeleteResponseDelay whereHelperint
@@ -198,6 +204,7 @@ var CommandsChannelsOverrideWhere = struct {
 	ChannelCategories:       whereHelpertypes_Int64Array{field: "\"commands_channels_overrides\".\"channel_categories\""},
 	Global:                  whereHelperbool{field: "\"commands_channels_overrides\".\"global\""},
 	CommandsEnabled:         whereHelperbool{field: "\"commands_channels_overrides\".\"commands_enabled\""},
+	AlwaysEphemeral:         whereHelperbool{field: "\"commands_channels_overrides\".\"always_ephemeral\""},
 	AutodeleteResponse:      whereHelperbool{field: "\"commands_channels_overrides\".\"autodelete_response\""},
 	AutodeleteTrigger:       whereHelperbool{field: "\"commands_channels_overrides\".\"autodelete_trigger\""},
 	AutodeleteResponseDelay: whereHelperint{field: "\"commands_channels_overrides\".\"autodelete_response_delay\""},
@@ -234,8 +241,8 @@ func (r *commandsChannelsOverrideR) GetCommandsCommandOverrides() CommandsComman
 type commandsChannelsOverrideL struct{}
 
 var (
-	commandsChannelsOverrideAllColumns            = []string{"id", "guild_id", "channels", "channel_categories", "global", "commands_enabled", "autodelete_response", "autodelete_trigger", "autodelete_response_delay", "autodelete_trigger_delay", "require_roles", "ignore_roles"}
-	commandsChannelsOverrideColumnsWithoutDefault = []string{"guild_id", "global", "commands_enabled", "autodelete_response", "autodelete_trigger", "autodelete_response_delay", "autodelete_trigger_delay", "require_roles", "ignore_roles"}
+	commandsChannelsOverrideAllColumns            = []string{"id", "guild_id", "channels", "channel_categories", "global", "commands_enabled", "always_ephemeral", "autodelete_response", "autodelete_trigger", "autodelete_response_delay", "autodelete_trigger_delay", "require_roles", "ignore_roles"}
+	commandsChannelsOverrideColumnsWithoutDefault = []string{"guild_id", "global", "commands_enabled", "always_ephemeral", "autodelete_response", "autodelete_trigger", "autodelete_response_delay", "autodelete_trigger_delay", "require_roles", "ignore_roles"}
 	commandsChannelsOverrideColumnsWithDefault    = []string{"id", "channels", "channel_categories"}
 	commandsChannelsOverridePrimaryKeyColumns     = []string{"id"}
 	commandsChannelsOverrideGeneratedColumns      = []string{}

--- a/commands/models/commands_command_overrides.go
+++ b/commands/models/commands_command_overrides.go
@@ -29,6 +29,7 @@ type CommandsCommandOverride struct {
 	CommandsChannelsOverridesID int64             `boil:"commands_channels_overrides_id" json:"commands_channels_overrides_id" toml:"commands_channels_overrides_id" yaml:"commands_channels_overrides_id"`
 	Commands                    types.StringArray `boil:"commands" json:"commands" toml:"commands" yaml:"commands"`
 	CommandsEnabled             bool              `boil:"commands_enabled" json:"commands_enabled" toml:"commands_enabled" yaml:"commands_enabled"`
+	AlwaysEphemeral             bool              `boil:"always_ephemeral" json:"always_ephemeral" toml:"always_ephemeral" yaml:"always_ephemeral"`
 	AutodeleteResponse          bool              `boil:"autodelete_response" json:"autodelete_response" toml:"autodelete_response" yaml:"autodelete_response"`
 	AutodeleteTrigger           bool              `boil:"autodelete_trigger" json:"autodelete_trigger" toml:"autodelete_trigger" yaml:"autodelete_trigger"`
 	AutodeleteResponseDelay     int               `boil:"autodelete_response_delay" json:"autodelete_response_delay" toml:"autodelete_response_delay" yaml:"autodelete_response_delay"`
@@ -46,6 +47,7 @@ var CommandsCommandOverrideColumns = struct {
 	CommandsChannelsOverridesID string
 	Commands                    string
 	CommandsEnabled             string
+	AlwaysEphemeral             string
 	AutodeleteResponse          string
 	AutodeleteTrigger           string
 	AutodeleteResponseDelay     string
@@ -58,6 +60,7 @@ var CommandsCommandOverrideColumns = struct {
 	CommandsChannelsOverridesID: "commands_channels_overrides_id",
 	Commands:                    "commands",
 	CommandsEnabled:             "commands_enabled",
+	AlwaysEphemeral:             "always_ephemeral",
 	AutodeleteResponse:          "autodelete_response",
 	AutodeleteTrigger:           "autodelete_trigger",
 	AutodeleteResponseDelay:     "autodelete_response_delay",
@@ -72,6 +75,7 @@ var CommandsCommandOverrideTableColumns = struct {
 	CommandsChannelsOverridesID string
 	Commands                    string
 	CommandsEnabled             string
+	AlwaysEphemeral             string
 	AutodeleteResponse          string
 	AutodeleteTrigger           string
 	AutodeleteResponseDelay     string
@@ -84,6 +88,7 @@ var CommandsCommandOverrideTableColumns = struct {
 	CommandsChannelsOverridesID: "commands_command_overrides.commands_channels_overrides_id",
 	Commands:                    "commands_command_overrides.commands",
 	CommandsEnabled:             "commands_command_overrides.commands_enabled",
+	AlwaysEphemeral:             "commands_command_overrides.always_ephemeral",
 	AutodeleteResponse:          "commands_command_overrides.autodelete_response",
 	AutodeleteTrigger:           "commands_command_overrides.autodelete_trigger",
 	AutodeleteResponseDelay:     "commands_command_overrides.autodelete_response_delay",
@@ -121,6 +126,7 @@ var CommandsCommandOverrideWhere = struct {
 	CommandsChannelsOverridesID whereHelperint64
 	Commands                    whereHelpertypes_StringArray
 	CommandsEnabled             whereHelperbool
+	AlwaysEphemeral             whereHelperbool
 	AutodeleteResponse          whereHelperbool
 	AutodeleteTrigger           whereHelperbool
 	AutodeleteResponseDelay     whereHelperint
@@ -133,6 +139,7 @@ var CommandsCommandOverrideWhere = struct {
 	CommandsChannelsOverridesID: whereHelperint64{field: "\"commands_command_overrides\".\"commands_channels_overrides_id\""},
 	Commands:                    whereHelpertypes_StringArray{field: "\"commands_command_overrides\".\"commands\""},
 	CommandsEnabled:             whereHelperbool{field: "\"commands_command_overrides\".\"commands_enabled\""},
+	AlwaysEphemeral:             whereHelperbool{field: "\"commands_command_overrides\".\"always_ephemeral\""},
 	AutodeleteResponse:          whereHelperbool{field: "\"commands_command_overrides\".\"autodelete_response\""},
 	AutodeleteTrigger:           whereHelperbool{field: "\"commands_command_overrides\".\"autodelete_trigger\""},
 	AutodeleteResponseDelay:     whereHelperint{field: "\"commands_command_overrides\".\"autodelete_response_delay\""},
@@ -169,8 +176,8 @@ func (r *commandsCommandOverrideR) GetCommandsChannelsOverride() *CommandsChanne
 type commandsCommandOverrideL struct{}
 
 var (
-	commandsCommandOverrideAllColumns            = []string{"id", "guild_id", "commands_channels_overrides_id", "commands", "commands_enabled", "autodelete_response", "autodelete_trigger", "autodelete_response_delay", "autodelete_trigger_delay", "require_roles", "ignore_roles"}
-	commandsCommandOverrideColumnsWithoutDefault = []string{"guild_id", "commands_channels_overrides_id", "commands", "commands_enabled", "autodelete_response", "autodelete_trigger", "autodelete_response_delay", "autodelete_trigger_delay", "require_roles", "ignore_roles"}
+	commandsCommandOverrideAllColumns            = []string{"id", "guild_id", "commands_channels_overrides_id", "commands", "commands_enabled", "always_ephemeral", "autodelete_response", "autodelete_trigger", "autodelete_response_delay", "autodelete_trigger_delay", "require_roles", "ignore_roles"}
+	commandsCommandOverrideColumnsWithoutDefault = []string{"guild_id", "commands_channels_overrides_id", "commands", "commands_enabled", "always_ephemeral", "autodelete_response", "autodelete_trigger", "autodelete_response_delay", "autodelete_trigger_delay", "require_roles", "ignore_roles"}
 	commandsCommandOverrideColumnsWithDefault    = []string{"id"}
 	commandsCommandOverridePrimaryKeyColumns     = []string{"id"}
 	commandsCommandOverrideGeneratedColumns      = []string{}

--- a/commands/plugin_bot.go
+++ b/commands/plugin_bot.go
@@ -172,24 +172,24 @@ func YAGCommandMiddleware(inner dcmd.RunFunc) dcmd.RunFunc {
 			guildID = data.GuildData.GS.ID
 		}
 
+		// Check if the user can execute the command
+		canExecute, resp, settings, err := yc.checkCanExecuteCommand(data)
+		if err != nil {
+			yc.Logger(data).WithError(err).Error("An error occured while checking if we could run command")
+		}
+
 		if data.TriggerType == dcmd.TriggerTypeSlashCommands && data.SlashCommandTriggerData.Interaction.Type != discordgo.InteractionApplicationCommandAutocomplete {
 			// Acknowledge the interaction
 			response := discordgo.InteractionResponse{
 				Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
 			}
-			if yc.IsResponseEphemeral {
+			if yc.IsResponseEphemeral || settings.AlwaysEphemeral {
 				response.Data = &discordgo.InteractionResponseData{Flags: 64}
 			}
 			err := data.Session.CreateInteractionResponse(data.SlashCommandTriggerData.Interaction.ID, data.SlashCommandTriggerData.Interaction.Token, &response)
 			if err != nil {
 				return nil, err
 			}
-		}
-
-		// Check if the user can execute the command
-		canExecute, resp, settings, err := yc.checkCanExecuteCommand(data)
-		if err != nil {
-			yc.Logger(data).WithError(err).Error("An error occured while checking if we could run command")
 		}
 
 		parseErr := dcmd.ParseCmdArgs(data)

--- a/commands/plugin_web.go
+++ b/commands/plugin_web.go
@@ -277,6 +277,7 @@ func HandleCreateChannelsOverride(w http.ResponseWriter, r *http.Request) (web.T
 		Channels:                formData.Channels,
 		ChannelCategories:       formData.ChannelCategories,
 		CommandsEnabled:         formData.CommandsEnabled,
+		AlwaysEphemeral:         formData.AlwaysEphemeral,
 		AutodeleteResponse:      formData.AutodeleteResponse,
 		AutodeleteTrigger:       formData.AutodeleteTrigger,
 		AutodeleteResponseDelay: formData.AutodeleteResponseDelay,
@@ -312,6 +313,7 @@ func HandleUpdateChannelsOverride(w http.ResponseWriter, r *http.Request, curren
 	currentOverride.Channels = formData.Channels
 	currentOverride.ChannelCategories = formData.ChannelCategories
 	currentOverride.CommandsEnabled = formData.CommandsEnabled
+	currentOverride.AlwaysEphemeral = formData.AlwaysEphemeral
 	currentOverride.AutodeleteResponse = formData.AutodeleteResponse
 	currentOverride.AutodeleteTrigger = formData.AutodeleteTrigger
 	currentOverride.AutodeleteResponseDelay = formData.AutodeleteResponseDelay
@@ -370,6 +372,7 @@ func HandleCreateCommandOverride(w http.ResponseWriter, r *http.Request, channel
 
 		Commands:                formData.Commands,
 		CommandsEnabled:         formData.CommandsEnabled,
+		AlwaysEphemeral:         formData.AlwaysEphemeral,
 		AutodeleteResponse:      formData.AutodeleteResponse,
 		AutodeleteTrigger:       formData.AutodeleteTrigger,
 		AutodeleteResponseDelay: formData.AutodeleteResponseDelay,
@@ -408,6 +411,7 @@ func HandleUpdateCommandOVerride(w http.ResponseWriter, r *http.Request, channel
 
 	override.Commands = formData.Commands
 	override.CommandsEnabled = formData.CommandsEnabled
+	override.AlwaysEphemeral = formData.AlwaysEphemeral
 	override.AutodeleteResponse = formData.AutodeleteResponse
 	override.AutodeleteTrigger = formData.AutodeleteTrigger
 	override.AutodeleteResponseDelay = formData.AutodeleteResponseDelay

--- a/commands/plugin_web.go
+++ b/commands/plugin_web.go
@@ -223,6 +223,7 @@ func ChannelOverrideMiddleware(inner func(w http.ResponseWriter, r *http.Request
 					Global:          true,
 					GuildID:         activeGuild.ID,
 					CommandsEnabled: true,
+					AlwaysEphemeral: false,
 					Channels:        []int64{},
 					RequireRoles:    []int64{},
 					IgnoreRoles:     []int64{},

--- a/commands/plugin_web.go
+++ b/commands/plugin_web.go
@@ -37,6 +37,7 @@ type ChannelOverrideForm struct {
 	ChannelCategories       []int64 `valid:"channel,true"`
 	Global                  bool
 	CommandsEnabled         bool
+	AlwaysEphemeral         bool
 	AutodeleteResponse      bool
 	AutodeleteTrigger       bool
 	AutodeleteResponseDelay int     `valid:"0,2678400"`
@@ -48,6 +49,7 @@ type ChannelOverrideForm struct {
 type CommandOverrideForm struct {
 	Commands                []string
 	CommandsEnabled         bool
+	AlwaysEphemeral         bool
 	AutodeleteResponse      bool
 	AutodeleteTrigger       bool
 	AutodeleteResponseDelay int     `valid:"0,2678400"`

--- a/commands/schema.go
+++ b/commands/schema.go
@@ -50,5 +50,5 @@ CREATE TABLE IF NOT EXISTS commands_command_overrides (
 `, `
 CREATE INDEX IF NOT EXISTS commands_command_groups_channels_override_idx ON commands_command_overrides(commands_channels_overrides_id);
 `, `
-ALTER TABLE commands_channels_overrides ADD COLUMN IF NOT EXISTS always_ephemeral BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE commands_command_overrides ADD COLUMN IF NOT EXISTS always_ephemeral BOOLEAN NOT NULL DEFAULT false;
 `}

--- a/commands/schema.go
+++ b/commands/schema.go
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS commands_channels_overrides (
 	global bool NOT NULL,
 
 	commands_enabled BOOL NOT NULL,
+	always_ephemeral BOOL NOT NULL,
 
 	autodelete_response BOOL NOT NULL,
 	autodelete_trigger BOOL NOT NULL,
@@ -25,6 +26,8 @@ CREATE INDEX IF NOT EXISTS commands_channels_overrides_guild_idx ON commands_cha
 `, `
 CREATE UNIQUE INDEX IF NOT EXISTS commands_channels_overrides_global_uniquex ON commands_channels_overrides (guild_id) WHERE global;
 `, `
+ALTER TABLE commands_channels_overrides ADD COLUMN IF NOT EXISTS always_ephemeral BOOLEAN NOT NULL DEFAULT false;
+`, `
 CREATE TABLE IF NOT EXISTS commands_command_overrides (
 	id BIGSERIAL PRIMARY KEY,
 	guild_id BIGINT NOT NULL,
@@ -33,6 +36,7 @@ CREATE TABLE IF NOT EXISTS commands_command_overrides (
 	commands TEXT[] NOT NULL,
 
 	commands_enabled BOOL NOT NULL,
+	always_ephemeral BOOL NOT NULL,
 
 	autodelete_response BOOL NOT NULL,
 	autodelete_trigger BOOL NOT NULL,
@@ -45,4 +49,6 @@ CREATE TABLE IF NOT EXISTS commands_command_overrides (
 );
 `, `
 CREATE INDEX IF NOT EXISTS commands_command_groups_channels_override_idx ON commands_command_overrides(commands_channels_overrides_id);
+`, `
+ALTER TABLE commands_channels_overrides ADD COLUMN IF NOT EXISTS always_ephemeral BOOLEAN NOT NULL DEFAULT false;
 `}

--- a/commands/util.go
+++ b/commands/util.go
@@ -338,12 +338,18 @@ func (e *EphemeralOrNone) Send(data *dcmd.Data) ([]*discordgo.Message, error) {
 		// 	Content: "Failed running the command.",
 		// })
 
-		if yc, ok := data.Cmd.Command.(*YAGCommand); ok && !yc.IsResponseEphemeral {
-			// Yeah so because the original reaction response is not marked as ephemeral, and there's no way to change that, just delete it i guess...
-			// because otherwise the followup message turns into the original response
-			err := data.Session.DeleteInteractionResponse(common.BotApplication.ID, data.SlashCommandTriggerData.Interaction.Token)
+		if yc, ok := data.Cmd.Command.(*YAGCommand); ok {
+			settings, err := yc.GetSettings(data.ContainerChain, data.GuildData.CS, data.GuildData.GS)
 			if err != nil {
 				return nil, err
+			}
+			if !(yc.IsResponseEphemeral || settings.AlwaysEphemeral) {
+				// Yeah so because the original reaction response is not marked as ephemeral, and there's no way to change that, just delete it i guess...
+				// because otherwise the followup message turns into the original response
+				err := data.Session.DeleteInteractionResponse(common.BotApplication.ID, data.SlashCommandTriggerData.Interaction.Token)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 

--- a/commands/yagcommmand.go
+++ b/commands/yagcommmand.go
@@ -800,6 +800,7 @@ func (yc *YAGCommand) GetSettingsWithLoadedOverrides(containerChain []*dcmd.Cont
 // Fills the command settings from a channel override, and if a matching command override is found, the command override
 func (cs *YAGCommand) fillSettings(cmdFullName string, override *models.CommandsChannelsOverride, settings *CommandSettings) {
 	settings.Enabled = override.CommandsEnabled
+	settings.AlwaysEphemeral = override.AlwaysEphemeral
 
 	settings.IgnoreRoles = override.IgnoreRoles
 	settings.RequiredRoles = override.RequireRoles
@@ -814,6 +815,7 @@ OUTER:
 		for _, cmd := range cmdOverride.Commands {
 			if strings.EqualFold(cmd, cmdFullName) {
 				settings.Enabled = cmdOverride.CommandsEnabled
+				settings.AlwaysEphemeral = cmdOverride.AlwaysEphemeral
 
 				settings.IgnoreRoles = cmdOverride.IgnoreRoles
 				settings.RequiredRoles = cmdOverride.RequireRoles

--- a/commands/yagcommmand.go
+++ b/commands/yagcommmand.go
@@ -702,7 +702,8 @@ func (cs *YAGCommand) customEnabled(guildID int64) (bool, error) {
 }
 
 type CommandSettings struct {
-	Enabled bool
+	Enabled         bool
+	AlwaysEphemeral bool
 
 	DelTrigger       bool
 	DelResponse      bool

--- a/commands/yagcommmand.go
+++ b/commands/yagcommmand.go
@@ -1058,6 +1058,7 @@ func GetAllOverrides(ctx context.Context, guildID int64) ([]*models.CommandsChan
 	global := &models.CommandsChannelsOverride{
 		Global:          true,
 		CommandsEnabled: true,
+		AlwaysEphemeral: false,
 	}
 	global.R = global.R.NewStruct()
 


### PR DESCRIPTION
Add a command override to make responses to slash commands always ephemeral.

Signed-off-by: SoggySaussages <vmdmaharaj@gmail.com>