### PR TITLE
moderation: fix unban modlog entry creation

### DIFF
--- a/moderation/plugin_bot.go
+++ b/moderation/plugin_bot.go
@@ -583,5 +583,9 @@ func handleScheduledUnban(evt *seventsmodels.ScheduledEvent, data interface{}) (
 	}
 
 	_, err = UnbanUser(config, guildID, common.BotUser, scheduledUnbanReason, user)
-	return false, err
+	if err != nil {
+		return scheduledevents2.CheckDiscordErrRetry(err), err
+	}
+
+	return false, nil
 }

--- a/moderation/plugin_bot.go
+++ b/moderation/plugin_bot.go
@@ -571,12 +571,6 @@ func handleScheduledUnban(evt *seventsmodels.ScheduledEvent, data interface{}) (
 		return false, nil
 	}
 
-	//err = common.BotSession.GuildBanDeleteWithReason(guildID, userID, scheduledUnbanReason)
-	//if err != nil {
-	//	logger.WithField("guild", guildID).WithError(err).Error("failed unbanning user")
-	//	return scheduledevents2.CheckDiscordErrRetry(err), err
-	//}
-
 	config, err := FetchConfig(guildID)
 	if err != nil {
 		return false, err

--- a/moderation/punishments.go
+++ b/moderation/punishments.go
@@ -152,7 +152,7 @@ func punish(config *Config, p Punishment, guildID int64, channel *dstate.Channel
 		return err
 	}
 
-	logger.WithField("guild_id", guildID).Infof("MODERATION: %s %s %s cause %q", author.Username, action.Prefix, user.Username, reason)
+	logger.WithField("guild_id", guildID).Infof("MODERATION: %s %s %s with reason %q", author.Username, action.Prefix, user.Username, reason)
 	if memberNotFound {
 		// Wait a tiny bit to make sure the audit log is updated
 		time.Sleep(time.Second * 3)
@@ -383,6 +383,10 @@ func UnbanUser(config *Config, guildID int64, author *discordgo.User, reason str
 	if err != nil {
 		notbanned, err := isNotFound(err)
 		return notbanned, err
+	}
+
+	if config.LogUnbans {
+		err = CreateModlogEmbed(config, author, action, user, reason, "")
 	}
 
 	logger.Infof("MODERATION: %s %s %s with reason %q", author.Username, action.Prefix, user.Username, reason)


### PR DESCRIPTION
Fix e3c64084 incorrectly reporting ban authors in the modlog.
Modlog creation for unbans was moved to the audit log entry event
handler, erroneously reporting the bot user as the author of any unban,
including manual unbans with the bot's moderation command. Instead,
UnbanUser now handles modlog entry creation, and handleScheduledUnban
calls the same UnbanUser function rather than directly unbanning the
user.

Signed-off-by: Galen CC <galen8183@gmail.com>
