### PR TITLE
moderation: ignore non-moderation audit log events

### DIFF
--- a/moderation/plugin_bot.go
+++ b/moderation/plugin_bot.go
@@ -330,15 +330,22 @@ func HandleGuildAuditLogEntryCreate(evt *eventsystem.EventData) (retry bool, err
 	// setup done, now we get to the actions.
 	switch {
 	case config.LogTimeouts && *data.ActionType == discordgo.AuditLogActionMemberUpdate:
+		var isTimeout bool
 		for _, c := range data.Changes {
 			if *c.Key == discordgo.AuditLogChangeKeyCommunicationDisabledUntil {
 				if c.NewValue == nil {
 					return false, nil
 				} else {
+					isTimeout = true
 					break
 				}
 			}
 		}
+
+		if !isTimeout {
+			return false, nil
+		}
+
 		err = CreateModlogEmbed(config, &author.User, MATimeoutAdded, target, data.Reason, "")
 	case config.LogKicks && *data.ActionType == discordgo.AuditLogActionMemberKick:
 		err = CreateModlogEmbed(config, &author.User, MAKick, target, data.Reason, "")


### PR DESCRIPTION
Ignore all non-moderation related audit log events, rather than
(re)trying to fetch nonexistant users multiple times.

Explicitly check for AuditLogChangeKeyCommunicationDisabledUntil to
differentiate between audit log member update events that change a
member's timeout and others.
AuditLogActionMemberUpdate fires for any member update event, including
things like role and nickname changes.

Signed-off-by: Galen CC <galen8183@gmail.com>