### PR TITLE
Fix typo in tmplRoleDropdownMulti web function name

### DIFF
--- a/web/template.go
+++ b/web/template.go
@@ -126,7 +126,7 @@ func tmplRoleDropdown(roles []discordgo.Role, highestBotRole *discordgo.Role, ar
 }
 
 // Same as tmplRoleDropdown but supports multiple selections
-func tmplRoleDropdownMutli(roles []discordgo.Role, highestBotRole *discordgo.Role, selections []int64) template.HTML {
+func tmplRoleDropdownMulti(roles []discordgo.Role, highestBotRole *discordgo.Role, selections []int64) template.HTML {
 
 	var builder strings.Builder
 

--- a/web/web.go
+++ b/web/web.go
@@ -96,7 +96,7 @@ func init() {
 		"formatTime":       prettyTime,
 		"checkbox":         tmplCheckbox,
 		"roleOptions":      tmplRoleDropdown,
-		"roleOptionsMulti": tmplRoleDropdownMutli,
+		"roleOptionsMulti": tmplRoleDropdownMulti,
 
 		"textChannelOptions":      tmplChannelOpts([]discordgo.ChannelType{discordgo.ChannelTypeGuildText, discordgo.ChannelTypeGuildNews, discordgo.ChannelTypeGuildVoice, discordgo.ChannelTypeGuildForum}),
 		"textChannelOptionsMulti": tmplChannelOptsMulti([]discordgo.ChannelType{discordgo.ChannelTypeGuildText, discordgo.ChannelTypeGuildNews, discordgo.ChannelTypeGuildVoice, discordgo.ChannelTypeGuildForum}),


### PR DESCRIPTION
Fix typo. Doubt this function will be referenced again in the future, but if so, it can be found more easily, maybe.