### PR TITLE
Rolemenu: include Discord error in rolemenu create error output

### DIFF
--- a/rolecommands/menu.go
+++ b/rolecommands/menu.go
@@ -129,7 +129,7 @@ func cmdFuncRoleMenuCreate(parsed *dcmd.Data) (interface{}, error) {
 			_, dErr := common.DiscordError(err)
 			errStr := "Failed creating the menu message, check the permissions on the channel"
 			if dErr != "" {
-				errStr += ", Discord responded with: " + errStr
+				errStr += ", Discord responded with: " + dErr
 			}
 			return errStr, err
 		}


### PR DESCRIPTION
Previously when the rolemenu create command entered an error state after attempting to send an initial message stating rolemenu setup has started, the user would receive the following output if they used the slash command; if text command, *nothing* happens.

![Discord_n4cu4q1UAP](https://github.com/user-attachments/assets/51ce3274-46d3-4e7f-a583-dcab8430bd1b)

This error is *duplicated*, using YAG's error twice, instead being followed by Discord's error.
This PR replaces the second instance of YAG's error with Discord's error.

YAG's error may be enough to get the message through that it does not have permission to send the message for the rolemenu.
However, I have left the addition of the Discord error just in case it would like to be kept, how I imagine it was meant to be.