### PR TITLE
[Suggestion: #2249] allow ne multiple args

### DIFF
--- a/lib/template/funcs.go
+++ b/lib/template/funcs.go
@@ -469,10 +469,10 @@ func eq(arg1 reflect.Value, arg2 ...reflect.Value) (bool, error) {
 }
 
 // ne evaluates the comparison a != b.
-func ne(arg1, arg2 reflect.Value) (bool, error) {
+func ne(arg1 reflect.Value, arg2 ...reflect.Value) (bool, error) {
 	// != is the inverse of ==.
-	equal, err := eq(arg1, arg2)
-	return !equal, err
+	equal, err := eq(arg1, arg2...)
+	return !equal, err 
 }
 
 // lt evaluates the comparison a < b.

--- a/lib/template/funcs.go
+++ b/lib/template/funcs.go
@@ -472,7 +472,7 @@ func eq(arg1 reflect.Value, arg2 ...reflect.Value) (bool, error) {
 func ne(arg1 reflect.Value, arg2 ...reflect.Value) (bool, error) {
 	// != is the inverse of ==.
 	equal, err := eq(arg1, arg2...)
-	return !equal, err 
+	return !equal, err
 }
 
 // lt evaluates the comparison a < b.


### PR DESCRIPTION
With this pr `ne` works like the `eq` function. You can give now multiple args.

**Example:**
![image](https://github.com/user-attachments/assets/165d6e99-45fd-4243-a680-61801d28bf97)
