### PR TITLE
cmddocsgen: note un/nick hist cmds disabled

### DIFF
--- a/common/run/run.go
+++ b/common/run/run.go
@@ -38,7 +38,7 @@ var (
 	flagLogTimestamp bool
 
 	flagSysLog        bool
-	flagGenCmdDocs    bool
+	FlagGenCmdDocs    bool
 	flagGenConfigDocs bool
 
 	flagLogAppName string
@@ -59,7 +59,7 @@ func init() {
 	flag.BoolVar(&flagSysLog, "syslog", false, "Set to log to syslog (only linux)")
 	flag.StringVar(&flagLogAppName, "logappname", "yagpdb", "When using syslog, the application name will be set to this")
 	flag.BoolVar(&flagRunBWC, "backgroundworkers", false, "Run the various background workers, atleast one process needs this")
-	flag.BoolVar(&flagGenCmdDocs, "gencmddocs", false, "Generate command docs and exit")
+	flag.BoolVar(&FlagGenCmdDocs, "gencmddocs", false, "Generate command docs and exit")
 	flag.BoolVar(&flagGenConfigDocs, "genconfigdocs", false, "Generate config docs and exit")
 
 	flag.BoolVar(&flagLogTimestamp, "ts", false, "Set to include timestamps in log")
@@ -135,7 +135,7 @@ func Run() {
 
 	commands.InitCommands()
 
-	if flagGenCmdDocs {
+	if FlagGenCmdDocs {
 		GenCommandsDocs()
 		return
 	}

--- a/logs/plugin_bot.go
+++ b/logs/plugin_bot.go
@@ -9,6 +9,7 @@ import (
 	"emperror.dev/errors"
 	"github.com/botlabs-gg/yagpdb/v2/bot/paginatedmessages"
 	"github.com/botlabs-gg/yagpdb/v2/common/config"
+	"github.com/botlabs-gg/yagpdb/v2/common/run"
 
 	"github.com/botlabs-gg/yagpdb/v2/bot"
 	"github.com/botlabs-gg/yagpdb/v2/bot/eventsystem"
@@ -30,6 +31,12 @@ func (p *Plugin) AddCommands() {
 		commands.AddRootCommands(p, cmdLogs, cmdWhois, cmdNicknames, cmdUsernames, cmdClearNames)
 	} else {
 		commands.AddRootCommands(p, cmdLogs, cmdWhois)
+		if run.FlagGenCmdDocs {
+			for _, cmd := range []*commands.YAGCommand{cmdNicknames, cmdUsernames, cmdClearNames} {
+				cmd.Description = fmt.Sprint(cmd.Description, " Disabled on the public instance.")
+				commands.AddRootCommands(p, cmd)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
When generating command docs with username logging config disabled, instead of omitting the relevant commands as is the current behaviour, this PR adds a note mentioning the relevant  commands are disabled on the public instance. This 
allows for unaffected command docs to be generated including the commands in question on an instance running nickname 
logging. For instances with username logging disabled, the docs generate for the benefit of downstream forks using the 
upstream's docs while informing it's own users it won't be accessible.

Signed-off-by: SoggySaussages <vmdmaharaj@gmail.com>