### PR TITLE
draft: premium: provide 3d grace period after slot removed

### DIFF
--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -683,7 +683,9 @@ func CCActionExecLimit(guildID int64) int {
 	return CCActionExecLimitNormal
 }
 
-func (p *Plugin) OnRemovedPremiumGuild(GuildID int64) error {
+var _ premium.PremiumGuildGracePeriodEndedListener = (*Plugin)(nil)
+
+func (p *Plugin) OnPremiumGuildGracePeriodEnded(GuildID int64) error {
 	commands, err := models.CustomCommands(qm.Where("guild_id = ?", GuildID), qm.Offset(MaxCommands)).AllG(context.Background())
 	if err != nil {
 		return errors.WrapIf(err, "failed getting custom commands")

--- a/customcommands/web.go
+++ b/customcommands/web.go
@@ -103,6 +103,7 @@ func (p *Plugin) InitWeb() {
 	getDBHandler := web.ControllerHandler(handleGetDatabase, "cp_custom_commands_database")
 
 	subMux := goji.SubMux()
+	subMux.Use(premium.GracePeriodEndingMiddleware("custom commands exceeding standard limits will be disabled"))
 	web.CPMux.Handle(pat.New("/customcommands"), subMux)
 	web.CPMux.Handle(pat.New("/customcommands/*"), subMux)
 	web.CPMux.Handle(pat.New("/customcommands/database"), subMux)

--- a/reddit/bot.go
+++ b/reddit/bot.go
@@ -9,6 +9,7 @@ import (
 	"github.com/botlabs-gg/yagpdb/v2/bot"
 	"github.com/botlabs-gg/yagpdb/v2/commands"
 	"github.com/botlabs-gg/yagpdb/v2/lib/dcmd"
+	"github.com/botlabs-gg/yagpdb/v2/premium"
 	"github.com/botlabs-gg/yagpdb/v2/reddit/models"
 	"github.com/botlabs-gg/yagpdb/v2/stdcommands/util"
 	"github.com/volatiletech/sqlboiler/v4/queries/qm"
@@ -27,7 +28,9 @@ func (p *Plugin) RemoveGuild(g int64) error {
 	return nil
 }
 
-func (p *Plugin) OnRemovedPremiumGuild(guildID int64) error {
+var _ premium.PremiumGuildGracePeriodEndedListener = (*Plugin)(nil)
+
+func (p *Plugin) OnPremiumGuildGracePeriodEnded(guildID int64) error {
 	logger.WithField("guild_id", guildID).Infof("Removed Excess Reddit Feeds")
 	feeds, err := models.RedditFeeds(qm.Where("guild_id = ? and disabled = ?", guildID, false), qm.Offset(GuildMaxFeedsNormal)).AllG(context.Background())
 

--- a/reddit/plugin_web.go
+++ b/reddit/plugin_web.go
@@ -14,6 +14,7 @@ import (
 	"github.com/botlabs-gg/yagpdb/v2/common/cplogs"
 	"github.com/botlabs-gg/yagpdb/v2/common/pubsub"
 	"github.com/botlabs-gg/yagpdb/v2/lib/discordgo"
+	"github.com/botlabs-gg/yagpdb/v2/premium"
 	"github.com/botlabs-gg/yagpdb/v2/reddit/models"
 	"github.com/botlabs-gg/yagpdb/v2/web"
 	"github.com/volatiletech/sqlboiler/v4/boil"
@@ -74,6 +75,7 @@ func (p *Plugin) InitWeb() {
 	redditMux.Use(web.RequireBotMemberMW)
 	redditMux.Use(web.RequirePermMW(discordgo.PermissionManageWebhooks))
 	redditMux.Use(baseData)
+	redditMux.Use(premium.GracePeriodEndingMiddleware("Reddit feeds exceeding standard limits will be disabled"))
 
 	redditMux.Handle(pat.Get("/"), web.RenderHandler(HandleReddit, "cp_reddit"))
 	redditMux.Handle(pat.Get(""), web.RenderHandler(HandleReddit, "cp_reddit"))

--- a/twitter/bot.go
+++ b/twitter/bot.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/botlabs-gg/yagpdb/v2/common/mqueue"
+	"github.com/botlabs-gg/yagpdb/v2/premium"
 	"github.com/botlabs-gg/yagpdb/v2/twitter/models"
 )
 
@@ -35,7 +36,9 @@ func (p *Plugin) DisableFeed(elem *mqueue.QueuedElement, err error) {
 	}
 }
 
-func (p *Plugin) OnRemovedPremiumGuild(guildID int64) error {
+var _ premium.PremiumGuildGracePeriodEndedListener = (*Plugin)(nil)
+
+func (p *Plugin) OnPremiumGuildGracePeriodEnded(guildID int64) error {
 	logger.WithField("guild_id", guildID).Infof("Removed Excess Twitter Feeds")
 	_, err := models.TwitterFeeds(models.TwitterFeedWhere.GuildID.EQ(int64(guildID))).UpdateAllG(context.Background(), models.M{"enabled": false})
 	if err != nil {

--- a/twitter/web.go
+++ b/twitter/web.go
@@ -54,6 +54,7 @@ func (p *Plugin) InitWeb() {
 	mux := goji.SubMux()
 	mux.Use(web.RequireBotMemberMW)
 	mux.Use(web.RequirePermMW(discordgo.PermissionManageWebhooks))
+	mux.Use(premium.GracePeriodEndingMiddleware("all Twitter feeds will be disabled"))
 	web.CPMux.Handle(pat.New("/twitter/*"), mux)
 	web.CPMux.Handle(pat.New("/twitter"), mux)
 

--- a/youtube/bot.go
+++ b/youtube/bot.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/botlabs-gg/yagpdb/v2/common"
 	"github.com/botlabs-gg/yagpdb/v2/lib/discordgo"
+	"github.com/botlabs-gg/yagpdb/v2/premium"
 	"github.com/botlabs-gg/yagpdb/v2/youtube/models"
 	"github.com/mediocregopher/radix/v3"
 	"github.com/volatiletech/sqlboiler/v4/queries/qm"
@@ -20,7 +21,9 @@ func (p *Plugin) Status() (string, string) {
 	return "Unique/Total", fmt.Sprintf("%d/%d", unique, total)
 }
 
-func (p *Plugin) OnRemovedPremiumGuild(guildID int64) error {
+var _ premium.PremiumGuildGracePeriodEndedListener = (*Plugin)(nil)
+
+func (p *Plugin) OnPremiumGuildGracePeriodEnded(guildID int64) error {
 	numDisabled, err := models.YoutubeChannelSubscriptions(
 		models.YoutubeChannelSubscriptionWhere.GuildID.EQ(discordgo.StrID(guildID)),
 		models.YoutubeChannelSubscriptionWhere.Enabled.EQ(true),

--- a/youtube/web.go
+++ b/youtube/web.go
@@ -18,6 +18,7 @@ import (
 	"github.com/botlabs-gg/yagpdb/v2/common"
 	"github.com/botlabs-gg/yagpdb/v2/common/cplogs"
 	"github.com/botlabs-gg/yagpdb/v2/lib/discordgo"
+	"github.com/botlabs-gg/yagpdb/v2/premium"
 	"github.com/botlabs-gg/yagpdb/v2/web"
 	"github.com/botlabs-gg/yagpdb/v2/youtube/models"
 	"github.com/mediocregopher/radix/v3"
@@ -76,6 +77,7 @@ func (p *Plugin) InitWeb() {
 	// All handlers here require guild channels present
 	ytMux.Use(web.RequireBotMemberMW)
 	ytMux.Use(web.RequirePermMW(discordgo.PermissionMentionEveryone))
+	ytMux.Use(premium.GracePeriodEndingMiddleware("YouTube feeds exceeding standard limits will be disabled"))
 
 	mainGetHandler := web.ControllerHandler(p.HandleYoutube, "cp_youtube")
 


### PR DESCRIPTION
Here is a possible implementation of a grace period before which premium features--additional custom commands, feeds, and so on--are disabled after a guild loses its premium slot.

It is intended really only as a possible starting point and has not been tested very thoroughly (though it works in the simple cases I have tried): I'm happy to see parts of this code cherry-picked and included in the final implementation and the original PR abandoned.

One important issue to note with this and similar approaches is that, as is, users can assign a premium slot to a server, then immediately unlink it to get 3 free days of premium while keeping their premium slot available for use on other servers. In other words, this code does not distinguish between users deliberately unlinking their premium slot from a server and a premium slot expiring naturally--it probably should.