### PR TITLE
tickets: Make ticket closing prompt more granular

### DIFF
--- a/tickets/tickets_bot.go
+++ b/tickets/tickets_bot.go
@@ -216,6 +216,10 @@ func closeTicket(gs *dstate.GuildSet, currentTicket *Ticket, ticketCS *dstate.Ch
 		var closingMsgBuilder strings.Builder
 		closingMsgBuilder.WriteString(closingMsg)
 
+		if conf.TicketsUseTXTTranscripts {
+			closingMsgBuilder.WriteString("\nCreating logs.")
+		}
+
 		closingMsgBuilder.WriteString("\nThis may take a while, if the ticket is long.")
 		closingMsg = closingMsgBuilder.String()
 	}

--- a/tickets/tickets_bot.go
+++ b/tickets/tickets_bot.go
@@ -220,6 +220,10 @@ func closeTicket(gs *dstate.GuildSet, currentTicket *Ticket, ticketCS *dstate.Ch
 			closingMsgBuilder.WriteString("\nCreating logs.")
 		}
 
+		if conf.DownloadAttachments {
+			closingMsgBuilder.WriteString("\nDownloading attachments.")
+		}
+
 		closingMsgBuilder.WriteString("\nThis may take a while, if the ticket is long.")
 		closingMsg = closingMsgBuilder.String()
 	}

--- a/tickets/tickets_bot.go
+++ b/tickets/tickets_bot.go
@@ -210,6 +210,16 @@ func closeTicket(gs *dstate.GuildSet, currentTicket *Ticket, ticketCS *dstate.Ch
 
 	closingMsg := "Closing ticket."
 
+	// We only need to build up a more detailed closing msg.
+	// if we're creating logs.
+	if conf.TicketsUseTXTTranscripts || conf.DownloadAttachments {
+		var closingMsgBuilder strings.Builder
+		closingMsgBuilder.WriteString(closingMsg)
+
+		closingMsgBuilder.WriteString("\nThis may take a while, if the ticket is long.")
+		closingMsg = closingMsgBuilder.String()
+	}
+
 	// send a heads up that this can take a while
 	common.BotSession.ChannelMessageSend(currentTicket.Ticket.ChannelID, closingMsg)
 

--- a/tickets/tickets_bot.go
+++ b/tickets/tickets_bot.go
@@ -193,8 +193,6 @@ func openTicket(ctx context.Context, gs *dstate.GuildSet, ms *dstate.MemberState
 var closingTickets = make(map[int64]bool)
 var closingTicketsLock sync.Mutex
 
-const closingTicketMsg = "Closing ticket, creating logs, downloading attachments and so on.\nThis may take a while if the ticket is big."
-
 func closeTicket(gs *dstate.GuildSet, currentTicket *Ticket, ticketCS *dstate.ChannelState, conf *models.TicketConfig, member *discordgo.User, reason string, ctx context.Context) (string, error) {
 	// protect again'st calling close multiple times at the sime time
 	closingTicketsLock.Lock()
@@ -210,8 +208,10 @@ func closeTicket(gs *dstate.GuildSet, currentTicket *Ticket, ticketCS *dstate.Ch
 		closingTicketsLock.Unlock()
 	}()
 
+	closingMsg := "Closing ticket."
+
 	// send a heads up that this can take a while
-	common.BotSession.ChannelMessageSend(currentTicket.Ticket.ChannelID, closingTicketMsg)
+	common.BotSession.ChannelMessageSend(currentTicket.Ticket.ChannelID, closingMsg)
 
 	currentTicket.Ticket.ClosedAt.Time = time.Now()
 	currentTicket.Ticket.ClosedAt.Valid = true


### PR DESCRIPTION
A server manager recently expressed their concerns, with YAGPDB
unconditionally suggesting it was downloading attachments
sent in tickets. They left this disabled for the privacy of members,
and felt the prompt may scare members, as it contradicted
their stated behaviour.

This PR updates the ticket closing function,
to use a more granular prompt, based on whether
it is creating a transcript of the ticket and/or downloading attachments.