### PR TITLE
Custom Commands: New error output for regex cache limit

### DIFF
--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -24,7 +24,7 @@ import (
 var (
 	ErrTooManyCalls    = errors.New("too many calls to this function")
 	ErrTooManyAPICalls = errors.New("too many potential Discord API calls")
-	ErrRegexCacheLimit = errors.New("too many different regular expressions")
+	ErrRegexCacheLimit = errors.New("too many unique RegExes")
 )
 
 func (c *Context) tmplSendDM(s ...interface{}) string {

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -24,7 +24,7 @@ import (
 var (
 	ErrTooManyCalls    = errors.New("too many calls to this function")
 	ErrTooManyAPICalls = errors.New("too many potential Discord API calls")
-	ErrRegexCacheLimit = errors.New("too many unique RegExes")
+	ErrRegexCacheLimit = errors.New("too many unique regular expressions (regex)")
 )
 
 func (c *Context) tmplSendDM(s ...interface{}) string {

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -23,7 +23,8 @@ import (
 
 var (
 	ErrTooManyCalls    = errors.New("too many calls to this function")
-	ErrTooManyAPICalls = errors.New("too many potential discord api calls function")
+	ErrTooManyAPICalls = errors.New("too many potential Discord API calls")
+	ErrRegexCacheLimit = errors.New("too many different regular expressions")
 )
 
 func (c *Context) tmplSendDM(s ...interface{}) string {
@@ -1734,7 +1735,7 @@ func (c *Context) compileRegex(r string) (*regexp.Regexp, error) {
 	}
 
 	if len(c.RegexCache) >= 10 {
-		return nil, ErrTooManyAPICalls
+		return nil, ErrRegexCacheLimit
 	}
 
 	compiled, err := regexp.Compile(r)


### PR DESCRIPTION
When a custom command uses more than 10 different regular expressions, the CC would error stating "too many discord api calls function." As CC regex functions do not use the Discord API, this is misleading and causes confusion around the issue.

![Discord_4B0cghSwf1](https://github.com/user-attachments/assets/da8e0c40-deea-4f56-9367-34e0e95d1390)

This PR adds a new error, ErrRegexCacheLimit, which instead outputs "too many different regular expressions."
This PR also rewords and reformats the ErrTooManyAPICalls error to read "too many Discord API calls."