### PR TITLE
autorole: ignore muted users

### DIFF
--- a/autorole/bot.go
+++ b/autorole/bot.go
@@ -16,6 +16,7 @@ import (
 	scheduledEventsModels "github.com/botlabs-gg/yagpdb/v2/common/scheduledevents2/models"
 	"github.com/botlabs-gg/yagpdb/v2/lib/dcmd"
 	"github.com/botlabs-gg/yagpdb/v2/lib/discordgo"
+	"github.com/botlabs-gg/yagpdb/v2/moderation"
 	"github.com/mediocregopher/radix/v3"
 )
 
@@ -489,8 +490,9 @@ func handleAssignRole(evt *scheduledEventsModels.ScheduledEvent, data interface{
 func handleGuildMemberUpdate(evt *eventsystem.EventData) (retry bool, err error) {
 	update := evt.GuildMemberUpdate()
 	member := update.Member
-	// ignore timedout users
-	if member.CommunicationDisabledUntil != nil && member.CommunicationDisabledUntil.After(time.Now()) {
+	// Ignore timed out and muted users.
+	if (member.CommunicationDisabledUntil != nil && member.CommunicationDisabledUntil.After(time.Now())) ||
+		moderation.IsMuted(member.GuildID, member.User.ID) {
 		return false, nil
 	}
 

--- a/moderation/punishments.go
+++ b/moderation/punishments.go
@@ -440,6 +440,17 @@ const (
 	ErrNoMuteRole = errors.Sentinel("No mute role")
 )
 
+func IsMuted(guildID, userID int64) bool {
+	mute, err := models.MutedUsers(
+		models.MutedUserWhere.UserID.EQ(userID),
+		models.MutedUserWhere.GuildID.EQ(guildID),
+	).OneG(context.Background())
+	if err != nil {
+		return false // assume not muted
+	}
+	return mute.ExpiresAt.IsZero() || mute.ExpiresAt.Time.After(time.Now())
+}
+
 // Unmut or mute a user, ignore duration if unmuting
 // TODO: i don't think we need to track mutes in its own database anymore now with the new scheduled event system
 func MuteUnmuteUser(config *Config, mute bool, guildID int64, channel *dstate.ChannelState, message *discordgo.Message, author *discordgo.User, reason string, member *dstate.MemberState, duration int, executedByCommandTemplate bool) error {


### PR DESCRIPTION
If a server configures autorole to give role A, and also sets up mute to remove role A, then the bot will continually attempt to add and remove role A from muted users in a loop. Fix this bug by telling autorole to ignore muted users; it already ignores timed out users.