### PR TITLE
moderation: improve external mod action logging

### DIFF
--- a/lib/discordgo/structs.go
+++ b/lib/discordgo/structs.go
@@ -1377,6 +1377,7 @@ type AuditLogEntry struct {
 	ActionType *AuditLogAction   `json:"action_type"`
 	Options    *AuditLogOptions  `json:"options"`
 	Reason     string            `json:"reason"`
+	GuildID    int64             `json:"guild_id,string,omitempty"`
 }
 
 // A UserGuildSettingsChannelOverride stores data for a channel override for a users guild settings.

--- a/moderation/moderation.go
+++ b/moderation/moderation.go
@@ -38,10 +38,6 @@ func RedisKeyBannedUser(guildID, userID int64) string {
 	return "moderation_banned_user:" + discordgo.StrID(guildID) + ":" + discordgo.StrID(userID)
 }
 
-func RedisKeyUnbannedUser(guildID, userID int64) string {
-	return "moderation_unbanned_user:" + discordgo.StrID(guildID) + ":" + discordgo.StrID(userID)
-}
-
 func RedisKeyLockedMute(guildID, userID int64) string {
 	return "moderation_updating_mute:" + discordgo.StrID(guildID) + ":" + discordgo.StrID(userID)
 }

--- a/moderation/plugin_bot.go
+++ b/moderation/plugin_bot.go
@@ -50,11 +50,8 @@ func (p *Plugin) BotInit() {
 	scheduledevents2.RegisterLegacyMigrater("unmute", handleMigrateScheduledUnmute)
 	scheduledevents2.RegisterLegacyMigrater("mod_unban", handleMigrateScheduledUnban)
 
-	eventsystem.AddHandlerAsyncLastLegacy(p, bot.ConcurrentEventHandler(HandleGuildBanAddRemove), eventsystem.EventGuildBanAdd, eventsystem.EventGuildBanRemove)
-	eventsystem.AddHandlerAsyncLast(p, HandleGuildMemberRemove, eventsystem.EventGuildMemberRemove)
 	eventsystem.AddHandlerAsyncLast(p, LockMemberMuteMW(HandleMemberJoin), eventsystem.EventGuildMemberAdd)
 	eventsystem.AddHandlerAsyncLast(p, LockMemberMuteMW(HandleGuildMemberUpdate), eventsystem.EventGuildMemberUpdate)
-	eventsystem.AddHandlerAsyncLast(p, HandleGuildMemberTimeoutChange, eventsystem.EventGuildMemberUpdate)
 
 	eventsystem.AddHandlerAsyncLast(p, HandleGuildAuditLogEntryCreate, eventsystem.EventGuildAuditLogEntryCreate)
 
@@ -304,169 +301,6 @@ func RefreshMuteOverrideForChannel(config *Config, channel dstate.ChannelState) 
 	}
 }
 
-func HandleGuildMemberTimeoutChange(evt *eventsystem.EventData) (retry bool, err error) {
-	data := evt.GuildMemberUpdate()
-	//ignore members who aren't timedout or have been timedout in the past
-	if data.CommunicationDisabledUntil == nil || data.CommunicationDisabledUntil.Before(time.Now()) {
-		return false, nil
-	}
-
-	config, err := BotCachedGetConfig(data.GuildID)
-	if err != nil {
-		return true, errors.WithStackIf(err)
-	}
-
-	// no modlog channel setup
-	if config.ActionChannel == 0 {
-		return false, nil
-	}
-
-	if !config.LogTimeouts {
-		// User doesn't want us to log timeouts not made through yag
-		return false, nil
-	}
-
-	// If we poll the audit log too fast then there sometimes wont be a audit log entry
-	time.Sleep(time.Second * 3)
-
-	author, entry := FindAuditLogEntry(data.GuildID, discordgo.AuditLogActionMemberUpdate, data.User.ID, time.Second*5)
-	if entry == nil || author == nil {
-		return false, nil
-	}
-	logger.Infof("got timeout event %v", entry)
-
-	auditLogChange := entry.Changes[0]
-
-	if *auditLogChange.Key != discordgo.AuditLogChangeKeyCommunicationDisabledUntil {
-		return false, nil
-	}
-
-	if author.ID == common.BotUser.ID {
-		// Bot performed the timeout, don't make duplicate modlog entries
-		return false, nil
-	}
-
-	action := MATimeoutAdded
-	timeoutUntil, err := discordgo.Timestamp(auditLogChange.NewValue.(string)).Parse()
-	if err == nil {
-		duration := timeoutUntil.Sub(bot.SnowflakeToTime(entry.ID))
-		action.Footer = "Expires after: " + common.HumanizeDuration(common.DurationPrecisionMinutes, duration)
-	}
-
-	err = CreateModlogEmbed(config, author, action, data.User, entry.Reason, "")
-	if err != nil {
-		logger.WithError(err).WithField("guild", data.GuildID).Error("Failed sending timeout log message")
-		return false, errors.WithStackIf(err)
-	}
-
-	return false, nil
-}
-
-func HandleGuildBanAddRemove(evt *eventsystem.EventData) {
-	var user *discordgo.User
-	var guildID = evt.GS.ID
-	var action ModlogAction
-
-	botPerformed := false
-
-	switch evt.Type {
-	case eventsystem.EventGuildBanAdd:
-
-		user = evt.GuildBanAdd().User
-		action = MABanned
-
-		var i int
-		common.RedisPool.Do(radix.Cmd(&i, "GET", RedisKeyBannedUser(guildID, user.ID)))
-		if i > 0 {
-			// The bot banned the user earlier, don't make duplicate entries in the modlog
-			common.RedisPool.Do(radix.Cmd(nil, "DEL", RedisKeyBannedUser(guildID, user.ID)))
-			return
-		}
-
-	case eventsystem.EventGuildBanRemove:
-
-		action = MAUnbanned
-		user = evt.GuildBanRemove().User
-
-		var i int
-		common.RedisPool.Do(radix.Cmd(&i, "GET", RedisKeyUnbannedUser(guildID, user.ID)))
-		if i > 0 {
-			// The bot was the one that performed the unban
-			common.RedisPool.Do(radix.Cmd(nil, "DEL", RedisKeyUnbannedUser(guildID, user.ID)))
-			if i == 2 {
-				//Bot performed non-scheduled unban, don't make duplicate entries in the modlog
-				return
-			}
-			// Bot performed scheduled unban, modlog entry must be handled
-			botPerformed = true
-		}
-
-	default:
-		return
-	}
-
-	config, err := BotCachedGetConfig(guildID)
-	if err != nil {
-		logger.WithError(err).WithField("guild", guildID).Error("Failed retrieving config")
-		return
-	}
-
-	if config.ActionChannel == 0 {
-		return
-	}
-
-	var author *discordgo.User
-	reason := ""
-
-	if !botPerformed {
-		// If we poll it too fast then there sometimes wont be a audit log entry
-		time.Sleep(time.Second * 3)
-
-		auditlogAction := discordgo.AuditLogActionMemberBanAdd
-		if evt.Type == eventsystem.EventGuildBanRemove {
-			auditlogAction = discordgo.AuditLogActionMemberBanRemove
-		}
-
-		var entry *discordgo.AuditLogEntry
-		author, entry = FindAuditLogEntry(guildID, auditlogAction, user.ID, -1)
-		if entry != nil {
-			reason = entry.Reason
-		}
-	}
-
-	if (action == MAUnbanned && !config.LogUnbans && !botPerformed) ||
-		(action == MABanned && !config.LogBans) {
-		return
-	}
-
-	// The bot only unbans people in the case of timed bans
-	if botPerformed {
-		author = common.BotUser
-		reason = "Timed ban expired"
-	}
-
-	err = CreateModlogEmbed(config, author, action, user, reason, "")
-	if err != nil {
-		logger.WithError(err).WithField("guild", guildID).Error("Failed sending " + action.Prefix + " log message")
-	}
-}
-
-func HandleGuildMemberRemove(evt *eventsystem.EventData) (retry bool, err error) {
-	data := evt.GuildMemberRemove()
-
-	config, err := BotCachedGetConfig(data.GuildID)
-	if err != nil {
-		return true, errors.WithStackIf(err)
-	}
-
-	if config.ActionChannel == 0 {
-		return false, nil
-	}
-
-	go checkAuditLogMemberRemoved(config, data)
-	return false, nil
-}
-
 func HandleGuildAuditLogEntryCreate(evt *eventsystem.EventData) (retry bool, err error) {
 	data := evt.GuildAuditLogEntryCreate()
 
@@ -534,31 +368,6 @@ func HandleGuildAuditLogEntryCreate(evt *eventsystem.EventData) (retry bool, err
 	}
 
 	return false, nil
-}
-
-func checkAuditLogMemberRemoved(config *Config, data *discordgo.GuildMemberRemove) {
-	// If we poll the audit log too fast then there sometimes wont be a audit log entry
-	time.Sleep(time.Second * 3)
-
-	author, entry := FindAuditLogEntry(data.GuildID, discordgo.AuditLogActionMemberKick, data.User.ID, time.Second*5)
-	if entry == nil || author == nil {
-		return
-	}
-
-	if author.ID == common.BotUser.ID {
-		// Bot performed the kick, don't make duplicate modlog entries
-		return
-	}
-
-	if !config.LogKicks {
-		// User doesn't want us to log kicks not made through yag
-		return
-	}
-
-	err := CreateModlogEmbed(config, author, MAKick, data.User, entry.Reason, "")
-	if err != nil {
-		logger.WithError(err).WithField("guild", data.GuildID).Error("Failed sending kick log message")
-	}
 }
 
 // Since updating mutes are now a complex operation with removing roles and whatnot,

--- a/moderation/punishments.go
+++ b/moderation/punishments.go
@@ -368,9 +368,6 @@ func UnbanUser(config *Config, guildID int64, author *discordgo.User, reason str
 		user = guildBan.User
 	}
 
-	// Set a key in redis that marks that this user has appeared in the modlog already
-	common.RedisPool.Do(radix.FlatCmd(nil, "SETEX", RedisKeyUnbannedUser(guildID, user.ID), 30, 2))
-
 	// Prepends the author's name, if unban wasn't triggered automatically.
 	fullReason := reason
 	if author.ID != common.BotUser.ID {
@@ -383,12 +380,7 @@ func UnbanUser(config *Config, guildID int64, author *discordgo.User, reason str
 		return notbanned, err
 	}
 
-	logger.Infof("MODERATION: %s %s %s cause %q", author.Username, action.Prefix, user.Username, reason)
-
-	//modLog Entry handling
-	if config.LogUnbans {
-		err = CreateModlogEmbed(config, author, action, user, reason, "")
-	}
+	logger.Infof("MODERATION: %s %s %s with reason %q", author.Username, action.Prefix, user.Username, reason)
 	return false, err
 }
 


### PR DESCRIPTION
This PR aims to overall improve the performance of reporting external
moderation actions (i.e. actions not made through YAGPDB), by utilising
the Guild Audit Log Entry Create event fired by the Gateway whenever a
new audit log entry was created.

Due to the now more centralised nature of handling external mod actions,
we can remove some now obsolete event handlers as well, with an
additional (though probably subjective) benefit to readability of the
relevant code.

Testing reveals a rather significant speedup in posting to the mod-log
compared to the previous implementation, simply because we no longer
wait three seconds to fetch the audit log due to a potential for race
conditions. I confirmed, to the best of my ability, that the new
implementation is functionally equivalent to the old one.

This is a combination of three commits:

* discordgo: add guild_id extra field to AuditLogEntry

  When receiving Guild Audit Log Entry Create events, Discord sends an
  Audit Log entry object with an extra guild_id key as inner payload. Add
  that field such that we can use it later.

* moderation: use guild audit log entry create event

  Use the Guild Audit Log Entry Create event instead of subscribing to
  individual events and having to (slowly) parse through the guild's audit
  log.
  That way, we can significantly improve the speed of reporting external
  moderation actions not made with YAGPDB.

* moderation: remove now obsolete event handlers

  601d0a9876 (moderation: use guild audit log entry create event)
  introduced a new way to handle external moderation action logging,
  making some event handlers now obsolete. Remove them.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
