### PR TITLE
Add `suppressEmbeds` and `unsuppressEmbeds` functions for CC

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -657,6 +657,8 @@ func baseContextFuncs(c *Context) {
 	c.addContextFunc("publishMessage", c.tmplPublishMessage)
 	c.addContextFunc("publishResponse", c.tmplPublishResponse)
 	c.addContextFunc("unpinMessage", c.tmplPinMessage(true))
+	c.addContextFunc("suppressEmbeds", c.tmplSuppressEmbeds(true))
+	c.addContextFunc("unsuppressEmbeds", c.tmplSuppressEmbeds(false))
 
 	// Message send functions
 	c.addContextFunc("sendDM", c.tmplSendDM)

--- a/frontend/static/js/yagFuncs.js
+++ b/frontend/static/js/yagFuncs.js
@@ -205,4 +205,6 @@ var yagFuncs = {
   dbBottomEntries: true,
   dbCount: true,
   dbRank: true,
+  suppressEmbeds: true,
+  unsuppressEmbeds: true,
 };

--- a/lib/template/parse/parse_test.go
+++ b/lib/template/parse/parse_test.go
@@ -800,4 +800,6 @@ var funcs = map[string]interface{}{
 	"userArg":                   func() interface{} { return nil },
 	"verb":                      func() interface{} { return nil },
 	"weekNumber":                func() interface{} { return nil },
+	"suppressEmbeds":            func() interface{} { return nil },
+	"unsuppressEmbeds":          func() interface{} { return nil },
 }


### PR DESCRIPTION
These functions enable the suppressing of embeds on messages not sent by YAGPDB via the [SUPPRESS_EMBEDS](https://discord.com/developers/docs/resources/message#message-object-message-flags) flag.

The implementation should be functional if not for the bug discussed in https://github.com/bwmarrin/discordgo/issues/1484 which is patched in https://github.com/bwmarrin/discordgo/pull/1483/. Discussion in the Discord was split on whether it is best to implement that solution in YAGPDB's discordgo library or to create an entirely new restapi function `ChannelMessageEditFlags` that handles specifically editing only flags. Look around [here](https://discord.com/channels/166207328570441728/384011387132706816/1316820207095906426) if context is wanted.

There has also been discussion of whether this should be part of `complexMessageEdit`, but little of a consensus, so it so far not.