### PR TITLE
cc/cron: alter time calc to aid tests

### DIFF
--- a/customcommands/interval.go
+++ b/customcommands/interval.go
@@ -88,7 +88,7 @@ func CalcNextRunTime(cc *models.CustomCommand, now time.Time) time.Time {
 			// this can never run
 			return time.Time{}
 		}
-		tNext = specSchedule.Next(time.Now().UTC())
+		tNext = specSchedule.Next(now.UTC())
 	}
 
 	return tNext

--- a/customcommands/interval_test.go
+++ b/customcommands/interval_test.go
@@ -1,7 +1,6 @@
 package customcommands
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -34,15 +33,8 @@ func TestNextRunTimeBasic(t *testing.T) {
 
 	// cron
 
-	now := time.Now().UTC()
-	tim = time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(), 0, 0, time.UTC)
 	cc.TriggerType = int(CommandTriggerCron)
-
-	minute := tim.Minute() + 5
-	if minute > 59 {
-		minute -= 60
-	}
-	cc.TextTrigger = fmt.Sprintf("%d * * * *", minute)
+	cc.TextTrigger = "5 * * * *"
 
 	next = CalcNextRunTime(cc, tim)
 	expected = tim.UTC().Add(time.Minute * 5)
@@ -138,22 +130,8 @@ func TestNextRunTimeExcludingHours(t *testing.T) {
 
 	// cron
 
-	now := time.Now().UTC()
-	tim = time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(), 0, 0, time.UTC)
-	expected = tim.Add((time.Hour * 2) + (time.Minute * 5))
 	cc.TriggerType = int(CommandTriggerCron)
-
-	nextHour := int64(tim.Hour()) + 1
-	if nextHour > 23 {
-		nextHour -= 24
-	}
-	cc.TimeTriggerExcludingHours = []int64{int64(tim.Hour()), nextHour}
-
-	minute := tim.Minute() + 5
-	if minute > 59 {
-		minute -= 60
-	}
-	cc.TextTrigger = fmt.Sprintf("%d * * * *", minute)
+	cc.TextTrigger = "5 * * * *"
 
 	nextRun = CalcNextRunTime(cc, tim)
 
@@ -180,22 +158,9 @@ func TestNextRunTimeExcludingDays(t *testing.T) {
 
 	// cron
 
-	now := time.Now().UTC()
-	tim = time.Date(now.Year(), now.Month(), now.Day(), 0, now.Minute(), 0, 0, time.UTC)
-	expected = tim.Add(time.Hour*48 + time.Minute*5)
 	cc.TriggerType = int(CommandTriggerCron)
-
-	nextDay := int64(tim.Weekday()) + 1
-	if nextDay > 6 {
-		nextDay -= 7
-	}
-	cc.TimeTriggerExcludingDays = []int64{int64(tim.Weekday()), nextDay}
-
-	minute := tim.Minute() + 5
-	if minute > 59 {
-		minute -= 60
-	}
-	cc.TextTrigger = fmt.Sprintf("%d * * * *", minute)
+	cc.TextTrigger = "5 * * * *"
+	expected = expected.Add(time.Minute * 5)
 
 	nextRun = CalcNextRunTime(cc, tim)
 
@@ -225,33 +190,13 @@ func TestNextRunTimeExcludingDaysHours(t *testing.T) {
 
 	// cron
 
-	now := time.Now().UTC()
-	tim = time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(), 0, 0, time.UTC)
-	expected = tim.Add(time.Hour*47 + time.Minute*5)
 	cc.TriggerType = int(CommandTriggerCron)
-
-	cc.TimeTriggerExcludingHours = []int64{}
-	for i := range 24 {
-		if i != tim.Hour()-1 {
-			cc.TimeTriggerExcludingHours = append(cc.TimeTriggerExcludingHours, int64(i))
-		}
-	}
-
-	nextDay := int64(tim.Weekday()) + 1
-	if nextDay > 6 {
-		nextDay -= 7
-	}
-	cc.TimeTriggerExcludingDays = []int64{nextDay}
-
-	minute := tim.Minute() + 5
-	if minute > 59 {
-		minute -= 60
-	}
-	cc.TextTrigger = fmt.Sprintf("%d * * * *", minute)
+	cc.TextTrigger = "5 * * * *"
+	expected = expected.Add(time.Minute * 5)
 
 	nextRun = CalcNextRunTime(cc, tim)
 
-	if nextRun != expected && tim.Hour() != 0 {
+	if nextRun != expected {
 		t.Errorf("next run should be: %s (w:%d) got %s (w:%d - %d)", expected, expected.Weekday(), nextRun, int(nextRun.Weekday()), nextRun.Hour())
 	}
 }


### PR DESCRIPTION
Simplifies the cron next run time calculation to allow for simple and consistent deterministic testing.

Thank you to Joe for spending 45 minutes to point out this much easier solution to my oblivious mind.

Signed-off-by: SoggySaussages <vmdmaharaj@gmail.com>