### PR TITLE
discordblog: support embeds, timestampt, webhooks

### DIFF
--- a/frontend/templates/cp_selectserver.html
+++ b/frontend/templates/cp_selectserver.html
@@ -38,6 +38,7 @@
                     {{.Content}}
                     {{if ne .ImageURL ""}}<img src="{{.ImageURL}}">{{end}}
                 </div>
+                {{end}}
             </div>
         </secton>
         {{end}}

--- a/frontend/templates/cp_selectserver.html
+++ b/frontend/templates/cp_selectserver.html
@@ -28,11 +28,16 @@
         {{range .Posts}}
         <secton class="card">
             <header class="card-header">
-                <h2 class="card-title float-left"><img class="avatar mr-2" src="{{.Message.Author.AvatarURL "256"}}"></img>{{.Message.Author.Globalname}}</h2>
+                <h2 class="card-title float-left"><img class="avatar mr-2" src="{{.Message.Author.AvatarURL "256"}}"></img>{{.AuthorName}}</h2>
                 <span class="float-right">{{humanizeTimeSinceDays .ParsedTimestamp}} ago ({{.ParsedTimestamp.Format "02 Jan 06 15:04"}})</span>
             </header>
             <div class="card-body">
                 {{.RenderedBody}}
+                {{range .RenderedEmbeds}}
+                <div class="col-auto" style="border-left: 5px solid {{if ne .ColorHex ""}}{{.ColorHex}}{{else}}black{{end}};">
+                    {{.Content}}
+                    {{if ne .ImageURL ""}}<img src="{{.ImageURL}}">{{end}}
+                </div>
             </div>
         </secton>
         {{end}}

--- a/web/discordblog/discordblog.go
+++ b/web/discordblog/discordblog.go
@@ -1,8 +1,11 @@
 package discordblog
 
 import (
+	"fmt"
 	"html/template"
 	"regexp"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -11,8 +14,16 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type RenderedEmbed struct {
+	ColorHex string
+	Content  template.HTML
+	ImageURL string
+}
+
 type Post struct {
+	AuthorName      string
 	Message         *discordgo.Message
+	RenderedEmbeds  []*RenderedEmbed
 	RenderedBody    template.HTML
 	ParsedTimestamp time.Time
 }
@@ -36,6 +47,92 @@ func RunPoller(session *discordgo.Session, channel int64, interval time.Duration
 }
 
 var mentionStrippingRegex = regexp.MustCompile("<@(#|&)[0-9]*>")
+var unixTimestampRegex = regexp.MustCompile(`(?i)<t:\d+:(t|d|f|r)>`)
+
+func replaceUnixTimestamps(body string) string {
+	return unixTimestampRegex.ReplaceAllStringFunc(body, func(match string) string {
+		unix, _ := strconv.ParseInt(match[3:len(match)-3], 10, 64)
+		timestamp := time.Unix(unix, 0)
+		return timestamp.Format(time.RFC1123)
+	})
+}
+
+func renderBody(body string) template.HTML {
+	stripped := mentionStrippingRegex.ReplaceAllString(body, "")
+	timestamped := replaceUnixTimestamps(stripped)
+	rendered := github_flavored_markdown.Markdown([]byte(timestamped))
+	return template.HTML(string(rendered))
+}
+
+func renderMessageEmbeds(msg *discordgo.Message) []*RenderedEmbed {
+	var embeds []*RenderedEmbed
+	for _, embed := range msg.Embeds {
+		bodyLines := []string{msg.ContentWithMentionsReplaced()}
+		if embed.Author != nil {
+			authorLine := embed.Author.Name
+			if embed.Author.URL != "" {
+				authorLine = fmt.Sprintf("[%s](%s)", authorLine, embed.Author.URL)
+			}
+			bodyLines = append(bodyLines, authorLine)
+		}
+		if embed.Title != "" {
+			titleLine := embed.Title
+			if embed.URL != "" {
+				titleLine = fmt.Sprintf("[%s](%s)", titleLine, embed.URL)
+			}
+			titleLine = "### " + titleLine
+			bodyLines = append(bodyLines, titleLine)
+		}
+		if embed.Description != "" {
+			bodyLines = append(bodyLines, embed.Description)
+		}
+		for _, f := range embed.Fields {
+			fieldBody := fmt.Sprintf("**%s**\n%s", f.Name, f.Value)
+			bodyLines = append(bodyLines, fieldBody)
+		}
+
+		var footerLine string
+		if embed.Footer != nil {
+			footerLine = embed.Footer.Text
+		}
+		if embed.Timestamp != "" {
+			timestamp, err := discordgo.Timestamp(embed.Timestamp).Parse()
+			if err != nil {
+				timestampString := timestamp.Format(time.RFC1123)
+				if footerLine != "" {
+					footerLine = footerLine + " · " + timestampString
+				} else {
+					footerLine = timestampString
+				}
+			}
+		}
+		if footerLine != "" {
+			bodyLines = append(bodyLines, footerLine)
+		}
+
+		rendered := &RenderedEmbed{
+			Content: renderBody(strings.Join(bodyLines, "\n\n")),
+		}
+		if embed.Color != 0 {
+			rendered.ColorHex = fmt.Sprintf("#%x", embed.Color)
+		}
+		if embed.Image != nil {
+			rendered.ImageURL = embed.Image.URL
+		}
+
+		embeds = append(embeds, rendered)
+	}
+
+	return embeds
+}
+
+func formatAuthorString(msg *discordgo.Message) string {
+	author := msg.Author.Globalname
+	if author == "" {
+		author = msg.Author.String()
+	}
+	return author
+}
 
 func updatePosts(session *discordgo.Session, channel int64) error {
 	messages, err := session.ChannelMessages(channel, 25, 0, 0, 0)
@@ -47,15 +144,13 @@ func updatePosts(session *discordgo.Session, channel int64) error {
 	posts = make([]*Post, len(messages))
 
 	for i, v := range messages {
-		body := v.ContentWithMentionsReplaced()
-		body = mentionStrippingRegex.ReplaceAllString(body, "")
-		rendered := github_flavored_markdown.Markdown([]byte(body))
-
 		ts, _ := v.Timestamp.Parse()
 
 		p := &Post{
+			AuthorName:      formatAuthorString(v),
 			Message:         v,
-			RenderedBody:    template.HTML(string(rendered)),
+			RenderedBody:    renderBody(v.ContentWithMentionsReplaced()),
+			RenderedEmbeds:  renderMessageEmbeds(v),
 			ParsedTimestamp: ts.UTC(),
 		}
 		posts[i] = p

--- a/web/discordblog/discordblog.go
+++ b/web/discordblog/discordblog.go
@@ -98,7 +98,7 @@ func renderMessageEmbeds(msg *discordgo.Message) []*RenderedEmbed {
 		}
 		if embed.Timestamp != "" {
 			timestamp, err := discordgo.Timestamp(embed.Timestamp).Parse()
-			if err != nil {
+			if err == nil {
 				timestampString := timestamp.Format(time.RFC1123)
 				if footerLine != "" {
 					footerLine = footerLine + " · " + timestampString

--- a/web/discordblog/discordblog.go
+++ b/web/discordblog/discordblog.go
@@ -67,12 +67,13 @@ func renderBody(body string) template.HTML {
 func renderMessageEmbeds(msg *discordgo.Message) []*RenderedEmbed {
 	var embeds []*RenderedEmbed
 	for _, embed := range msg.Embeds {
-		bodyLines := []string{msg.ContentWithMentionsReplaced()}
+		var bodyLines[]string
 		if embed.Author != nil {
 			authorLine := embed.Author.Name
 			if embed.Author.URL != "" {
 				authorLine = fmt.Sprintf("[%s](%s)", authorLine, embed.Author.URL)
 			}
+			authorLine = "#### " + authorLine
 			bodyLines = append(bodyLines, authorLine)
 		}
 		if embed.Title != "" {

--- a/web/discordblog/discordblog.go
+++ b/web/discordblog/discordblog.go
@@ -67,7 +67,7 @@ func renderBody(body string) template.HTML {
 func renderMessageEmbeds(msg *discordgo.Message) []*RenderedEmbed {
 	var embeds []*RenderedEmbed
 	for _, embed := range msg.Embeds {
-		var bodyLines[]string
+		var bodyLines []string
 		if embed.Author != nil {
 			authorLine := embed.Author.Name
 			if embed.Author.URL != "" {
@@ -115,7 +115,7 @@ func renderMessageEmbeds(msg *discordgo.Message) []*RenderedEmbed {
 			Content: renderBody(strings.Join(bodyLines, "\n\n")),
 		}
 		if embed.Color != 0 {
-			rendered.ColorHex = fmt.Sprintf("#%x", embed.Color)
+			rendered.ColorHex = fmt.Sprintf("#%06x", embed.Color)
 		}
 		if embed.Image != nil {
 			rendered.ImageURL = embed.Image.URL


### PR DESCRIPTION
Add support for the discordblog to render embeds, parse unix timestamps, and render webhooks' names. This allows bot
admins to timestamp their announcements, such as with status updates throughout a downtime event. It also allows them
to use embeds in their announcements, a not uncommon practice for bot support servers to use in their announcement
channels. Finally it allows for server admins to use webhooks, particularly relevant for tools such as Discohook.

Signed-off-by: SoggySaussages <vmdmaharaj@gmail.com>