### PR TITLE
dgo/dstate: add RoleSubscriptionData to Message struct

### DIFF
--- a/lib/discordgo/message.go
+++ b/lib/discordgo/message.go
@@ -167,6 +167,9 @@ type Message struct {
 	// An array of StickerItem objects, is the message contains any.
 	StickerItems  []*StickerItem `json:"sticker_items"`
 	ApplicationID int64          `json:"application_id,string"`
+
+	// Data of the role subscription purchase or renewal that prompted this role subscription message.
+	RoleSubscriptionData *RoleSubscriptionData `json:"role_subscription_data,omitempty"`
 }
 
 type MessageSnapshot struct {
@@ -563,4 +566,12 @@ type MessageInteraction struct {
 
 	// Member is only present when the interaction is from a guild.
 	Member *Member `json:"member"`
+}
+
+// RoleSubscriptionData contains information about the data that prompted a role subscription purchase message (type 25).
+type RoleSubscriptionData struct {
+	RoleSubscriptionListingID int64  `json:"role_subscription_listing_id"`
+	TierName                  string `json:"tier_name"`
+	TotalMonthsSubscribed     int    `json:"total_months_subscribed"`
+	IsRenewal                 bool   `json:"is_renewal"`
 }

--- a/lib/dstate/helpers.go
+++ b/lib/dstate/helpers.go
@@ -80,19 +80,20 @@ func MessageStateFromDgo(m *discordgo.Message) *MessageState {
 	}
 
 	ms := &MessageState{
-		ID:               m.ID,
-		GuildID:          m.GuildID,
-		ChannelID:        m.ChannelID,
-		Author:           author,
-		Member:           m.Member,
-		Content:          m.Content,
-		MessageSnapshots: convertMessageSnapshots(m.MessageSnapshots),
-		Embeds:           embeds,
-		Mentions:         mentions,
-		Attachments:      attachments,
-		MentionRoles:     m.MentionRoles,
-		ParsedCreatedAt:  parsedC,
-		ParsedEditedAt:   parsedE,
+		ID:                   m.ID,
+		GuildID:              m.GuildID,
+		ChannelID:            m.ChannelID,
+		Author:               author,
+		Member:               m.Member,
+		Content:              m.Content,
+		MessageSnapshots:     convertMessageSnapshots(m.MessageSnapshots),
+		Embeds:               embeds,
+		Mentions:             mentions,
+		Attachments:          attachments,
+		MentionRoles:         m.MentionRoles,
+		ParsedCreatedAt:      parsedC,
+		ParsedEditedAt:       parsedE,
+		RoleSubscriptionData: m.RoleSubscriptionData,
 	}
 	if m.Reference() != nil {
 		ms.MessageReference = *m.Reference()

--- a/lib/dstate/interface.go
+++ b/lib/dstate/interface.go
@@ -420,6 +420,8 @@ type MessageState struct {
 	ParsedEditedAt  time.Time
 
 	Deleted bool
+
+	RoleSubscriptionData *discordgo.RoleSubscriptionData
 }
 
 func (m *MessageState) GetMessageContents() []string {


### PR DESCRIPTION
See [`#custom-command-help`][cchelp] for a motivation of this change.
In short: Discord populates a `role_subscription_data` field on messages
of type 25 (`ROLE_SUBSCRIPTION_PURCHASE`); add it to the `Message`
object, that way we can make it available in custom commands (and
potentially elsewhere for internal usage).

[cchelp]: https://discord.com/channels/166207328570441728/871323274066407454/1356979018070491306

This is a combination of two commits:

- discordgo: add RoleSubscriptionData message field
- dstate: add RoleSubscriptionData to MessageState struct

Unfortunately I am unable to test it myself, because I don't have any
role subscriptions enabled on any of my servers--I would expect this
change to work as expected, however, as the process of adding new stuff
to the Message struct is quite clear.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
