### PR TITLE
moderation: Clarify warning ID command args.

### DIFF
--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -1003,7 +1003,7 @@ var ModerationCommands = []*commands.YAGCommand{
 		Description:   "Deletes a warning, id is the first number of each warning from the warnings command",
 		RequiredArgs:  1,
 		Arguments: []*dcmd.ArgDef{
-			{Name: "Id", Type: dcmd.Int},
+			{Name: "WarningId", Type: dcmd.Int},
 			{Name: "Reason", Type: dcmd.String},
 		},
 		RequiredDiscordPermsHelp: "ManageMessages or ManageGuild",

--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -961,7 +961,7 @@ var ModerationCommands = []*commands.YAGCommand{
 		Description:   "Edit a warning, id is the first number of each warning from the warnings command",
 		RequiredArgs:  2,
 		Arguments: []*dcmd.ArgDef{
-			{Name: "Id", Type: dcmd.Int},
+			{Name: "WarningId", Type: dcmd.Int},
 			{Name: "NewMessage", Type: dcmd.String},
 		},
 		RequiredDiscordPermsHelp: "ManageMessages or ManageGuild",


### PR DESCRIPTION
Users have expressed continual confusion regarding the type of ID
they should be using with the `-delwarning` command.
This commit should help rectify this to a degree.

Whilst less common, `-editwarning` uses the same naming scheme
for it's ID argument, and this will also update it accordingly
for a similar reason, even if it encounters complaints less frequently.