### PR TITLE
refact(reddit): Clean up subreddit name processing

### DIFF
--- a/reddit/assets/reddit.html
+++ b/reddit/assets/reddit.html
@@ -46,7 +46,7 @@
             score of above 10 after 15 minutes, it will be posted in your discord
             {{else}}<b>Fast</b> feeds are 1 minute behind and you can't apply upvote filters to them, use the slow feed
             for that.{{end}}</p>
-        <p>The subreddit field is just the name of the subreddit (no /r/ in front of it), examples: "games",
+        <p>The subreddit field is just the name of the subreddit (not the URL), examples: "games",
             "multicopter"</p>
         <p><b>If Server Channel is set to "None" the added or already active Reddit feed will be disabled.</b></p>
     </div>

--- a/reddit/plugin_web.go
+++ b/reddit/plugin_web.go
@@ -261,7 +261,7 @@ func HandleRemove(w http.ResponseWriter, r *http.Request) interface{} {
 
 	go cplogs.RetryAddEntry(web.NewLogEntryFromContext(r.Context(), panelLogKeyRemovedFeed, &cplogs.Param{Type: cplogs.ParamTypeString, Value: item.Subreddit}))
 	go pubsub.Publish("reddit_clear_subreddit_cache", -1, PubSubSubredditEventData{
-		Subreddit: strings.ToLower(strings.TrimSpace(item.Subreddit)),
+		Subreddit: item.Subreddit,
 		Slow:      item.Slow,
 	})
 

--- a/reddit/plugin_web.go
+++ b/reddit/plugin_web.go
@@ -139,10 +139,7 @@ func HandleNew(w http.ResponseWriter, r *http.Request) interface{} {
 	subreddit := strings.TrimSpace(newElem.Subreddit)
 	subreddit = strings.ToLower(subreddit)
 	subreddit = strings.TrimPrefix(subreddit, "/")
-
-	for ; strings.HasPrefix(subreddit, "r/"); {
-		subreddit = strings.TrimPrefix(subreddit, "r/")
-	}
+	subreddit = strings.TrimPrefix(subreddit, "r/")
 
 	watchItem := &models.RedditFeed{
 		GuildID:         activeGuild.ID,

--- a/reddit/plugin_web.go
+++ b/reddit/plugin_web.go
@@ -217,7 +217,7 @@ func HandleModify(w http.ResponseWriter, r *http.Request) interface{} {
 
 	go cplogs.RetryAddEntry(web.NewLogEntryFromContext(r.Context(), panelLogKeyUpdatedFeed, &cplogs.Param{Type: cplogs.ParamTypeString, Value: item.Subreddit}))
 	go pubsub.Publish("reddit_clear_subreddit_cache", -1, PubSubSubredditEventData{
-		Subreddit: strings.ToLower(strings.TrimSpace(item.Subreddit)),
+		Subreddit: item.Subreddit,
 		Slow:      item.Slow,
 	})
 


### PR DESCRIPTION
Users prefixing their input with r/ when adding Reddit feeds,
has been a persistent issue, enough to the point it had a dedicated note
on the config. page in the control panel.

This PR initially intended to address exclusively this issue,
by adding behaviour to strip leading instances of /r/
from inputs provided when adding subreddit feeds,
but also discovered the functions handling modifying
and removing these feeds, seemed to be performing redundant work
processing the subreddit names, when this work was already performed
when creating the feed.

Consequently, this PR also removes these redundant function calls,
cleaning up the handling of subreddit names in general.