### PR TITLE
Change the unknown user to remove the # on unknown user

### DIFF
--- a/bot/util.go
+++ b/bot/util.go
@@ -411,6 +411,7 @@ func GetUsers(guildID int64, ids ...int64) []*discordgo.User {
 		if err != nil {
 			logger.WithError(err).WithField("guild", guildID).Error("failed retrieving user from api")
 			resp = append(resp, &discordgo.User{
+				Discriminator: "0",
 				ID:       id,
 				Username: "Unknown (" + strconv.FormatInt(id, 10) + ")",
 			})


### PR DESCRIPTION
With the default behavior for the discordgo.User .String() method, that don't show the # if u.Discriminator == "0"