### PR TITLE
customcommands web: stop redundant alerts

### DIFF
--- a/customcommands/customcommands.go
+++ b/customcommands/customcommands.go
@@ -185,7 +185,9 @@ func (cc *CustomCommand) Validate(tmpl web.TemplateData, guild_id int64) (ok boo
 	}
 
 	if !foundOkayResponse {
-		tmpl.AddAlerts(web.ErrorAlert("No response set"))
+		if len(tmpl.Alerts()) == 0 {
+			tmpl.AddAlerts(web.ErrorAlert("No response set"))
+		}
 		return false
 	}
 


### PR DESCRIPTION
Only add the "No response set" alert if no other alerts were added.
This means syntax errors in the response templates will not be
obstructed, a common issue on mobile devices.

Signed-off-by: Galen CC <galen8183@gmail.com>
