### PR TITLE
templates: decrease thread call restrictions

### DIFF
--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -1039,17 +1039,13 @@ func (c *Context) tmplThreadMemberAdd(threadID, memberID interface{}) string {
 
 func (c *Context) tmplCloseThread(channel interface{}, flags ...bool) (string, error) {
 
-	if c.IncreaseCheckCallCounter("edit_channel", 10) {
+	if c.IncreaseCheckCallCounter("edit_thread", 10) {
 		return "", ErrTooManyCalls
 	}
 
 	cID := c.ChannelArg(channel)
 	if cID == 0 {
 		return "", nil //dont send an error, a nil output would indicate invalid/unknown channel
-	}
-
-	if c.IncreaseCheckCallCounter("edit_channel_"+strconv.FormatInt(cID, 10), 2) {
-		return "", ErrTooManyCalls
 	}
 
 	cstate := c.GS.GetChannelOrThread(cID)
@@ -1217,7 +1213,7 @@ func (c *Context) tmplDeleteThread(thread interface{}) (string, error) {
 
 func (c *Context) tmplEditThread(channel interface{}, args ...interface{}) (string, error) {
 
-	if c.IncreaseCheckCallCounter("edit_channel", 10) {
+	if c.IncreaseCheckCallCounter("edit_thread", 10) {
 		return "", ErrTooManyCalls
 	}
 
@@ -1226,7 +1222,7 @@ func (c *Context) tmplEditThread(channel interface{}, args ...interface{}) (stri
 		return "", nil //dont send an error, a nil output would indicate invalid/unknown channel
 	}
 
-	if c.IncreaseCheckCallCounter("edit_channel_"+strconv.FormatInt(cID, 10), 2) {
+	if c.IncreaseCheckCallCounter("edit_thread_"+strconv.FormatInt(cID, 10), 2) {
 		return "", ErrTooManyCalls
 	}
 
@@ -1276,11 +1272,7 @@ func (c *Context) tmplEditThread(channel interface{}, args ...interface{}) (stri
 
 func (c *Context) tmplOpenThread(cID int64) (string, error) {
 
-	if c.IncreaseCheckCallCounter("edit_channel", 10) {
-		return "", ErrTooManyCalls
-	}
-
-	if c.IncreaseCheckCallCounter("edit_channel_"+strconv.FormatInt(cID, 10), 2) {
+	if c.IncreaseCheckCallCounter("edit_thread", 10) {
 		return "", ErrTooManyCalls
 	}
 
@@ -1526,17 +1518,13 @@ func processThreadArgs(newThread bool, parent *dstate.ChannelState, values ...in
 func (c *Context) tmplPinForumPost(unpin bool) func(channel interface{}) (string, error) {
 	return func(channel interface{}) (string, error) {
 
-		if c.IncreaseCheckCallCounter("edit_channel", 10) {
+		if c.IncreaseCheckCallCounter("edit_thread", 10) {
 			return "", ErrTooManyCalls
 		}
 
 		cID := c.ChannelArg(channel)
 		if cID == 0 {
 			return "", nil //dont send an error, a nil output would indicate invalid/unknown channel
-		}
-
-		if c.IncreaseCheckCallCounter("edit_channel_"+strconv.FormatInt(cID, 10), 2) {
-			return "", ErrTooManyCalls
 		}
 
 		cstate := c.GS.GetChannelOrThread(cID)


### PR DESCRIPTION
Separated thread and channel edits for call counters. Additionally 
removed the extra harsh 2 per thread limit for functions which are not heavily rate limited as name editing is (opening, closing, locking, 
pinning threads).

Signed-off-by: SoggySaussages <vmdmaharaj@gmail.com>