### PR TITLE
templates: prefer print over joinStr ""

### DIFF
--- a/automod/assets/automod.html
+++ b/automod/assets/automod.html
@@ -616,7 +616,7 @@ $(function(){
             <div class='form-group row'>
                 <label class='col-lg-2'>{{.Name}}:</label>
                 <div class='col-lg-10'>
-                    {{$name := joinStr "" $namePrefix "." $dot.partIndex ".Data." .Key}}
+                    {{$name := joinStr "." $namePrefix $dot.partIndex "Data" .Key}}
                     {{if eq .Kind "int"}}
                     <input type='number' class='form-control' name="{{$name}}" {{if or .Min .Max}} min="{{.Min}}" max="{{.Max}}" {{end}} value="{{index $dot.settings .Key}}"></input>
                     {{else if eq .Kind "multi_role"}}

--- a/automod_legacy/assets/automod_legacy.html
+++ b/automod_legacy/assets/automod_legacy.html
@@ -211,7 +211,7 @@
 {{define "automod_legacy_common_fields"}}
 
 <br />
-{{checkbox (joinStr "" .Name ".Enabled") (joinStr "" .Name ".Enabled") "Enabled" .Rule.Enabled}}
+{{checkbox (print .Name ".Enabled") (print .Name ".Enabled") "Enabled" .Rule.Enabled}}
 <hr />
 <div class="form-group">
     <label for="ViolationsExpire">Violations expire after (minutes):</label>

--- a/commands/assets/commands.html
+++ b/commands/assets/commands.html
@@ -218,7 +218,7 @@
         {{if .Override}}{{$commandsEnabled = .Override.CommandsEnabled}}{{end}}
 
         {{if not .Override.Global}}
-            {{checkbox "CommandsEnabled" (joinStr "" "commands-enabled-" .Override.ID) $desc $commandsEnabled}}
+            {{checkbox "CommandsEnabled" (print "commands-enabled-" .Override.ID) $desc $commandsEnabled}}
         {{else}}
             <div class="form-group d-flex align-items-center">
                 <input type="checkbox" class="tgl tgl-flat" name="CommandsEnabled" id="commands-enabled-global"

--- a/frontend/templates/cp_nav.html
+++ b/frontend/templates/cp_nav.html
@@ -337,7 +337,7 @@
         {{range $index, $element := .ManagedGuilds -}}{{if not $element.Connected -}}
         <li>
             <a
-                href="https://discordapp.com/oauth2/authorize?client_id={{$clientid}}&scope=applications.commands%20bot&permissions=1516122532343&guild_id={{$element.ID}}&response_type=code&redirect_uri={{joinStr "" $baseURL "/manage"}}"><i
+                href="https://discordapp.com/oauth2/authorize?client_id={{$clientid}}&scope=applications.commands%20bot&permissions=1516122532343&guild_id={{$element.ID}}&response_type=code&redirect_uri={{print $baseURL "/manage"}}"><i
                     class="fas fa-plus"></i>{{$element.Name}}</a>
         </li>
         {{end}}{{end}}

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -54,7 +54,7 @@
           <a class="nav-link" href="/status">Status</a>
         </li>
         <li class="nav-item active">
-          <a class="nav-link" href="https://discordapp.com/oauth2/authorize?client_id={{.ClientID}}&scope=applications.commands%20bot&permissions=1516122532343&response_type=code&redirect_uri={{urlquery (joinStr ""  "https://" .Host "/manage")}}">Add to server</a>
+          <a class="nav-link" href="https://discordapp.com/oauth2/authorize?client_id={{.ClientID}}&scope=applications.commands%20bot&permissions=1516122532343&response_type=code&redirect_uri={{urlquery (print "https://" .Host "/manage")}}">Add to server</a>
         </li>
         <li class="nav-item active">
           <a class="nav-link" href="/premium">Premium</a>

--- a/reddit/assets/reddit.html
+++ b/reddit/assets/reddit.html
@@ -132,15 +132,15 @@
             <div class="form-row">
                 <div class="col d-flex flex-column">
                     <Span class="mb-2">Enable Spoilers</span>
-                    {{checkbox "spoilers_enabled" (joinStr "" "spoiler-toggle-" .ID) `` .SpoilersEnabled}}
+                    {{checkbox "spoilers_enabled" (print "spoiler-toggle-" .ID) `` .SpoilersEnabled}}
                 </div>
                 <div class="col d-flex flex-column">
                     <Span class="mb-2">Use embed</span>
-                    {{checkbox "use_embeds" (joinStr "" "use-embed-" .ID) `` .UseEmbeds}}
+                    {{checkbox "use_embeds" (print "use-embed-" .ID) `` .UseEmbeds}}
                 </div>
                 <div class="col d-flex flex-column">
                     <Span class="mb-2">Enabled</span>
-                    {{checkbox "feed_enabled" (joinStr "" "feed-enabled-" .ID) `` (not .Disabled)}}
+                    {{checkbox "feed_enabled" (print "feed-enabled-" .ID) `` (not .Disabled)}}
                 </div>
 
                 <div class="form-group col">

--- a/rolecommands/assets/rolecommands.html
+++ b/rolecommands/assets/rolecommands.html
@@ -280,8 +280,8 @@
                         <div id="{{.Group.ID}}-group-single-opts" class="col-lg-4 {{if ne .Group.Mode 1}}hidden{{end}}">
                             <p class="help-block">Mode specific settings</p>
 
-                            {{checkbox "SingleRequireOne" (joinStr "" .Group.ID "-single-require-one") "Require 1 role in group at all times (after initial assignment)" .Group.SingleRequireOne}}
-                            {{checkbox "SingleAutoToggleOff" (joinStr "" .Group.ID "-single-auto-toggle") "Remove existing role when assigning another role in group." .Group.SingleAutoToggleOff}}
+                            {{checkbox "SingleRequireOne" (print .Group.ID "-single-require-one") "Require 1 role in group at all times (after initial assignment)" .Group.SingleRequireOne}}
+                            {{checkbox "SingleAutoToggleOff" (print .Group.ID "-single-auto-toggle") "Remove existing role when assigning another role in group." .Group.SingleAutoToggleOff}}
                         </div>
                         <div id="{{.Group.ID}}-group-multi-opts" class="col-lg-4 {{if ne .Group.Mode 2}}hidden{{end}}">
                             <p class="help-block">Mode specific settings</p>

--- a/tickets/tickets.go
+++ b/tickets/tickets.go
@@ -29,7 +29,7 @@ func RegisterPlugin() {
 }
 
 const (
-	DefaultTicketMsg        = "{{$embed := cembed `description` (joinStr `` `Welcome ` .User.Mention `\n\nPlease describe the reasoning for opening this ticket, include any information you think may be relevant such as proof, other third parties and so on.` " + DefaultTicketMsgClose + DefaultTicketMsgAddUser + ")}}\n{{sendMessage nil $embed}}"
+	DefaultTicketMsg        = "{{$embed := cembed \"description\" (print \"Welcome \" .User.Mention `\n\nPlease describe the reasoning for opening this ticket, include any information you think may be relevant such as proof, other third parties and so on.` " + DefaultTicketMsgClose + DefaultTicketMsgAddUser + ")}}\n{{sendMessage nil $embed}}"
 	DefaultTicketMsgClose   = "\n\"\\n\\nuse the following command to close the ticket\\n\"\n\"`-ticket close reason for closing here`\\n\\n\""
 	DefaultTicketMsgAddUser = "\n\"use the following command to add users to the ticket\\n\"\n\"`-ticket adduser @user`\""
 )

--- a/twitter/assets/twitter.html
+++ b/twitter/assets/twitter.html
@@ -65,17 +65,17 @@
                             </select>
                         </div>
                         <div class="form-group col">
-                            {{$id_include_replies := (joinStr "" "feed-" .ID "-replies")}}
+                            {{$id_include_replies := (joinStr "-" "feed" .ID "replies")}}
                             <label for="{{$id_include_replies}}">Include Replies</label>
                             {{checkbox "IncludeReplies" $id_include_replies `` .IncludeReplies}}
                         </div>
                         <div class="form-group col">
-                            {{$id_include_rts := (joinStr "" "feed-" .ID "-rts")}}
+                            {{$id_include_rts := (joinStr "-" "feed" .ID "rts")}}
                             <label for="{{$id_include_rts}}">Include Retweets</label>
                             {{checkbox "IncludeRetweets" $id_include_rts `` .IncludeRT}}
                         </div>
                         <div class="form-group col">
-                            {{$id_enabled := (joinStr "" "feed-" .ID "-enabled")}}
+                            {{$id_enabled := (joinStr "-" "feed" .ID "enabled")}}
                             <label for="{{$id_enabled}}">Enabled</label>
                             {{checkbox "Enabled" $id_enabled `` .Enabled}}
                         </div>

--- a/youtube/assets/youtube.html
+++ b/youtube/assets/youtube.html
@@ -166,7 +166,7 @@
                         </td>
                         <td class="yt-tbl-column custom-announcement-disables">
                             <span class="custom-announcement-popover">
-                            {{checkbox "MentionEveryone" (joinStr "" "mention-everyone-" .ID) `Mention everyone` .MentionEveryone (joinStr "" `form="sub-item-` .ID `"`)}}
+                            {{checkbox "MentionEveryone" (print "mention-everyone-" .ID) `Mention everyone` .MentionEveryone (print `form="sub-item-` .ID `"`)}}
                             </span>
                         </td>
                         <td class="yt-tbl-column custom-announcement-disables">
@@ -178,13 +178,13 @@
                             </span>
                         </td>
                         <td class="yt-tbl-column">
-                            {{checkbox "PublishLivestream" (joinStr "" "publish-livestream-" .ID) `Publish Livestreams` .PublishLivestream (joinStr "" `form="sub-item-` .ID `"`)}}
+                            {{checkbox "PublishLivestream" (print "publish-livestream-" .ID) `Publish Livestreams` .PublishLivestream (print `form="sub-item-` .ID `"`)}}
                         </td>
                         <td class="yt-tbl-column">
-                            {{checkbox "PublishShorts" (joinStr "" "publish-shorts-" .ID) `Publish Shorts` .PublishShorts (joinStr "" `form="sub-item-` .ID `"`)}}
+                            {{checkbox "PublishShorts" (print "publish-shorts-" .ID) `Publish Shorts` .PublishShorts (print `form="sub-item-` .ID `"`)}}
                         </td>
                         <td class="yt-tbl-column">
-                            {{checkbox "Enabled" (joinStr "" "feed-enabled-" .ID) `` .Enabled (joinStr "" `form="sub-item-` .ID `"`)}}
+                            {{checkbox "Enabled" (print "feed-enabled-" .ID) `` .Enabled (print `form="sub-item-` .ID `"`)}}
                         </td>
                         <td class="yt-tbl-column yt-tbl-actions-column">
                             <button form="sub-item-{{.ID}}" type="submit" class="btn btn-success" formaction="/manage/{{$dot.ActiveGuild.ID}}/youtube/{{.ID}}/update" data-async-form-alertsonly>Save</button>


### PR DESCRIPTION
Replace instances of `joinStr ""` with `print`, or use the separator arg
where appropriate.

Signed-off-by: Galen CC <galen8183@gmail.com>
