### PR TITLE
tickets: add optional buttons to interface

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -495,7 +495,13 @@ func (c *Context) SendResponse(content string) (m *discordgo.Message, err error)
 	embeds = append(embeds, c.CurrentFrame.EmbedsToSend...)
 	msgSend.Embeds = embeds
 	msgSend.Content = content
-	if (len(msgSend.Embeds) == 0 && strings.TrimSpace(content) == "") || (c.CurrentFrame.DelResponse && c.CurrentFrame.DelResponseDelay < 1) {
+	if len(c.CurrentFrame.ComponentsToSend) > 0 {
+		msgSend.Components = append(msgSend.Components, c.CurrentFrame.ComponentsToSend...)
+		if len(msgSend.Components) > 5 {
+			msgSend.Components = msgSend.Components[:5]
+		}
+	}
+	if (len(msgSend.Embeds) == 0 && strings.TrimSpace(content) == "" && len(msgSend.Components) == 0) || (c.CurrentFrame.DelResponse && c.CurrentFrame.DelResponseDelay < 1) {
 		// no point in sending the response if it gets deleted immedietely
 		return nil, nil
 	}
@@ -511,13 +517,6 @@ func (c *Context) SendResponse(content string) (m *discordgo.Message, err error)
 					},
 				},
 			},
-		}
-	}
-
-	if len(c.CurrentFrame.ComponentsToSend) > 0 {
-		msgSend.Components = append(msgSend.Components, c.CurrentFrame.ComponentsToSend...)
-		if len(msgSend.Components) > 5 {
-			msgSend.Components = msgSend.Components[:5]
 		}
 	}
 

--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -208,6 +208,7 @@ type ContextFrame struct {
 
 	DelResponseDelay         int
 	EmbedsToSend             []*discordgo.MessageEmbed
+	ComponentsToSend         []discordgo.MessageComponent
 	AddResponseReactionNames []string
 
 	isNestedTemplate bool
@@ -510,6 +511,13 @@ func (c *Context) SendResponse(content string) (m *discordgo.Message, err error)
 					},
 				},
 			},
+		}
+	}
+
+	if len(c.CurrentFrame.ComponentsToSend) > 0 {
+		msgSend.Components = append(msgSend.Components, c.CurrentFrame.ComponentsToSend...)
+		if len(msgSend.Components) > 5 {
+			msgSend.Components = msgSend.Components[:5]
 		}
 	}
 

--- a/tickets/assets/tickets_control_panel.html
+++ b/tickets/assets/tickets_control_panel.html
@@ -94,6 +94,9 @@
                                     {{template "template_helper_user"}} - The user opening the ticket<br />
                                     <code>{{"{{.Reason}}"}}</code> - The reason for opening the ticket<br />
                                 </p>
+                                <p>Append any of the following buttons to the ticket opening message?</p>
+                                {{checkbox "AppendButtonsClose" "tickets-append-buttons-close-box" `Append a button to close the ticket` .PluginSettingsAppendButtons.Close}}
+                                {{checkbox "AppendButtonsCloseWithReason" "tickets-append-buttons-close-with-reason-box" `Append a button to close the ticket and provide a reason` .PluginSettingsAppendButtons.CloseWithReason}}
                             </div>
                         </div>
                     </div>

--- a/tickets/models/ticket_configs.go
+++ b/tickets/models/ticket_configs.go
@@ -35,6 +35,7 @@ type TicketConfig struct {
 	ModRoles                           types.Int64Array `boil:"mod_roles" json:"mod_roles,omitempty" toml:"mod_roles" yaml:"mod_roles,omitempty"`
 	AdminRoles                         types.Int64Array `boil:"admin_roles" json:"admin_roles,omitempty" toml:"admin_roles" yaml:"admin_roles,omitempty"`
 	TicketsTranscriptsChannelAdminOnly int64            `boil:"tickets_transcripts_channel_admin_only" json:"tickets_transcripts_channel_admin_only" toml:"tickets_transcripts_channel_admin_only" yaml:"tickets_transcripts_channel_admin_only"`
+	AppendButtons                      int64            `boil:"append_buttons" json:"append_buttons" toml:"append_buttons" yaml:"append_buttons"`
 
 	R *ticketConfigR `boil:"-" json:"-" toml:"-" yaml:"-"`
 	L ticketConfigL  `boil:"-" json:"-" toml:"-" yaml:"-"`
@@ -52,6 +53,7 @@ var TicketConfigColumns = struct {
 	ModRoles                           string
 	AdminRoles                         string
 	TicketsTranscriptsChannelAdminOnly string
+	AppendButtons                      string
 }{
 	GuildID:                            "guild_id",
 	Enabled:                            "enabled",
@@ -64,6 +66,7 @@ var TicketConfigColumns = struct {
 	ModRoles:                           "mod_roles",
 	AdminRoles:                         "admin_roles",
 	TicketsTranscriptsChannelAdminOnly: "tickets_transcripts_channel_admin_only",
+	AppendButtons:                      "append_buttons",
 }
 
 var TicketConfigTableColumns = struct {
@@ -78,6 +81,7 @@ var TicketConfigTableColumns = struct {
 	ModRoles                           string
 	AdminRoles                         string
 	TicketsTranscriptsChannelAdminOnly string
+	AppendButtons                      string
 }{
 	GuildID:                            "ticket_configs.guild_id",
 	Enabled:                            "ticket_configs.enabled",
@@ -90,6 +94,7 @@ var TicketConfigTableColumns = struct {
 	ModRoles:                           "ticket_configs.mod_roles",
 	AdminRoles:                         "ticket_configs.admin_roles",
 	TicketsTranscriptsChannelAdminOnly: "ticket_configs.tickets_transcripts_channel_admin_only",
+	AppendButtons:                      "ticket_configs.append_buttons",
 }
 
 // Generated where
@@ -189,6 +194,7 @@ var TicketConfigWhere = struct {
 	ModRoles                           whereHelpertypes_Int64Array
 	AdminRoles                         whereHelpertypes_Int64Array
 	TicketsTranscriptsChannelAdminOnly whereHelperint64
+	AppendButtons                      whereHelperint64
 }{
 	GuildID:                            whereHelperint64{field: "\"ticket_configs\".\"guild_id\""},
 	Enabled:                            whereHelperbool{field: "\"ticket_configs\".\"enabled\""},
@@ -201,6 +207,7 @@ var TicketConfigWhere = struct {
 	ModRoles:                           whereHelpertypes_Int64Array{field: "\"ticket_configs\".\"mod_roles\""},
 	AdminRoles:                         whereHelpertypes_Int64Array{field: "\"ticket_configs\".\"admin_roles\""},
 	TicketsTranscriptsChannelAdminOnly: whereHelperint64{field: "\"ticket_configs\".\"tickets_transcripts_channel_admin_only\""},
+	AppendButtons:                      whereHelperint64{field: "\"ticket_configs\".\"append_buttons\""},
 }
 
 // TicketConfigRels is where relationship names are stored.
@@ -220,9 +227,9 @@ func (*ticketConfigR) NewStruct() *ticketConfigR {
 type ticketConfigL struct{}
 
 var (
-	ticketConfigAllColumns            = []string{"guild_id", "enabled", "ticket_open_msg", "tickets_channel_category", "status_channel", "tickets_transcripts_channel", "download_attachments", "tickets_use_txt_transcripts", "mod_roles", "admin_roles", "tickets_transcripts_channel_admin_only"}
+	ticketConfigAllColumns            = []string{"guild_id", "enabled", "ticket_open_msg", "tickets_channel_category", "status_channel", "tickets_transcripts_channel", "download_attachments", "tickets_use_txt_transcripts", "mod_roles", "admin_roles", "tickets_transcripts_channel_admin_only", "append_buttons"}
 	ticketConfigColumnsWithoutDefault = []string{"guild_id", "enabled", "ticket_open_msg", "tickets_channel_category", "status_channel", "tickets_transcripts_channel", "download_attachments", "tickets_use_txt_transcripts"}
-	ticketConfigColumnsWithDefault    = []string{"mod_roles", "admin_roles", "tickets_transcripts_channel_admin_only"}
+	ticketConfigColumnsWithDefault    = []string{"mod_roles", "admin_roles", "tickets_transcripts_channel_admin_only", "append_buttons"}
 	ticketConfigPrimaryKeyColumns     = []string{"guild_id"}
 	ticketConfigGeneratedColumns      = []string{}
 )

--- a/tickets/schema.go
+++ b/tickets/schema.go
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS ticket_configs  (
 `, `
 ALTER TABLE ticket_configs ADD COLUMN IF NOT EXISTS tickets_transcripts_channel_admin_only BIGINT NOT NULL DEFAULT 0;
 `, `
-ALTER TABLE ticket_configs ADD COLUMN IF NOT EXISTS append_buttons INT NOT NULL DEFAULT 0;
+ALTER TABLE ticket_configs ADD COLUMN IF NOT EXISTS append_buttons BIGINT NOT NULL DEFAULT 0;
 `, `
 CREATE TABLE IF NOT EXISTS tickets (
 	guild_id BIGINT NOT NULL,

--- a/tickets/schema.go
+++ b/tickets/schema.go
@@ -20,6 +20,8 @@ CREATE TABLE IF NOT EXISTS ticket_configs  (
 `, `
 ALTER TABLE ticket_configs ADD COLUMN IF NOT EXISTS tickets_transcripts_channel_admin_only BIGINT NOT NULL DEFAULT 0;
 `, `
+ALTER TABLE ticket_configs ADD COLUMN IF NOT EXISTS append_buttons INT NOT NULL DEFAULT 0;
+`, `
 CREATE TABLE IF NOT EXISTS tickets (
 	guild_id BIGINT NOT NULL,
 	local_id BIGINT NOT NULL,

--- a/tickets/tickets_bot.go
+++ b/tickets/tickets_bot.go
@@ -407,7 +407,7 @@ func (p *Plugin) handleInteractionCreate(evt *eventsystem.EventData) (retry bool
 		return
 	}
 
-	if !conf.Enabled {
+	if !conf.Enabled && strings.Contains(customID, "open") {
 		common.BotSession.CreateInteractionResponse(ic.ID, ic.Token, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseChannelMessageWithSource,
 			Data: &discordgo.InteractionResponseData{

--- a/tickets/tickets_bot.go
+++ b/tickets/tickets_bot.go
@@ -443,7 +443,7 @@ func (p *Plugin) handleInteractionCreate(evt *eventsystem.EventData) (retry bool
 	}
 	if response != nil {
 		if response.Data.Content == "" {
-			response.Data.Content = "Something went wrong when running this command, either discord or the bot may be having issues."
+			response = errorResponse
 		}
 	} else {
 		response = errorResponse

--- a/tickets/tickets_bot.go
+++ b/tickets/tickets_bot.go
@@ -55,6 +55,11 @@ const (
 	ErrMaxOpenTickets   TicketUserError = "You're currently in over 10 open tickets on this server, please close some of the ones you're in."
 )
 
+const (
+	AppendButtonsClose           int64 = 1 << 0
+	AppendButtonsCloseWithReason int64 = 1 << 1
+)
+
 func CreateTicket(ctx context.Context, gs *dstate.GuildSet, ms *dstate.MemberState, conf *models.TicketConfig, topic string, checkMaxTickets, executedByCommandTemplate bool) (*dstate.GuildSet, *models.Ticket, error) {
 	if gs.GetChannel(conf.TicketsChannelCategory) == nil {
 		return gs, nil, ErrNoTicketCateogry
@@ -134,6 +139,21 @@ func CreateTicket(ctx context.Context, gs *dstate.GuildSet, ms *dstate.MemberSta
 	ticketOpenMsg := conf.TicketOpenMSG
 	if ticketOpenMsg == "" {
 		ticketOpenMsg = DefaultTicketMsg
+	}
+	
+	if conf.AppendButtons & AppendButtonsClose == AppendButtonsClose {
+		tmplCTX.CurrentFrame.ComponentsToSend = append(tmplCTX.CurrentFrame.ComponentsToSend, discordgo.ActionsRow{Components: []discordgo.MessageComponent{discordgo.Button{
+			Label: "Close Ticket",
+			CustomID: "tickets-close",
+			Style: discordgo.DangerButton,
+		}}})
+	}
+	if conf.AppendButtons & AppendButtonsCloseWithReason == AppendButtonsCloseWithReason {
+		tmplCTX.CurrentFrame.ComponentsToSend = append(tmplCTX.CurrentFrame.ComponentsToSend, discordgo.ActionsRow{Components: []discordgo.MessageComponent{discordgo.Button{
+			Label: "Close Ticket with Reason",
+			CustomID: "tickets-close-reason",
+			Style: discordgo.SecondaryButton,
+		}}})
 	}
 
 	err = tmplCTX.ExecuteAndSendWithErrors(ticketOpenMsg, channel.ID)

--- a/tickets/tickets_bot.go
+++ b/tickets/tickets_bot.go
@@ -428,12 +428,6 @@ func (p *Plugin) handleInteractionCreate(evt *eventsystem.EventData) (retry bool
 	}
 
 	var currentChannel *dstate.ChannelState = evt.GS.GetChannel(ic.ChannelID)
-	if err != nil {
-		respErr := common.BotSession.CreateInteractionResponse(ic.ID, ic.Token, errorResponse)
-		if err == nil {
-			err = respErr
-		}
-	}
 
 	switch ic.Type {
 	case discordgo.InteractionMessageComponent:
@@ -449,8 +443,8 @@ func (p *Plugin) handleInteractionCreate(evt *eventsystem.EventData) (retry bool
 		response = errorResponse
 	}
 
-	err = common.BotSession.CreateInteractionResponse(ic.ID, ic.Token, response)
-	if err != nil {
+	respErr := common.BotSession.CreateInteractionResponse(ic.ID, ic.Token, response)
+	if respErr != nil {
 		common.BotSession.CreateFollowupMessage(ic.ApplicationID, ic.Token, &discordgo.WebhookParams{
 			Content: response.Data.Content,
 			Flags:   int64(response.Data.Flags),

--- a/tickets/tickets_bot.go
+++ b/tickets/tickets_bot.go
@@ -436,7 +436,7 @@ func (p *Plugin) handleInteractionCreate(evt *eventsystem.EventData) (retry bool
 		response, err = handleModal(evt, ic, ic.Member, conf, currentChannel)
 	}
 	if response != nil {
-		if response.Data.Content == "" {
+		if response.Data.Content == "" && len(response.Data.Components) == 0 {
 			response = errorResponse
 		}
 	} else {

--- a/tickets/tickets_bot.go
+++ b/tickets/tickets_bot.go
@@ -363,6 +363,8 @@ func (p *Plugin) handleInteractionCreate(evt *eventsystem.EventData) (retry bool
 		return
 	}
 
+	evt.GS = bot.State.GetGuild(ic.GuildID)
+
 	conf, err := models.FindTicketConfigG(evt.Context(), ic.GuildID)
 	if err != nil {
 		if err != sql.ErrNoRows {

--- a/tickets/tickets_bot.go
+++ b/tickets/tickets_bot.go
@@ -140,19 +140,19 @@ func CreateTicket(ctx context.Context, gs *dstate.GuildSet, ms *dstate.MemberSta
 	if ticketOpenMsg == "" {
 		ticketOpenMsg = DefaultTicketMsg
 	}
-	
-	if conf.AppendButtons & AppendButtonsClose == AppendButtonsClose {
+
+	if conf.AppendButtons&AppendButtonsClose == AppendButtonsClose {
 		tmplCTX.CurrentFrame.ComponentsToSend = append(tmplCTX.CurrentFrame.ComponentsToSend, discordgo.ActionsRow{Components: []discordgo.MessageComponent{discordgo.Button{
-			Label: "Close Ticket",
+			Label:    "Close Ticket",
 			CustomID: "tickets-close",
-			Style: discordgo.DangerButton,
+			Style:    discordgo.DangerButton,
 		}}})
 	}
-	if conf.AppendButtons & AppendButtonsCloseWithReason == AppendButtonsCloseWithReason {
+	if conf.AppendButtons&AppendButtonsCloseWithReason == AppendButtonsCloseWithReason {
 		tmplCTX.CurrentFrame.ComponentsToSend = append(tmplCTX.CurrentFrame.ComponentsToSend, discordgo.ActionsRow{Components: []discordgo.MessageComponent{discordgo.Button{
-			Label: "Close Ticket with Reason",
+			Label:    "Close Ticket with Reason",
 			CustomID: "tickets-close-reason",
-			Style: discordgo.SecondaryButton,
+			Style:    discordgo.SecondaryButton,
 		}}})
 	}
 
@@ -396,16 +396,6 @@ func (p *Plugin) handleInteractionCreate(evt *eventsystem.EventData) (retry bool
 			},
 		})
 		return
-	}
-
-	err = common.BotSession.CreateInteractionResponse(ic.ID, ic.Token, &discordgo.InteractionResponse{
-		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
-		Data: &discordgo.InteractionResponseData{
-			Flags: discordgo.MessageFlagsEphemeral,
-		},
-	})
-	if err != nil {
-		return bot.CheckDiscordErrRetry(err), err
 	}
 
 	var response *discordgo.InteractionResponse

--- a/tickets/tickets_bot.go
+++ b/tickets/tickets_bot.go
@@ -422,7 +422,7 @@ func (p *Plugin) handleInteractionCreate(evt *eventsystem.EventData) (retry bool
 	errorResponse := &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
-			Content: "Something went wrong when running this command, either discord or the bot may be having issues.",
+			Content: "Something went wrong when running this ticket interaction, either discord or the bot may be having issues.",
 			Flags:   discordgo.MessageFlagsEphemeral,
 		},
 	}

--- a/tickets/tickets_bot.go
+++ b/tickets/tickets_bot.go
@@ -445,10 +445,14 @@ func (p *Plugin) handleInteractionCreate(evt *eventsystem.EventData) (retry bool
 
 	respErr := common.BotSession.CreateInteractionResponse(ic.ID, ic.Token, response)
 	if respErr != nil {
-		common.BotSession.CreateFollowupMessage(ic.ApplicationID, ic.Token, &discordgo.WebhookParams{
+		// try again as a followup, if that still fails, return the original error
+		_, followupErr := common.BotSession.CreateFollowupMessage(ic.ApplicationID, ic.Token, &discordgo.WebhookParams{
 			Content: response.Data.Content,
 			Flags:   int64(response.Data.Flags),
 		})
+		if followupErr != nil {
+			return bot.CheckDiscordErrRetry(respErr), respErr
+		}
 	}
 	return false, err
 }

--- a/tickets/tickets_bot.go
+++ b/tickets/tickets_bot.go
@@ -263,6 +263,7 @@ func handleButton(evt *eventsystem.EventData, interaction discordgo.MessageCompo
 						Components: []discordgo.MessageComponent{discordgo.TextInput{
 							CustomID:  "reason",
 							Label:     "Reason for opening",
+							Style:     discordgo.TextInputShort,
 							Required:  true,
 							MaxLength: 90,
 						}},
@@ -305,6 +306,7 @@ func handleButton(evt *eventsystem.EventData, interaction discordgo.MessageCompo
 					Components: []discordgo.MessageComponent{discordgo.TextInput{
 						CustomID:  "reason",
 						Label:     "Reason for closing",
+						Style:     discordgo.TextInputShort,
 						Required:  true,
 						MaxLength: 90,
 					}},

--- a/tickets/tickets_commands.go
+++ b/tickets/tickets_commands.go
@@ -319,6 +319,7 @@ func (p *Plugin) AddCommands() {
 					}
 					return ""
 				})
+				reason = strings.TrimSpace(reason)
 
 				if common.ContainsStringSlice(usedReasons, reason) {
 					return "You may not use the exact same reason on multiple buttons", nil

--- a/tickets/tickets_commands.go
+++ b/tickets/tickets_commands.go
@@ -270,10 +270,10 @@ func (p *Plugin) AddCommands() {
 		Name:            "MenuCreate",
 		Aliases:         []string{"mc"},
 		Description:     "Creates a menu with buttons to open tickets.",
-		LongDescription: "Creates and sends a message with buttons allowing users to open tickets, optionally with predefined reasons.\n\nInstead of creating a new message, attach it to another message the bot has sent with `-message bot-message-id-here`. This __must__ be a message the bot has sent.\nCreate buttons with up to 9 predefined reasons with `-button-1 \"Reason for button 1\"`, `-button-2 \"Reason for button 2\"`, etc.\nIf using predefined reason buttons, you may optionally disable the custom reason button with `-custom false`.",
+		LongDescription: "Creates and sends a message with buttons allowing users to open tickets, optionally with predefined reasons.\n\nInstead of creating a new message, attach it to another message the bot has sent with `-message bot-message-id-here`. This __must__ be a message the bot has sent.\nCreate buttons with up to 9 predefined reasons with `-button-1 \"Reason for button 1\"`, `-button-2 \"Reason for button 2\"`, etc.\nIf using predefined reason buttons, you may optionally disable the custom reason button with `-disable-custom`.",
 		ArgSwitches: []*dcmd.ArgDef{
 			{Name: "message", Help: "ID to attach menu to", Type: dcmd.BigInt},
-			{Name: "custom", Help: "Enable Cutsom Reason button", Default: true},
+			{Name: "disable-custom", Help: "Disable Cutsom Reason button", Default: false},
 			{Name: "button-1", Help: "Predefined reason for button 1", Type: dcmd.String},
 			{Name: "button-2", Help: "Predefined reason for button 2", Type: dcmd.String},
 			{Name: "button-3", Help: "Predefined reason for button 3", Type: dcmd.String},
@@ -309,7 +309,7 @@ func (p *Plugin) AddCommands() {
 				usedReasons = append(usedReasons, arg.Str())
 			}
 
-			if len(components) == 0 || parsed.Switches["custom"].Bool() {
+			if len(components) == 0 || !parsed.Switches["disable-custom"].Bool() {
 				label := "Create a Ticket"
 				if len(components) > 0 {
 					label = "Custom Reason"

--- a/tickets/tickets_commands.go
+++ b/tickets/tickets_commands.go
@@ -286,9 +286,9 @@ func (p *Plugin) AddCommands() {
 		},
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 			var components []discordgo.MessageComponent
-			for i := 1; i <= 10; i++ {
+			for i := 1; i < 10; i++ {
 				arg := parsed.Switches["button-"+strconv.Itoa(i)]
-				if arg == nil {
+				if arg.Value == nil {
 					continue
 				}
 				if len(arg.Str()) > 85 {

--- a/tickets/tickets_commands.go
+++ b/tickets/tickets_commands.go
@@ -288,7 +288,7 @@ func (p *Plugin) AddCommands() {
 			var components []discordgo.MessageComponent
 			for i := 1; i <= 10; i++ {
 				arg := parsed.Switches["button-"+strconv.Itoa(i)]
-				if arg.Value == nil {
+				if arg == nil {
 					continue
 				}
 				if len(arg.Str()) > 85 {

--- a/tickets/tickets_commands.go
+++ b/tickets/tickets_commands.go
@@ -292,7 +292,7 @@ func (p *Plugin) AddCommands() {
 					continue
 				}
 				if len(arg.Str()) > 85 {
-					return fmt.Sprintf("Reason for button %d too long; must be max 85 characters."), nil
+					return fmt.Sprintf("Reason for button %d too long; must be max 85 characters.", i), nil
 				}
 				label := arg.Str()
 				if len(label) > 80 {

--- a/tickets/tickets_commands.go
+++ b/tickets/tickets_commands.go
@@ -397,7 +397,7 @@ func (p *Plugin) AddCommands() {
 	container.AddCommand(cmdRenameTicket, cmdRenameTicket.GetTrigger().SetMiddlewares(RequireActiveTicketMW))
 	container.AddCommand(cmdCloseTicket, cmdCloseTicket.GetTrigger().SetMiddlewares(RequireActiveTicketMW))
 	container.AddCommand(cmdAdminsOnly, cmdAdminsOnly.GetTrigger().SetMiddlewares(RequireActiveTicketMW))
-	container.AddCommand(cmdMenuCreate, cmdMenuCreate.GetTrigger().SetMiddlewares(RequireActiveTicketMW))
+	container.AddCommand(cmdMenuCreate, cmdMenuCreate.GetTrigger().SetMiddlewares(ProhibitActiveTicketMW))
 
 	commands.RegisterSlashCommandsContainer(container, false, TicketCommandsRolesRunFuncfunc)
 }
@@ -423,7 +423,17 @@ func TicketCommandsRolesRunFuncfunc(gs *dstate.GuildSet) ([]int64, error) {
 func RequireActiveTicketMW(inner dcmd.RunFunc) dcmd.RunFunc {
 	return func(data *dcmd.Data) (interface{}, error) {
 		if data.Context().Value(CtxKeyCurrentTicket) == nil {
-			return "This command can only be ran in a active ticket", nil
+			return "This command can only be run in a active ticket", nil
+		}
+
+		return inner(data)
+	}
+}
+
+func ProhibitActiveTicketMW(inner dcmd.RunFunc) dcmd.RunFunc {
+	return func(data *dcmd.Data) (interface{}, error) {
+		if data.Context().Value(CtxKeyCurrentTicket) != nil {
+			return "This command cannot be run in a active ticket", nil
 		}
 
 		return inner(data)

--- a/tickets/tickets_commands.go
+++ b/tickets/tickets_commands.go
@@ -298,7 +298,7 @@ func (p *Plugin) AddCommands() {
 				}
 
 				reason := arg.Str()
-				var emoji *discordgo.ComponentEmoji
+				emoji := &discordgo.ComponentEmoji{}
 				reason = regexp.MustCompile(emojiRegex).ReplaceAllStringFunc(reason, func(match string) string {
 					// <:ye:733037741532643428>
 					customEmojiParts := strings.Split(match, ":")

--- a/tickets/tickets_commands.go
+++ b/tickets/tickets_commands.go
@@ -270,7 +270,7 @@ func (p *Plugin) AddCommands() {
 		Name:            "MenuCreate",
 		Aliases:         []string{"mc"},
 		Description:     "Creates a menu with buttons to open tickets.",
-		LongDescription: "Creates and sends a message with buttons allowing users to open tickets, optionally with predefined reasons.\n\nInstead of creating a new message, attach it to another message the bot has sent with `-message bot-message-id-here`. This __must__ be a message the bot has sent.\nCreate buttons with up to 9 predefined reasons with `\"-button-1 Reason for button 1\"`, `\"-button-2 Reason for button 2\"`, etc.\nIf using predefined reason buttons, you may optionally disable the custom reason button with `-custom false`.",
+		LongDescription: "Creates and sends a message with buttons allowing users to open tickets, optionally with predefined reasons.\n\nInstead of creating a new message, attach it to another message the bot has sent with `-message bot-message-id-here`. This __must__ be a message the bot has sent.\nCreate buttons with up to 9 predefined reasons with `-button-1 \"Reason for button 1\"`, `-button-2 \"Reason for button 2\"`, etc.\nIf using predefined reason buttons, you may optionally disable the custom reason button with `-custom false`.",
 		ArgSwitches: []*dcmd.ArgDef{
 			{Name: "message", Help: "ID to attach menu to", Type: dcmd.BigInt},
 			{Name: "custom", Help: "Enable Cutsom Reason button", Default: true},

--- a/tickets/tickets_commands.go
+++ b/tickets/tickets_commands.go
@@ -286,6 +286,7 @@ func (p *Plugin) AddCommands() {
 		},
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 			var components []discordgo.MessageComponent
+			var usedReasons []string
 			for i := 1; i < 10; i++ {
 				arg := parsed.Switches["button-"+strconv.Itoa(i)]
 				if arg.Value == nil {
@@ -293,6 +294,9 @@ func (p *Plugin) AddCommands() {
 				}
 				if len(arg.Str()) > 85 {
 					return fmt.Sprintf("Reason for button %d too long; must be max 85 characters.", i), nil
+				}
+				if common.ContainsStringSlice(usedReasons, arg.Str()) {
+					return "You may not use the exact same reason on multiple buttons", nil
 				}
 				label := arg.Str()
 				if len(label) > 80 {
@@ -302,6 +306,7 @@ func (p *Plugin) AddCommands() {
 					Label:    label,
 					CustomID: "tickets-open-" + arg.Str(),
 				})
+				usedReasons = append(usedReasons, arg.Str())
 			}
 
 			if len(components) == 0 || parsed.Switches["custom"].Bool() {

--- a/tickets/tickets_commands.go
+++ b/tickets/tickets_commands.go
@@ -317,6 +317,7 @@ func (p *Plugin) AddCommands() {
 				customButton := discordgo.Button{
 					Label:    label,
 					CustomID: "tickets-open-",
+					Style:    discordgo.SecondaryButton,
 				}
 				components = append([]discordgo.MessageComponent{customButton}, components...)
 			}
@@ -333,6 +334,9 @@ func (p *Plugin) AddCommands() {
 				message, err := common.BotSession.ChannelMessage(parsed.ChannelID, parsed.Switches["message"].Int64())
 				if err != nil {
 					return nil, err
+				}
+				if message.Author.ID != common.BotUser.ID {
+					return "You must select a message that YAGPDB has sent.", nil
 				}
 
 				_, err = common.BotSession.ChannelMessageEditComplex(&discordgo.MessageEdit{


### PR DESCRIPTION
Adds optional buttons which server admins can use on their server for opening and closing tickets.

- Add a new command to create a ticket menu
    - By default, sends a standard message with a button allowing users to fill out a modal for their reason. Then
opens the ticket with that reason.
    - With the `-message` switch, can instead append the buttons to another message sent by the bot.
    - Can preset up to 9 reasons in separate buttons with switches. These buttons open with the set reason
instead of prompting the user via modal.
    - If preset reasons are used, can set the `-disable-custom` switch to disable the custom reason button, only
allowing users to open with the preset reasons.

- Add new ticket config to append "Close" and/or "Close with Reason" buttons to a ticket opener message.
    - Close with reason sends a modal to prompt the user to specify the reason
    - Scalable to allow adding more in-ticket buttons in the future (add/remove user, join/leave ticket, etc.)

Signed-off-by: SoggySaussages <vmdmaharaj@gmail.com>

<img width="621" alt="Screenshot 2024-12-08 at 00 45 18" src="https://github.com/user-attachments/assets/446a7833-3819-4f9f-a131-e7ba6a1ed579">

<img width="468" alt="Screenshot 2024-12-08 at 00 38 57" src="https://github.com/user-attachments/assets/a66ca0fa-0d65-4350-b2a0-34ee48218ab7">

<img width="578" alt="Screenshot 2024-12-08 at 00 39 22" src="https://github.com/user-attachments/assets/7d95585f-3191-4717-837d-2ee721a75a3b">

<img width="324" alt="Screenshot 2024-12-08 at 00 45 47" src="https://github.com/user-attachments/assets/3c27fce9-ae5f-445b-915d-98467a5e54bf">

<img width="335" alt="Screenshot 2024-12-08 at 00 46 28" src="https://github.com/user-attachments/assets/a64c41da-76e9-43cd-ba80-8eb90ddc57a1">