### PR TITLE
(Suggestion) Removing the default higher role for rolecommand panel

### DIFF
--- a/rolecommands/assets/rolecommands.html
+++ b/rolecommands/assets/rolecommands.html
@@ -58,7 +58,7 @@
                                             <label for="new-role-command-role">Role</label>
                                             <select class="form-control" name="Role" id="new-role-command-role"
                                                 onchange="rolecmdRoleDropdownChanged()">
-                                                {{roleOptions .ActiveGuild.Roles .HighestRole}}
+                                                {{roleOptions .ActiveGuild.Roles .HighestRole 0 "Select a role"}}
                                             </select>
                                         </div>
                                     </div>


### PR DESCRIPTION
(mb for the branch)
[Following this suggestion (✅`9` vs ❎`2` )](https://discord.com/channels/166207328570441728/356486960417734666/957040017539215361)

Just added in webTemplate


Suggestion: 
```In Role Commands, the "default" role / the role set before changing anything is set to the highest ranked manageable role. I think it would be better to either be set to "None," in which case you would not be able to save without setting one, or the lowest ranked manageable role to prevent accidents in cases where something like this (link expired) happens.```