### PR TITLE
web: add env for ports

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -30,14 +30,17 @@ var (
 	Templates *template.Template
 
 	Debug              = true // Turns on debug mode
-	ListenAddressHTTP  = ":5000"
-	ListenAddressHTTPS = ":5001"
+	ListenAddressHTTP  string
+	ListenAddressHTTPS string
 
 	// Muxers
 	RootMux            *goji.Mux
 	CPMux              *goji.Mux
 	ServerPublicMux    *goji.Mux
 	ServerPublicAPIMux *goji.Mux
+
+	confListenAddressHTTP  = config.RegisterOption("yagpdb.web.http_address", "Port to listen for HTTP requests on. Overriden by the -pa flag", 5000)
+	confListenAddressHTTPS = config.RegisterOption("yagpdb.web.https_address", "Port to listen for HTTPS requests on. Overriden by the -pa flag", 5001)
 
 	properAddresses bool
 
@@ -152,6 +155,9 @@ func Run() {
 	if properAddresses {
 		ListenAddressHTTP = ":80"
 		ListenAddressHTTPS = ":443"
+	} else {
+		ListenAddressHTTP = ":" + confListenAddressHTTP.GetString()
+		ListenAddressHTTPS = ":" + confListenAddressHTTPS.GetString()
 	}
 
 	patreon.Run()


### PR DESCRIPTION
This PR aims to assist baremetal hosters in port mapping to avoid 
conflicts with other baremetal instances. Adding this to the base
branch would facilitate ease of branch switching and merges.

Notably, the subset of users who are:
1. Self-hosters
2. Baremetal
3. Host multiple apps which need port 5000 and 5001 on the same 
machine
4. Frequently switch branches
5. Reverse proxy users

Is very slim. Notwithstanding, it is worth noting that:

pleasepleasepleasepleasepleasepleasepleasepleasepleaseplease

Signed-off-by: SoggySaussages <vmdmaharaj@gmail.com>