### PR TITLE
reminders: fix target channel flag

### DIFF
--- a/reminders/plugin_bot.go
+++ b/reminders/plugin_bot.go
@@ -77,6 +77,7 @@ var cmds = []*commands.YAGCommand{
 			id := parsed.ChannelID
 			if c := parsed.Switch("channel"); c.Value != nil {
 				cs := c.Value.(*dstate.ChannelState)
+				id = cs.ID
 				mention, _ := cs.Mention()
 
 				hasPerms, err := bot.AdminOrPermMS(parsed.GuildData.GS.ID, cs.ID, parsed.GuildData.MS, discordgo.PermissionSendMessages|discordgo.PermissionViewChannel)


### PR DESCRIPTION
The `remindme` command's `-channel` flag was broken in https://github.com/botlabs-gg/yagpdb/commit/244f2d56fe6d53ed7e3965d3db336e31ff6c3301
This sets the target ID correctly

Signed-off-by: Galen CC <galen8183@gmail.com>
