### PR TITLE
Update `roast` embed

### DIFF
--- a/stdcommands/roast/roast.go
+++ b/stdcommands/roast/roast.go
@@ -20,16 +20,20 @@ var Command = &commands.YAGCommand{
 	DefaultEnabled:      true,
 	SlashCommandEnabled: true,
 	RunFunc: func(data *dcmd.Data) (interface{}, error) {
-		target := "a random person nearby"
-		description := fmt.Sprintf(`## %s`, html.UnescapeString(randomRoast()))
-		if data.Args[0].Value != nil {
-			target = data.Args[0].Value.(*discordgo.User).Username
-			description = fmt.Sprintf(`## Hey %s, %s`, target, html.UnescapeString(randomRoast()))
+		roast := html.UnescapeString(randomRoast())
+		embed := &discordgo.MessageEmbed{
+			Title: data.Author.Username + " roasted ",
+			Footer: &discordgo.MessageEmbedFooter {Text: "Boom, roasted!"},
 		}
-		embed := &discordgo.MessageEmbed{}
-		embed.Title = fmt.Sprintf(`%s roasted %s`, data.Author.Username, target)
-		embed.Description = description
-		embed.Footer = &discordgo.MessageEmbedFooter{Text: "Boom, roasted!"}
+		if arg0 := data.Args[0].Value; arg0 != nil {
+			target := arg0.(*discordgo.User)
+			embed.Title += target.Username
+			embed.Description = fmt.Sprintf(`## Hey %s, %s`, target.Mention(), roast)
+		} else {
+			embed.Title += "a random person nearby"
+			embed.Description = "## " + roast
+		}
+
 		return embed, nil
 	},
 }

--- a/stdcommands/roast/roast.go
+++ b/stdcommands/roast/roast.go
@@ -27,6 +27,7 @@ var Command = &commands.YAGCommand{
 		embed := &discordgo.MessageEmbed{}
 		embed.Title = fmt.Sprintf(`%s roasted %s`, data.Author.Username, target)
 		embed.Description = html.UnescapeString(randomRoast())
+		embed.Footer = &discordgo.MessageEmbedFooter{Text: "Boom, roasted!"}
 		return embed, nil
 	},
 }

--- a/stdcommands/roast/roast.go
+++ b/stdcommands/roast/roast.go
@@ -21,12 +21,14 @@ var Command = &commands.YAGCommand{
 	SlashCommandEnabled: true,
 	RunFunc: func(data *dcmd.Data) (interface{}, error) {
 		target := "a random person nearby"
+		description := fmt.Sprintf(`## %s`, html.UnescapeString(randomRoast()))
 		if data.Args[0].Value != nil {
 			target = data.Args[0].Value.(*discordgo.User).Username
+			description = fmt.Sprintf(`## Hey %s, %s`, target, html.UnescapeString(randomRoast()))
 		}
 		embed := &discordgo.MessageEmbed{}
 		embed.Title = fmt.Sprintf(`%s roasted %s`, data.Author.Username, target)
-		embed.Description = html.UnescapeString(randomRoast())
+		embed.Description = description
 		embed.Footer = &discordgo.MessageEmbedFooter{Text: "Boom, roasted!"}
 		return embed, nil
 	},


### PR DESCRIPTION
This PR adds a footer text of `Boom, roasted!` to the embed output of the `-roast` command. 
This PR also changes the roast text to be bold, and, if a user was tagged in the command initiation, adds their username to the roast text as well.

![Discord_OA2uQKnyPL](https://github.com/user-attachments/assets/ad235608-3bb6-4985-9aaa-7d553074e541)
