### PR TITLE
templates: prevent writing leading and trailing whitespace

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -779,9 +779,14 @@ func baseContextFuncs(c *Context) {
 type limitedWriter struct {
 	W io.Writer
 	N int64
+	i int64
 }
 
 func (l *limitedWriter) Write(p []byte) (n int, err error) {
+	if l.N == l.i && len(bytes.TrimSpace(p)) < 1 {
+		return 0, nil
+	}
+
 	if l.N <= 0 {
 		return 0, io.ErrShortWrite
 	}
@@ -799,9 +804,9 @@ func (l *limitedWriter) Write(p []byte) (n int, err error) {
 
 // LimitWriter works like io.LimitReader. It writes at most n bytes
 // to the underlying Writer. It returns io.ErrShortWrite if more than n
-// bytes are attempted to be written.
+// bytes are attempted to be written. It will not write leading whitespace.
 func LimitWriter(w io.Writer, n int64) io.Writer {
-	return &limitedWriter{W: w, N: n}
+	return &limitedWriter{W: w, N: n, i: n}
 }
 
 func MaybeScheduledDeleteMessage(guildID, channelID, messageID int64, delaySeconds int, token string) {


### PR DESCRIPTION
Prevent limitwriter from writing leading and trailing whitespace to the template response. This ensures whitespace which
would be trimmed off of the response regardless is not written to the buffer.

Review commit by commit, the commits get increasingly more complex to approach more consistent whitespace trim.

<img width="700" alt="Screenshot 2025-03-13 at 04 52 25" src="https://github.com/user-attachments/assets/774c186f-c3b8-43a2-a9bd-10fd2f896b9d" />

Signed-off-by: SoggySaussages <vmdmaharaj@gmail.com>