### PR TITLE
util: try to fix link regex

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -26,7 +26,7 @@ import (
 func KeyGuild(guildID int64) string         { return "guild:" + discordgo.StrID(guildID) }
 func KeyGuildChannels(guildID int64) string { return "channels:" + discordgo.StrID(guildID) }
 
-var LinkRegex = regexp.MustCompile(`(?i)([a-z\d]+://)([\w\W_-]+(?:(?:\.[\w\W_-]+)+))([\w\W.,@?^=%&:/~+#-]*[\w\W@?^=%&/~+#-])`)
+var LinkRegex = regexp.MustCompile(`(?i)([a-z\d]+://)([\w-._~:/?#\[\]@!$&'()*+,;%=]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])`)
 var DomainFinderRegex = regexp.MustCompile(`(?i)(?:[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?\.)+[a-z\d][a-z\d-]{0,61}[a-z\d]`)
 var UGCHtmlPolicy = bluemonday.NewPolicy().AllowElements("h1", "h2", "h3", "h4", "h5", "h6", "p", "ol", "ul", "li", "dl", "dd", "dt", "blockquote", "table", "thead", "th", "tr", "td", "tbody", "del", "i", "b")
 var ForwardSlashReplacer = strings.NewReplacer("\\", "")


### PR DESCRIPTION
https://github.com/botlabs-gg/yagpdb/pull/1796 changed the link regex to catch URL-encoded links such as `https://%20@yagpdb.xyz`. Unfortunately, it caused a regression where text after the URL is matched. The new URL regex matches on the entirety of this text, *including the second line*:

```
https://yagpdb.xyz
and this is matched too!
```

We try to tune the regex so that it catches URL-encoded characters while avoiding the regression. The regex before #1796, after #1796, and after this PR is:

```
before #1796:    (?i)([a-z\d]+://)([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])
after #1796:     (?i)([a-z\d]+://)([\w\W_-]+(?:(?:\.[\w\W_-]+)+))([\w\W.,@?^=%&:/~+#-]*[\w\W@?^=%&/~+#-])
                                      ^^ added         ^^ added      ^^ added             ^^ added
this PR:         (?i)([a-z\d]+://)([\w-._~:/?#\[\]@!$&'()*+,;%=]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^ changed   ^^ reverted ^^ reverted        ^^ reverted
```
Explicitly, the problem from #1796 is that `\w` and `\W` together match on every character. We revert back to the old regex, but expand the character set in the second capturing group per https://stackoverflow.com/a/1547940 so that it still matches `https://%20@yagpdb.xyz`.