### PR TITLE
frontend: ask before leaving the page with unsaved changes

### DIFF
--- a/frontend/static/js/spongebob.js
+++ b/frontend/static/js/spongebob.js
@@ -674,6 +674,13 @@ function hideUnsavedChangesPopup(form) {
 	updateUnsavedChangesPopup(form)
 }
 
+// onbeforeunload
+function unsavedChangesAlert() {
+    if (unsavedChangesStack.length > 0) {
+        return "You have unsaved changes, are you sure you want to leave?";
+    }
+}
+
 function updateUnsavedChangesPopup() {
 	if (unsavedChangesStack.length == 0) {
 		$("#unsaved-changes-popup").attr("hidden", true)

--- a/frontend/templates/cp_main.html
+++ b/frontend/templates/cp_main.html
@@ -73,7 +73,7 @@
     <!-- What are these comments even they are wasted bandwidth, thats what they are -->
     <!-- The current time is 4:14 am on the 21st of may, maybe i just like adding onto this whenever i come across this section after forgetting about it? -->
 </head>
-<body>
+<body onbeforeunload="return unsavedChangesAlert()">
     <div id="loading-overlay">
         <section class="card">
             <header class="card-header">


### PR DESCRIPTION
Ask the user before leaving the page when they have unsaved changes. We
use the `onbeforeunload` event for that and return a non-empty string in
the called function.[^0]

This is also a suggestion on the support server[^1].

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

[^0]: https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event
[^1]: https://discord.com/channels/166207328570441728/356486960417734666/742956841566208093
