### PR TITLE
Improve thanks detection regex

### DIFF
--- a/reputation/plugin_bot.go
+++ b/reputation/plugin_bot.go
@@ -33,7 +33,7 @@ func (p *Plugin) BotInit() {
 	eventsystem.AddHandlerAsyncLastLegacy(p, handleMessageCreate, eventsystem.EventMessageCreate)
 }
 
-var thanksRegex = regexp.MustCompile(`(?i)( |\n|^)(thanks?\pP*|danks|ty|thx|\+rep|\+ ?\<\@[0-9]*\>)( |\n|$)`)
+var thanksRegex = regexp.MustCompile(`(?i)( |\n|^)?(thanks?|danks|ty|thx|\+rep|\+ ?\<\@[0-9]*\>)( |\pP|\n|$)`)
 
 func createRepDisabledError(g *dcmd.GuildContextData) string {
 	return fmt.Sprintf("**The reputation system is disabled for this server.** Enable it at: <%s/reputation>.", web.ManageServerURL(g.GS.ID))


### PR DESCRIPTION
This PR is intended to improve the success rate for the automatic detection of thanks by adjusting the regex to match more reliably around punctuation.

The current thanks detection regex...

`(?i)( |\n|^)(thanks?\pP*|danks|ty|thx|\+rep|\+ ?\<\@[0-9]*\>)( |\n|$)`

...misses several variants of "thanks" due to how the regex will only match if punctuation followed `thanks` but not other variants like `ty` and `thx`.

The improved thanks detection regex...

`(?i)( |\n|^)?(thanks?|danks|ty|thx|\+rep|\+ ?\<\@[0-9]*\>)( |\pP|\n|$)`

...will additionally catch variants like `ty` and `thx` when there is trailing punctuation.

_Note: Matching on "danks" was not added by this PR; this variant was already in the regex when I found it. Although this has generated questions and skepticism with people whom I have asked to review the regex, I have left it in there._

The change has been tested using regex101.com's interactive tool for Golang-flavored regular expressions.

Before:
<img width="777" alt="image" src="https://github.com/user-attachments/assets/572cde2d-dfca-464e-9b56-09d1ed270ea2" />

After:
<img width="792" alt="image" src="https://github.com/user-attachments/assets/84280e57-5d5f-45fb-94a3-fce11b020b38" />
