### PR TITLE
moderation: revert removal of report ephemeral

### DIFF
--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -583,7 +583,7 @@ var ModerationCommands = []*commands.YAGCommand{
 		},
 		SlashCommandEnabled: true,
 		DefaultEnabled:      false,
-		IsResponseEphemeral: false,
+		IsResponseEphemeral: true,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 			config, _, err := MBaseCmd(parsed, 0)
 			if err != nil {


### PR DESCRIPTION
Report should always be ephemeral for privacy of the reporter. 

Signed-off-by: SoggySaussages <vmdmaharaj@gmail.com>