### PR TITLE
fix(rolecommands): Re-add `rr` check on menu setup

### DIFF
--- a/rolecommands/menu.go
+++ b/rolecommands/menu.go
@@ -100,7 +100,9 @@ func cmdFuncRoleMenuCreate(parsed *dcmd.Data) (interface{}, error) {
 		RoleGroupID:                null.Int64From(group.ID),
 		OwnMessage:                 true,
 		DisableSendDM:              parsed.Switches["nodm"].Value != nil && parsed.Switches["nodm"].Value.(bool),
-		RemoveRoleOnReactionRemove: true,
+		// `rr` is `true` by default, which is why we want
+		// a `true` value, if `.Value` is `nil`.
+		RemoveRoleOnReactionRemove: parsed.Switches["rr"].Value == nil || !parsed.Switches["rr"].Value.(bool),
 		SkipAmount:                 skipAmount,
 	}
 


### PR DESCRIPTION
When the `-rr` flag was introduced, a condition to flip its state to `true` if the `-rr` flag was included, was introduced. For whatever reason, at some point this conditional was removed, and the flag, has not been functional when creating a Role Menu ever since

This commit introduces an inverted version of the statement used for the `-nodm`, for `-rr`, to hopefully reintroduce this functionality.