### PR TITLE
strip all invites from dms in message content to prevent abuse. 

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -503,6 +503,7 @@ func (c *Context) SendResponse(content string) (m *discordgo.Message, err error)
 		return nil, nil
 	}
 	if sendType == sendMessageDM {
+		msgSend.Content = common.ReplaceServerInvites(msgSend.Content, 0, "[removed-server-invite]")
 		msgSend.Components = []discordgo.MessageComponent{
 			discordgo.ActionsRow{
 				Components: []discordgo.MessageComponent{

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -49,7 +49,7 @@ func (c *Context) tmplSendDM(s ...interface{}) string {
 			return ""
 		}
 	default:
-		msgSend.Content = fmt.Sprint(s...)
+		msgSend.Content = common.ReplaceServerInvites(fmt.Sprint(s...), 0, "[removed-server-invite]")
 	}
 	serverInfo := []discordgo.MessageComponent{
 		discordgo.ActionsRow{
@@ -388,6 +388,7 @@ func (c *Context) tmplSendMessage(filterSpecialMentions bool, returnID bool) fun
 		}
 
 		if sendType == sendMessageDM {
+			msgSend.Content = common.ReplaceServerInvites(ToString(msg), 0, "[removed-server-invite]")
 			serverInfo := []discordgo.MessageComponent{
 				discordgo.ActionsRow{
 					Components: []discordgo.MessageComponent{

--- a/notifications/plugin_bot.go
+++ b/notifications/plugin_bot.go
@@ -186,6 +186,7 @@ func sendTemplate(gs *dstate.GuildSet, cs *dstate.ChannelState, tmpl string, ms 
 
 	var m *discordgo.Message
 	if cs.Type == discordgo.ChannelTypeDM {
+		msg = common.ReplaceServerInvites(msg, 0, "[removed-server-invite]")
 		msgSend := ctx.MessageSend(msg)
 		msgSend.Components = []discordgo.MessageComponent{
 			discordgo.ActionsRow{


### PR DESCRIPTION
Though there are genuine cases that may need this, they can continue to use embeds to send these invites, the key goal here is to prevent nsfw invites from showing up auto-embeded messages in a users dm. 