### PR TITLE
web/database: add usage indicator

### DIFF
--- a/customcommands/assets/customcommands-database.html
+++ b/customcommands/assets/customcommands-database.html
@@ -20,6 +20,25 @@
 </header>
 {{template "cp_alerts" .}}
 
+<div>
+    <section class="card">
+        <header class="card-header">
+            <h2 class="card-title">Database Usage - {{.DatabaseUsagePercent}}% Full</h2>
+        </header>
+        <div class="card-body">
+            <div class="col-auto">
+                <h4>{{.TotalDatabaseUsage}} Entries used of total {{.TotalDatabaseCapacity}}</h4>
+                <p>
+                    Total calculated by member count multiplied by 50{{if .IsGuildPremium}}0{{end}} (<code>{{.ActiveGuild.MemberCount}}*50{{if .IsGuildPremium}}0{{end}}</code>).{{if not .IsGuildPremium}} Get 10 times the
+                    database space with <a href="/premium">premium</a>!{{end}}
+                </p>
+                <meter id="database-usage-meter" class="meter" value="{{.TotalDatabaseUsage}}" low="{{.ThreeQuartersTotalDatabaseCapacity}}" high="{{.NineTenthsTotalDatabaseCapacity}}" title="Entries" 
+                    max="{{.TotalDatabaseCapacity}}"></meter>
+                <label for="database-usage-meter">Database usage</label>
+            </div> 
+        </div>
+    </section>
+</div>
 <div class="row">
     <div class="col-lg-6">
         <section class="card">
@@ -54,23 +73,6 @@
         </section>
     </div>
     <div class="col-lg-6">
-        <section class="card">
-            <header class="card-header">
-                <h2 class="card-title">Database Usage - {{.DatabaseUsagePercent}}% Full</h2>
-            </header>
-            <div class="card-body">
-                <div class="col-auto">
-                    <h4>{{.TotalDatabaseUsage}} Entries used of total {{.TotalDatabaseCapacity}}</h4>
-                    <p>
-                        Total calculated by member count multiplied by 50{{if .IsGuildPremium}}0{{end}} (<code>{{.ActiveGuild.MemberCount}}*50{{if .IsGuildPremium}}0{{end}}</code>).{{if not .IsGuildPremium}} Get 10 times the
-                        database space with <a href="/premium">premium</a>!{{end}}
-                    </p>
-                    <meter id="database-usage-meter" class="meter" value="{{.TotalDatabaseUsage}}" low="{{.ThreeQuartersTotalDatabaseCapacity}}" high="{{.NineTenthsTotalDatabaseCapacity}}" title="Entries" 
-                        max="{{.TotalDatabaseCapacity}}"></meter>
-                    <label for="database-usage-meter">Database usage</label>
-                </div> 
-            </div>
-        </section>
         <section class="card">
             <header class="card-header">
                 <h2 class="card-title">Info</h2>

--- a/customcommands/assets/customcommands-database.html
+++ b/customcommands/assets/customcommands-database.html
@@ -65,7 +65,7 @@
                         Total calculated by member count multiplied by 50{{if .IsGuildPremium}}0{{end}} (<code>{{.ActiveGuild.MemberCount}}*50{{if .IsGuildPremium}}0{{end}}</code>).{{if not .IsGuildPremium}} Get 10 times the
                         database space with <a href="/premium">premium</a>!{{end}}
                     </p>
-                    <meter id="database-usage-meter" class="meter" value="{{.TotalDatabaseUsage}}" low="{{mult .TotalDatabaseCapacity 0.75}}" high="{{mult .TotalDatabaseCapacity 0.9}}" title="Entries" 
+                    <meter id="database-usage-meter" class="meter" value="{{.TotalDatabaseUsage}}" low="{{.ThreeQuartersTotalDatabaseCapacity}}" high="{{.NineTenthsTotalDatabaseCapacity}}" title="Entries" 
                         max="{{.TotalDatabaseCapacity}}"></meter>
                     <label for="database-usage-meter">Database usage</label>
                 </div> 

--- a/customcommands/assets/customcommands-database.html
+++ b/customcommands/assets/customcommands-database.html
@@ -32,7 +32,7 @@
                     Total calculated by member count multiplied by 50{{if .IsGuildPremium}}0{{end}} (<code>{{.ActiveGuild.MemberCount}}*50{{if .IsGuildPremium}}0{{end}}</code>).{{if not .IsGuildPremium}} Get 10 times the
                     database space with <a href="/premium">premium</a>!{{end}}
                 </p>
-                <meter id="database-usage-meter" class="meter" value="{{.TotalDatabaseUsage}}" low="{{.ThreeQuartersTotalDatabaseCapacity}}" high="{{.NineTenthsTotalDatabaseCapacity}}" title="Entries" 
+                <meter id="database-usage-meter" class="meter" value="{{.TotalDatabaseUsage}}" low="{{.CapacityWarningCap}}" high="{{.CapacityDangerCap}}" title="Entries" 
                     max="{{.TotalDatabaseCapacity}}"></meter>
                 <label for="database-usage-meter">Database usage</label>
             </div> 

--- a/customcommands/assets/customcommands-database.html
+++ b/customcommands/assets/customcommands-database.html
@@ -27,7 +27,7 @@
         </header>
         <div class="card-body">
             <div class="col-auto">
-                <h4>{{.TotalDatabaseUsage}} Entries used of total {{.TotalDatabaseCapacity}}</h4>
+                <h4>{{.TotalDatabaseUsage}} Entries used of total {{.TotalDatabaseCapacity}}<p>{{sub .TotalDatabaseCapacity .TotalDatabaseUsage}} available</p></h4>
                 <p>
                     Total calculated by member count multiplied by 50{{if .IsGuildPremium}}0{{end}} (<code>{{.ActiveGuild.MemberCount}}*50{{if .IsGuildPremium}}0{{end}}</code>).{{if not .IsGuildPremium}} Get 10 times the
                     database space with <a href="/premium">premium</a>!{{end}}

--- a/customcommands/assets/customcommands-database.html
+++ b/customcommands/assets/customcommands-database.html
@@ -56,6 +56,23 @@
     <div class="col-lg-6">
         <section class="card">
             <header class="card-header">
+                <h2 class="card-title">Database Usage - {{.DatabaseUsagePercent}}% Full</h2>
+            </header>
+            <div class="card-body">
+                <div class="col-auto">
+                    <h4>{{.TotalDatabaseUsage}} Entries used of total {{.TotalDatabaseCapacity}}</h4>
+                    <p>
+                        Total calculated by member count multiplied by 50{{if .IsGuildPremium}}0{{end}} (<code>{{.ActiveGuild.MemberCount}}*50{{if .IsGuildPremium}}0{{end}}</code>).{{if not .IsGuildPremium}} Get 10 times the
+                        database space with <a href="/premium">premium</a>!{{end}}
+                    </p>
+                    <meter id="database-usage-meter" class="meter" value="{{.TotalDatabaseUsage}}" low="{{mult .TotalDatabaseCapacity 0.75}}" high="{{mult .TotalDatabaseCapacity 0.9}}" title="Entries" 
+                        max="{{.TotalDatabaseCapacity}}"></meter>
+                    <label for="database-usage-meter">Database usage</label>
+                </div> 
+            </div>
+        </section>
+        <section class="card">
+            <header class="card-header">
                 <h2 class="card-title">Info</h2>
             </header>
             <div class="card-body">

--- a/customcommands/web.go
+++ b/customcommands/web.go
@@ -219,7 +219,8 @@ func handleGetDatabase(w http.ResponseWriter, r *http.Request) (web.TemplateData
 	templateData["IsGuildPremium"] = premium
 	templateData["TotalDatabaseUsage"] = total
 	templateData["TotalDatabaseCapacity"] = limit
-	templateData["DatabaseUsagePercent"] = usagePercent
+	templateData["ThreeQuartersTotalDatabaseCapacity"] = float64(limit) * 0.75
+	templateData["NineTenthsTotalDatabaseCapacity"] = float64(limit) * 0.9
 
 	if usagePercent > 95 {
 		templateData.AddAlerts(web.WarningAlert("Database is almost full. Creating new entires will fail if you hit your limit."))

--- a/customcommands/web.go
+++ b/customcommands/web.go
@@ -219,8 +219,8 @@ func handleGetDatabase(w http.ResponseWriter, r *http.Request) (web.TemplateData
 	templateData["IsGuildPremium"] = premium
 	templateData["TotalDatabaseUsage"] = total
 	templateData["TotalDatabaseCapacity"] = limit
-	templateData["ThreeQuartersTotalDatabaseCapacity"] = float64(limit) * 0.75
-	templateData["NineTenthsTotalDatabaseCapacity"] = float64(limit) * 0.9
+	templateData["CapacityWarningCap"] = float64(limit) * 0.75
+	templateData["CapacityDangerCap"] = float64(limit) * 0.9
 	templateData["DatabaseUsagePercent"] = usagePercent
 
 	if usagePercent > 95 {

--- a/customcommands/web.go
+++ b/customcommands/web.go
@@ -221,6 +221,7 @@ func handleGetDatabase(w http.ResponseWriter, r *http.Request) (web.TemplateData
 	templateData["TotalDatabaseCapacity"] = limit
 	templateData["ThreeQuartersTotalDatabaseCapacity"] = float64(limit) * 0.75
 	templateData["NineTenthsTotalDatabaseCapacity"] = float64(limit) * 0.9
+	templateData["DatabaseUsagePercent"] = usagePercent
 
 	if usagePercent > 95 {
 		templateData.AddAlerts(web.WarningAlert("Database is almost full. Creating new entires will fail if you hit your limit."))

--- a/customcommands/web.go
+++ b/customcommands/web.go
@@ -208,6 +208,23 @@ func handleGetDatabase(w http.ResponseWriter, r *http.Request) (web.TemplateData
 	templateData["TotalPages"] = totalPages
 	templateData["Page"] = page
 
+	premium := premium.ContextPremium(r.Context())
+	limitMuliplier := 1
+	if premium {
+		limitMuliplier = 10
+	}
+	limit := activeGuild.MemberCount * 50 * int64(limitMuliplier)
+	usagePercent := int(float64(total) * 100 / float64(limit))
+
+	templateData["IsGuildPremium"] = premium
+	templateData["TotalDatabaseUsage"] = total
+	templateData["TotalDatabaseCapacity"] = limit
+	templateData["DatabaseUsagePercent"] = usagePercent
+
+	if usagePercent > 95 {
+		templateData.AddAlerts(web.WarningAlert("Database is almost full. Creating new entires will fail if you hit your limit."))
+	}
+
 	return templateData, nil
 }
 

--- a/frontend/static/css/custom.css
+++ b/frontend/static/css/custom.css
@@ -564,3 +564,9 @@ html.dark .feedlink {
   color: #abb4be;
 
 }
+
+.meter {
+  width: 100%;
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+}


### PR DESCRIPTION
Adds a meter of database usage and info to the database page.  Meter turns orange when 75% full and red when 90% full. There’s also a web alert at 95%. 

![database-usage](https://github.com/user-attachments/assets/89174666-5fb3-4b52-9e0a-f65f58830002)

Signed-off-by: SoggySaussages <vmdmaharaj@gmail.com>