### PR TITLE
logs: fix login link in pnotify alert

### DIFF
--- a/logs/web.go
+++ b/logs/web.go
@@ -239,8 +239,8 @@ func CheckCanAccessLogs(w http.ResponseWriter, r *http.Request, config *models.G
 	member := web.ContextMember(ctx)
 	if member == nil {
 		goTo := url.QueryEscape(r.RequestURI)
-		alertLink := fmt.Sprintf(`<a href="%s/login?goto=%s>here</a>`, web.BaseURL(), goTo)
-		alertMsg := fmt.Sprintf("This server has restricted log access to members only.\nIf you are a member, click %s to login.", alertLink)
+		alertLink := fmt.Sprintf(`<a href="%s/login?goto=%s">login here</a>`, web.BaseURL(), goTo)
+		alertMsg := fmt.Sprintf("This server has restricted log access to members only. If you are a member, %s to view this log.", alertLink)
 
 		tmpl.AddAlerts(web.ErrorAlert(alertMsg))
 		return false

--- a/logs/web.go
+++ b/logs/web.go
@@ -239,8 +239,8 @@ func CheckCanAccessLogs(w http.ResponseWriter, r *http.Request, config *models.G
 	member := web.ContextMember(ctx)
 	if member == nil {
 		goTo := url.QueryEscape(r.RequestURI)
-		alertLink := fmt.Sprintf(`<a href="%s/login?goto=%s">login here</a>`, web.BaseURL(), goTo)
-		alertMsg := fmt.Sprintf("This server has restricted log access to members only. If you are a member, %s to view this log.", alertLink)
+		alertLink := fmt.Sprintf(`<a href="%s/login?goto=%s">log in with Discord</a>`, web.BaseURL(), goTo)
+		alertMsg := fmt.Sprintf("This server has restricted log access to members only. Please %s to view this log.", alertLink)
 
 		tmpl.AddAlerts(web.ErrorAlert(alertMsg))
 		return false


### PR DESCRIPTION
Add a missing quotation mark to properly display the login hyperlink
prompt when trying to view logs restricted to server members.
Reword the alert to be more accessible (include "login" in the hyperlink
text).

Signed-off-by: Galen CC <galen8183@gmail.com>
