### PR TITLE
cc/cron: fix blacklist issues

### DIFF
--- a/customcommands/assets/customcommands-editcmd.html
+++ b/customcommands/assets/customcommands-editcmd.html
@@ -103,7 +103,7 @@
                                                 <option value="modal" {{if eq .CC.TriggerType 8}} selected{{end}}>
                                                     Modal Submission</option>
                                                 <option value="cron" {{ if eq .CC.TriggerType 9}} selected{{end}}>
-                                                    Crontab (ALPHA)</option>
+                                                    Crontab (Beta)</option>
                                             </select>
                                         </div>
                                     </div>

--- a/customcommands/interval.go
+++ b/customcommands/interval.go
@@ -82,8 +82,15 @@ func CalcNextRunTime(cc *models.CustomCommand, now time.Time) time.Time {
 				newDaysScheduledBitset = newDaysScheduledBitset | dayOfWeekBitVal
 			}
 		}
+
+		if newHoursScheduledBitset != (1<<hoursInADay)-1 { // if all hours set, leave as is to distinguish between "0,1,2...,23" and "*"
 		specSchedule.Hour = newHoursScheduledBitset
+		}
+
+		if newDaysScheduledBitset != (1<<daysInAWeek)-1 { // if all days set, leave as is to distinguish between "0,1,2...,6" and "*"
 		specSchedule.Dow = newDaysScheduledBitset
+		}
+
 		if specSchedule.Hour == 0 || specSchedule.Dow == 0 {
 			// this can never run
 			return time.Time{}

--- a/customcommands/interval.go
+++ b/customcommands/interval.go
@@ -113,12 +113,16 @@ func CalcNextRunTime(cc *models.CustomCommand, now time.Time) time.Time {
 			return time.Time{}
 		}
 
-		timeNext := specSchedule.Next(now.UTC())
-		for common.ContainsInt64Slice(cc.TimeTriggerExcludingDays, int64(timeNext.Weekday())) {
+		timeNext := now.UTC()
+		for i := 0; i < 200; i++ {
 			// alternative method if month/dom are configured but dow isn't. in
 			// the lucky scenarios where it's calculated right on the first
 			// try, this won't need to loop.
 			timeNext = specSchedule.Next(timeNext)
+			timeNextWeekdayIsBlacklisted := common.ContainsInt64Slice(cc.TimeTriggerExcludingDays, int64(timeNext.Weekday()))
+			if !timeNextWeekdayIsBlacklisted {
+				break
+			}
 		}
 		tNext = timeNext
 	}

--- a/customcommands/interval.go
+++ b/customcommands/interval.go
@@ -77,7 +77,6 @@ func CalcNextRunTime(cc *models.CustomCommand, now time.Time) time.Time {
 		}
 		monthOrDomConfigured := specSchedule.Month&(1<<63) == 0 || specSchedule.Dom&(1<<63) == 0
 		dowConfigured := specSchedule.Dow&(1<<63) == 0
-		logger.Info(monthOrDomConfigured, dowConfigured)
 
 		// if month/dom and dow are both configured, cron will process them
 		// using OR. If user didn't want that, they wouldn't set both in
@@ -87,13 +86,11 @@ func CalcNextRunTime(cc *models.CustomCommand, now time.Time) time.Time {
 		// this behaviour in their expression. For this reason, we only use
 		// the below method if month/dom aren't configured, or if week is.
 		skipBlacklistCheck := monthOrDomConfigured && !dowConfigured
-		logger.Info(skipBlacklistCheck)
 
 		for dayOfWeek := range daysInAWeek {
 			dayOfWeekBitVal := uint64(1) << dayOfWeek
 			dayPresentInSchedule := specSchedule.Dow&dayOfWeekBitVal != 0
 			if dayPresentInSchedule && (skipBlacklistCheck || !common.ContainsInt64Slice(cc.TimeTriggerExcludingDays, int64(dayOfWeek))) {
-				logger.Info("adding ", dayOfWeek)
 				newDaysScheduledBitset = newDaysScheduledBitset | dayOfWeekBitVal
 			}
 		}
@@ -112,13 +109,11 @@ func CalcNextRunTime(cc *models.CustomCommand, now time.Time) time.Time {
 		}
 
 		timeNext := specSchedule.Next(now.UTC())
-		logger.Info(timeNext)
 		for common.ContainsInt64Slice(cc.TimeTriggerExcludingDays, int64(timeNext.Weekday())) {
 			// alternative method if month/dom are configured but dow isn't. in
 			// the lucky scenarios where it's calculated right on the first
 			// try, this won't need to loop.
 			timeNext = specSchedule.Next(timeNext)
-			logger.Info(timeNext)
 		}
 		tNext = timeNext
 	}

--- a/customcommands/interval_test.go
+++ b/customcommands/interval_test.go
@@ -40,7 +40,7 @@ func TestNextRunTimeBasic(t *testing.T) {
 	expected = tim.UTC().Add(time.Minute * 5)
 
 	if next != expected {
-		t.Error("incorrect next run, should be: ", expected, ", got: ", nextRun)
+		t.Error("incorrect next run, should be: ", expected, ", got: ", next)
 	}
 }
 
@@ -138,6 +138,31 @@ func TestNextRunTimeExcludingHours(t *testing.T) {
 	if nextRun != expected {
 		t.Error("next run should be now: ", expected, ", got: ", nextRun)
 	}
+
+	cc.TextTrigger = "0 * 2 * *"
+	nextRun = CalcNextRunTime(cc, tim)
+	expected = tim.UTC().Add(time.Hour * 26)
+
+	if nextRun != expected {
+		t.Error("incorrect next run, should be: ", expected, ", got: ", nextRun)
+	}
+
+	cc.TextTrigger = "0 * * 2 *"
+	nextRun = CalcNextRunTime(cc, tim)
+	expected = time.Date(1, 2, 1, 2, 0, 0, 0, time.UTC)
+
+	if nextRun != expected {
+		t.Error("incorrect next run, should be: ", expected, ", got: ", nextRun)
+	}
+
+	cc.TextTrigger = "0 * * * 2"
+
+	nextRun = CalcNextRunTime(cc, tim)
+	expected = tim.UTC().Add(time.Hour * 26)
+
+	if nextRun != expected {
+		t.Error("incorrect next run, should be: ", expected, ", got: ", nextRun)
+	}
 }
 
 func TestNextRunTimeExcludingDays(t *testing.T) {
@@ -166,6 +191,34 @@ func TestNextRunTimeExcludingDays(t *testing.T) {
 
 	if nextRun != expected {
 		t.Error("next run should be now: ", expected, ", got: ", nextRun)
+	}
+
+	cc.TimeTriggerExcludingDays = append(cc.TimeTriggerExcludingDays, 2)
+	cc.TextTrigger = "0 * 2,3 * *"
+	nextRun = CalcNextRunTime(cc, tim)
+	expected = tim.UTC().Add(time.Hour * 48)
+
+	if nextRun != expected {
+		t.Error("incorrect next run, should be: ", expected, ", got: ", nextRun)
+	}
+
+	cc.TimeTriggerExcludingDays = []int64{4}
+	cc.TextTrigger = "0 * 1 2,3,4 *"
+	nextRun = CalcNextRunTime(cc, tim)
+	expected = time.Date(1, 4, 1, 0, 0, 0, 0, time.UTC)
+
+	if nextRun != expected {
+		t.Error("incorrect next run, should be: ", expected, ", got: ", nextRun)
+	}
+
+	cc.TimeTriggerExcludingDays = []int64{2}
+	cc.TextTrigger = "0 * * * 2,3"
+
+	nextRun = CalcNextRunTime(cc, tim)
+	expected = tim.UTC().Add(time.Hour * 48)
+
+	if nextRun != expected {
+		t.Error("incorrect next run, should be: ", expected, ", got: ", nextRun)
 	}
 }
 
@@ -198,5 +251,65 @@ func TestNextRunTimeExcludingDaysHours(t *testing.T) {
 
 	if nextRun != expected {
 		t.Errorf("next run should be: %s (w:%d) got %s (w:%d - %d)", expected, expected.Weekday(), nextRun, int(nextRun.Weekday()), nextRun.Hour())
+	}
+
+	cc.TimeTriggerExcludingDays = append(cc.TimeTriggerExcludingDays, 2)
+	cc.TextTrigger = "0 * 1,2,3 * *"
+	nextRun = CalcNextRunTime(cc, tim)
+	expected = tim.UTC().Add(time.Hour * 47)
+
+	if nextRun != expected {
+		t.Error("incorrect next run, should be: ", expected, ", got: ", nextRun)
+	}
+
+	cc.TimeTriggerExcludingDays = []int64{4}
+	cc.TextTrigger = "0 * 1 1,2,3,4 *"
+	nextRun = CalcNextRunTime(cc, tim)
+	expected = time.Date(1, 4, 1, 1, 0, 0, 0, time.UTC)
+
+	if nextRun != expected {
+		t.Error("incorrect next run, should be: ", expected, ", got: ", nextRun)
+	}
+
+	cc.TimeTriggerExcludingDays = []int64{2}
+	cc.TextTrigger = "0 * * * 1,2,3"
+
+	nextRun = CalcNextRunTime(cc, tim)
+	expected = tim.UTC().Add(time.Hour * 47)
+
+	if nextRun != expected {
+		t.Error("incorrect next run, should be: ", expected, ", got: ", nextRun)
+	}
+}
+
+func TestNextRunTimeSpecific(t *testing.T) {
+	cc := &models.CustomCommand{
+		TriggerType: int(CommandTriggerCron),
+	}
+
+	tim := time.Time{}
+	cc.TextTrigger = "0 * 2 * *"
+	nextRun := CalcNextRunTime(cc, tim)
+	expected := tim.UTC().Add(time.Hour * 24)
+
+	if nextRun != expected {
+		t.Error("incorrect next run, should be: ", expected, ", got: ", nextRun)
+	}
+
+	cc.TextTrigger = "0 * * 2 *"
+	nextRun = CalcNextRunTime(cc, tim)
+	expected = time.Date(1, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	if nextRun != expected {
+		t.Error("incorrect next run, should be: ", expected, ", got: ", nextRun)
+	}
+
+	cc.TextTrigger = "0 * * * 2"
+
+	nextRun = CalcNextRunTime(cc, tim)
+	expected = tim.UTC().Add(time.Hour * 24)
+
+	if nextRun != expected {
+		t.Error("incorrect next run, should be: ", expected, ", got: ", nextRun)
 	}
 }


### PR DESCRIPTION
The hour/day blacklists were causing difficulties, these fixes address those issues and add more thorough tests for 
cron.

Currently, cron parse parses a \* in hours the same as 0,1,2...,23, and similar for dow. This poses an issue since
0,1,2...,23 != \*. Now if all hours/dows are set, the parse will leave the input unchanged rather than forcing "\*"s to
"0,1,2...23"s.

If month/dom and dow are both configured, cron will process them using OR. If user didn't want that, they wouldn't set
both in the expression. but if using day of week blacklist, in the way we do it currently that would configure it, and
then cron would use OR and mess up the user's schedule if they explicitly avoided this behaviour in their expression.
For this reason, this commit now only uses the existing method if month/dom aren't configured, or if week is. Otherwise
it will loop recalculation of cron schedule until a new time is found which satisfies the dow blacklist.

Signed-off-by: SoggySaussages <vmdmaharaj@gmail.com>