### PR TITLE
web: also list stage channels in channel list

### DIFF
--- a/web/template.go
+++ b/web/template.go
@@ -296,7 +296,7 @@ func (g *channelOptsHTMLGenState) outputChannel(id int64, name string, channelTy
 	switch channelType {
 	case discordgo.ChannelTypeGuildText:
 		prefix = "#"
-	case discordgo.ChannelTypeGuildVoice:
+	case discordgo.ChannelTypeGuildVoice, discordgo.ChannelTypeGuildStageVoice:
 		prefix = "🔊"
 	case discordgo.ChannelTypeGuildForum:
 		prefix = "📃"

--- a/web/web.go
+++ b/web/web.go
@@ -95,11 +95,13 @@ func init() {
 		"roleOptions":      tmplRoleDropdown,
 		"roleOptionsMulti": tmplRoleDropdownMutli,
 
-		"textChannelOptions":      tmplChannelOpts([]discordgo.ChannelType{discordgo.ChannelTypeGuildText, discordgo.ChannelTypeGuildNews, discordgo.ChannelTypeGuildVoice, discordgo.ChannelTypeGuildForum}),
-		"textChannelOptionsMulti": tmplChannelOptsMulti([]discordgo.ChannelType{discordgo.ChannelTypeGuildText, discordgo.ChannelTypeGuildNews, discordgo.ChannelTypeGuildVoice, discordgo.ChannelTypeGuildForum}),
+		"textChannelOptions": tmplChannelOpts([]discordgo.ChannelType{discordgo.ChannelTypeGuildText, discordgo.ChannelTypeGuildNews, discordgo.ChannelTypeGuildVoice, discordgo.ChannelTypeGuildForum,
+			discordgo.ChannelTypeGuildStageVoice}),
+		"textChannelOptionsMulti": tmplChannelOptsMulti([]discordgo.ChannelType{discordgo.ChannelTypeGuildText, discordgo.ChannelTypeGuildNews, discordgo.ChannelTypeGuildVoice, discordgo.ChannelTypeGuildForum,
+			discordgo.ChannelTypeGuildStageVoice}),
 
-		"voiceChannelOptions":      tmplChannelOpts([]discordgo.ChannelType{discordgo.ChannelTypeGuildVoice}),
-		"voiceChannelOptionsMulti": tmplChannelOptsMulti([]discordgo.ChannelType{discordgo.ChannelTypeGuildVoice}),
+		"voiceChannelOptions":      tmplChannelOpts([]discordgo.ChannelType{discordgo.ChannelTypeGuildVoice, discordgo.ChannelTypeGuildStageVoice}),
+		"voiceChannelOptionsMulti": tmplChannelOptsMulti([]discordgo.ChannelType{discordgo.ChannelTypeGuildVoice, discordgo.ChannelTypeGuildStageVoice}),
 
 		"catChannelOptions":      tmplChannelOpts([]discordgo.ChannelType{discordgo.ChannelTypeGuildCategory}),
 		"catChannelOptionsMulti": tmplChannelOptsMulti([]discordgo.ChannelType{discordgo.ChannelTypeGuildCategory}),


### PR DESCRIPTION
Any option where users can select channels to either ignore/require,
stage channels were missing. Add them to the predefined allowed channel
types listings (textChannelOptions, voiceChannelOptions), thus allowing
users to select these as well.

It is not entirely clear why these weren't listed, but it seems fair to
assume it was a rather simple oversight, as voice channels (once they
also got a text channel attached) evidently were added to these listings.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
