### PR TITLE
general: include attachments from forwards

### DIFF
--- a/automod/conditions.go
+++ b/automod/conditions.go
@@ -620,7 +620,7 @@ func (mc *MessageAttachmentCondition) IsMet(data *TriggeredRuleData, settings in
 		return true, nil
 	}
 
-	if contains := len(data.Message.Attachments) > 0; mc.HasAttachments {
+	if contains := len(data.Message.GetMessageAttachments()) > 0; mc.HasAttachments {
 		return contains, nil
 	} else {
 		return !contains, nil

--- a/automod/triggers.go
+++ b/automod/triggers.go
@@ -763,7 +763,9 @@ func (s *SlowmodeTrigger) UserSettings() []*SettingDef {
 }
 
 func (s *SlowmodeTrigger) CheckMessage(triggerCtx *TriggerContext, cs *dstate.ChannelState, m *discordgo.Message) (bool, error) {
-	if s.Attachments && len(m.Attachments) < 1 {
+	attachments := m.GetMessageAttachments()
+
+	if s.Attachments && len(attachments) < 1 {
 		return false, nil
 	}
 
@@ -794,12 +796,14 @@ func (s *SlowmodeTrigger) CheckMessage(triggerCtx *TriggerContext, cs *dstate.Ch
 		}
 
 		if s.Attachments {
-			if len(v.Attachments) < 1 {
+			vAttachments := v.GetMessageAttachments()
+
+			if len(vAttachments) < 1 {
 				continue // we're only checking messages with attachments
 			}
 			if settings.SingleMessageAttachments {
 				// Add the count of all attachments of this message to the amount
-				amount += len(v.Attachments)
+				amount += len(vAttachments)
 			} else {
 				amount++
 			}
@@ -1098,7 +1102,7 @@ func (spam *SpamTrigger) CheckMessage(triggerCtx *TriggerContext, cs *dstate.Cha
 			break
 		}
 
-		if len(v.Attachments) > 0 {
+		if len(v.GetMessageAttachments()) > 0 {
 			break // treat any attachment as a different message, in the future i may download them and check hash or something? maybe too much
 		}
 
@@ -1532,7 +1536,7 @@ func (mat *MessageAttachmentTrigger) UserSettings() []*SettingDef {
 }
 
 func (mat *MessageAttachmentTrigger) CheckMessage(triggerCtx *TriggerContext, cs *dstate.ChannelState, m *discordgo.Message) (bool, error) {
-	contains := len(m.Attachments) > 0
+	contains := len(m.GetMessageAttachments()) > 0
 	if contains && mat.RequiresAttachment {
 		return true, nil
 	} else if !contains && !mat.RequiresAttachment {

--- a/automod/triggers.go
+++ b/automod/triggers.go
@@ -763,9 +763,7 @@ func (s *SlowmodeTrigger) UserSettings() []*SettingDef {
 }
 
 func (s *SlowmodeTrigger) CheckMessage(triggerCtx *TriggerContext, cs *dstate.ChannelState, m *discordgo.Message) (bool, error) {
-	attachments := m.GetMessageAttachments()
-
-	if s.Attachments && len(attachments) < 1 {
+	if s.Attachments && len(m.GetMessageAttachments()) < 1 {
 		return false, nil
 	}
 

--- a/lib/discordgo/message.go
+++ b/lib/discordgo/message.go
@@ -165,8 +165,8 @@ type Message struct {
 	Activity *MessageActivity `json:"activity"`
 
 	// An array of StickerItem objects, is the message contains any.
-	StickerItems []*StickerItem `json:"sticker_items"`
-	ApplicationID int64 `json:"application_id,string"`
+	StickerItems  []*StickerItem `json:"sticker_items"`
+	ApplicationID int64          `json:"application_id,string"`
 }
 
 type MessageSnapshot struct {
@@ -181,6 +181,16 @@ func (m *Message) GetMessageContents() []string {
 		}
 	}
 	return contents
+}
+
+func (m *Message) GetMessageAttachments() []*MessageAttachment {
+	attachments := m.Attachments
+	for _, s := range m.MessageSnapshots {
+		if s.Message != nil && len(s.Message.Attachments) > 0 {
+			attachments = append(attachments, s.Message.Attachments...)
+		}
+	}
+	return attachments
 }
 
 func (m *Message) GetGuildID() int64 {
@@ -261,7 +271,7 @@ type MessageSend struct {
 	AllowedMentions AllowedMentions    `json:"allowed_mentions,omitempty"`
 	Reference       *MessageReference  `json:"message_reference,omitempty"`
 	Flags           MessageFlags       `json:"flags,omitempty"`
-	StickerIDs	[]int64            `json:"sticker_ids"`
+	StickerIDs      []int64            `json:"sticker_ids"`
 
 	// TODO: Remove this when compatibility is not required.
 	File *File `json:"-"`

--- a/lib/dstate/interface.go
+++ b/lib/dstate/interface.go
@@ -433,6 +433,18 @@ func (m *MessageState) GetMessageContents() []string {
 	return contents
 }
 
+func (m *MessageState) GetMessageAttachments() []discordgo.MessageAttachment {
+	attachments := m.Attachments
+	for _, s := range m.MessageSnapshots {
+		if s.Message != nil && len(s.Message.Attachments) > 0 {
+			for _, a := range s.Message.Attachments {
+				attachments = append(attachments, *a)
+			}
+		}
+	}
+	return attachments
+}
+
 func (m *MessageState) ContentWithMentionsReplaced() string {
 	content := m.Content
 

--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -1370,7 +1370,7 @@ func (f *IgnorePinnedMessagesFilter) Matches(msg *dstate.MessageState) (delete b
 type MessagesWithAttachmentsFilter struct{}
 
 func (*MessagesWithAttachmentsFilter) Matches(msg *dstate.MessageState) (delete bool) {
-	return len(msg.Attachments) > 0
+	return len(msg.GetMessageAttachments()) > 0
 }
 
 // Only delete messages satisfying ToID<=id<=FromID.

--- a/tickets/tickets_commands.go
+++ b/tickets/tickets_commands.go
@@ -516,7 +516,7 @@ func createLogs(gs *dstate.GuildSet, conf *models.TicketConfig, ticket *models.T
 		for _, msg := range m {
 			// download attachments
 		OUTER:
-			for _, att := range msg.Attachments {
+			for _, att := range msg.GetMessageAttachments() {
 				msg.Content += fmt.Sprintf("(attachment: %s)", att.Filename)
 
 				totalAttachmentSize += att.Size


### PR DESCRIPTION
Include attachments from forwarded messages across various features of
the bot which reference a message's attachments.

Signed-off-by: SoggySaussages <vmdmaharaj@gmail.com>