### PR TITLE
report: optionally mention roles upon report

### DIFF
--- a/moderation/assets/moderation.html
+++ b/moderation/assets/moderation.html
@@ -143,6 +143,10 @@ the punishment, is an <a href="https://help.yagpdb.xyz/docs/reference/templates/
             Report will upload a log of the last 100 messages in the channel and send a message about it in the
             report channel.
         </p>
+        <select id="roles" class="multiselect form-control" multiple="multiple" name="ReportMentionRoles" data-plugin-multiselect>
+            {{roleOptionsMulti .ActiveGuild.Roles nil nil}}
+        </select>
+        <label for="roles">Mention Roles in Reports</label>
         <hr />
 
         {{checkbox "LogUnbans" "log-unbans" "Log unban events in the modlog channel" .ModConfig.LogUnbans}}

--- a/moderation/assets/moderation.html
+++ b/moderation/assets/moderation.html
@@ -144,7 +144,7 @@ the punishment, is an <a href="https://help.yagpdb.xyz/docs/reference/templates/
             report channel.
         </p>
         <select id="roles" class="multiselect form-control" multiple="multiple" name="ReportMentionRoles" data-plugin-multiselect>
-            {{roleOptionsMulti .ActiveGuild.Roles nil nil}}
+            {{roleOptionsMulti .ActiveGuild.Roles nil .ModConfig.ReportMentionRoles}}
         </select>
         <label for="roles">Mention Roles in Reports</label>
         <hr />

--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -613,7 +613,11 @@ var ModerationCommands = []*commands.YAGCommand{
 				return "No report channel set up", nil
 			}
 
-			topContent := fmt.Sprintf("%s reported **%s (ID %d)**", parsed.Author.Mention(), target.String(), target.ID)
+			var topContent string
+			for _, r := range config.ReportMentionRoles {
+				topContent += fmt.Sprintf("<@&%d> ", r)
+			}
+			topContent += fmt.Sprintf("%s reported **%s (ID %d)**", parsed.Author.Mention(), target.String(), target.ID)
 
 			embed := &discordgo.MessageEmbed{
 				Author: &discordgo.MessageEmbedAuthor{
@@ -631,7 +635,7 @@ var ModerationCommands = []*commands.YAGCommand{
 				Content: topContent,
 				Embeds:  []*discordgo.MessageEmbed{embed},
 				AllowedMentions: discordgo.AllowedMentions{
-					Parse: []discordgo.AllowedMentionType{discordgo.AllowedMentionTypeUsers},
+					Parse: []discordgo.AllowedMentionType{discordgo.AllowedMentionTypeUsers, discordgo.AllowedMentionTypeRoles},
 				},
 			}
 

--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -614,8 +614,11 @@ var ModerationCommands = []*commands.YAGCommand{
 			}
 
 			var topContent string
-			for _, r := range config.ReportMentionRoles {
-				topContent += fmt.Sprintf("<@&%d> ", r)
+			if len(config.ReportMentionRoles) > 0 {
+				for _, r := range config.ReportMentionRoles {
+					topContent += fmt.Sprintf("<@&%d>", r)
+				}
+				topContent += ":\n"
 			}
 			topContent += fmt.Sprintf("%s reported **%s (ID %d)**", parsed.Author.Mention(), target.String(), target.ID)
 
@@ -1059,7 +1062,7 @@ var ModerationCommands = []*commands.YAGCommand{
 				if config.DelwarnIncludeWarnReason {
 					reason = fmt.Sprintf("%s\n~~%s~~", reason, warning.Message)
 				}
-				
+
 				err = CreateModlogEmbed(config, parsed.Author, MADelwarn, user, reason, "")
 				if err != nil {
 					return "Failed sending modlog, warning deleted", err
@@ -1405,6 +1408,7 @@ type MessagesWithAttachmentsFilter struct{}
 func (*MessagesWithAttachmentsFilter) Matches(msg *dstate.MessageState) (delete bool) {
 	return len(msg.GetMessageAttachments()) > 0
 }
+
 // Only delete bot messages.
 type BotMessagesFilter struct{}
 

--- a/moderation/config.go
+++ b/moderation/config.go
@@ -89,13 +89,13 @@ type Config struct {
 	DefaultMuteDuration     null.Int64       `valid:"0,"`
 
 	// Warn
-	WarnCommandsEnabled    	bool
-	WarnCmdRoles           	types.Int64Array `valid:"role,true"`
-	WarnIncludeChannelLogs 	bool
-	WarnSendToModlog       	bool
-	DelwarnSendToModlog     	bool
+	WarnCommandsEnabled      bool
+	WarnCmdRoles             types.Int64Array `valid:"role,true"`
+	WarnIncludeChannelLogs   bool
+	WarnSendToModlog         bool
+	DelwarnSendToModlog      bool
 	DelwarnIncludeWarnReason bool
-	WarnMessage            	string `valid:"template,5000"`
+	WarnMessage              string `valid:"template,5000"`
 
 	// Misc
 	CleanEnabled       bool
@@ -152,13 +152,13 @@ func (c *Config) ToModel() *models.ModerationConfig {
 		UnmuteMessage:           null.StringFrom(c.UnmuteMessage),
 		DefaultMuteDuration:     c.DefaultMuteDuration,
 
-		WarnCommandsEnabled:    null.BoolFrom(c.WarnCommandsEnabled),
-		WarnCmdRoles:           c.WarnCmdRoles,
-		WarnIncludeChannelLogs: null.BoolFrom(c.WarnIncludeChannelLogs),
-		WarnSendToModlog:       null.BoolFrom(c.WarnSendToModlog),
-		DelwarnSendToModlog:     c.DelwarnSendToModlog,
+		WarnCommandsEnabled:      null.BoolFrom(c.WarnCommandsEnabled),
+		WarnCmdRoles:             c.WarnCmdRoles,
+		WarnIncludeChannelLogs:   null.BoolFrom(c.WarnIncludeChannelLogs),
+		WarnSendToModlog:         null.BoolFrom(c.WarnSendToModlog),
+		DelwarnSendToModlog:      c.DelwarnSendToModlog,
 		DelwarnIncludeWarnReason: c.DelwarnIncludeWarnReason,
-		WarnMessage:            null.StringFrom(c.WarnMessage),
+		WarnMessage:              null.StringFrom(c.WarnMessage),
 
 		CleanEnabled:       null.BoolFrom(c.CleanEnabled),
 		ReportEnabled:      null.BoolFrom(c.ReportEnabled),
@@ -220,13 +220,13 @@ func configFromModel(model *models.ModerationConfig) *Config {
 		UnmuteMessage:           model.UnmuteMessage.String,
 		DefaultMuteDuration:     model.DefaultMuteDuration,
 
-		WarnCommandsEnabled:    model.WarnCommandsEnabled.Bool,
-		WarnCmdRoles:           model.WarnCmdRoles,
-		WarnIncludeChannelLogs: model.WarnIncludeChannelLogs.Bool,
-		WarnSendToModlog:       model.WarnSendToModlog.Bool,
-		DelwarnSendToModlog:     model.DelwarnSendToModlog,
+		WarnCommandsEnabled:      model.WarnCommandsEnabled.Bool,
+		WarnCmdRoles:             model.WarnCmdRoles,
+		WarnIncludeChannelLogs:   model.WarnIncludeChannelLogs.Bool,
+		WarnSendToModlog:         model.WarnSendToModlog.Bool,
+		DelwarnSendToModlog:      model.DelwarnSendToModlog,
 		DelwarnIncludeWarnReason: model.DelwarnIncludeWarnReason,
-		WarnMessage:            model.WarnMessage.String,
+		WarnMessage:              model.WarnMessage.String,
 
 		CleanEnabled:       model.CleanEnabled.Bool,
 		ReportEnabled:      model.ReportEnabled.Bool,

--- a/moderation/config.go
+++ b/moderation/config.go
@@ -98,15 +98,16 @@ type Config struct {
 	WarnMessage            	string `valid:"template,5000"`
 
 	// Misc
-	CleanEnabled  bool
-	ReportEnabled bool
-	ActionChannel int64 `valid:"channel,true"`
-	ReportChannel int64 `valid:"channel,true"`
-	ErrorChannel  int64 `valid:"channel,true"`
-	LogUnbans     bool
-	LogBans       bool
-	LogKicks      bool
-	LogTimeouts   bool
+	CleanEnabled       bool
+	ReportEnabled      bool
+	ReportMentionRoles types.Int64Array `valid:"role,true"`
+	ActionChannel      int64            `valid:"channel,true"`
+	ReportChannel      int64            `valid:"channel,true"`
+	ErrorChannel       int64            `valid:"channel,true"`
+	LogUnbans          bool
+	LogBans            bool
+	LogKicks           bool
+	LogTimeouts        bool
 
 	GiveRoleCmdEnabled bool
 	GiveRoleCmdModlog  bool
@@ -159,15 +160,16 @@ func (c *Config) ToModel() *models.ModerationConfig {
 		DelwarnIncludeWarnReason: c.DelwarnIncludeWarnReason,
 		WarnMessage:            null.StringFrom(c.WarnMessage),
 
-		CleanEnabled:  null.BoolFrom(c.CleanEnabled),
-		ReportEnabled: null.BoolFrom(c.ReportEnabled),
-		ActionChannel: null.StringFrom(discordgo.StrID(c.ActionChannel)),
-		ReportChannel: null.StringFrom(discordgo.StrID(c.ReportChannel)),
-		ErrorChannel:  null.StringFrom(discordgo.StrID(c.ErrorChannel)),
-		LogUnbans:     null.BoolFrom(c.LogUnbans),
-		LogBans:       null.BoolFrom(c.LogBans),
-		LogKicks:      null.BoolFrom(c.LogKicks),
-		LogTimeouts:   null.BoolFrom(c.LogTimeouts),
+		CleanEnabled:       null.BoolFrom(c.CleanEnabled),
+		ReportEnabled:      null.BoolFrom(c.ReportEnabled),
+		ReportMentionRoles: c.ReportMentionRoles,
+		ActionChannel:      null.StringFrom(discordgo.StrID(c.ActionChannel)),
+		ReportChannel:      null.StringFrom(discordgo.StrID(c.ReportChannel)),
+		ErrorChannel:       null.StringFrom(discordgo.StrID(c.ErrorChannel)),
+		LogUnbans:          null.BoolFrom(c.LogUnbans),
+		LogBans:            null.BoolFrom(c.LogBans),
+		LogKicks:           null.BoolFrom(c.LogKicks),
+		LogTimeouts:        null.BoolFrom(c.LogTimeouts),
 
 		GiveRoleCmdEnabled: null.BoolFrom(c.GiveRoleCmdEnabled),
 		GiveRoleCmdModlog:  null.BoolFrom(c.GiveRoleCmdModlog),
@@ -226,15 +228,16 @@ func configFromModel(model *models.ModerationConfig) *Config {
 		DelwarnIncludeWarnReason: model.DelwarnIncludeWarnReason,
 		WarnMessage:            model.WarnMessage.String,
 
-		CleanEnabled:  model.CleanEnabled.Bool,
-		ReportEnabled: model.ReportEnabled.Bool,
-		ActionChannel: actionChannel,
-		ReportChannel: reportChannel,
-		ErrorChannel:  errorChannel,
-		LogUnbans:     model.LogUnbans.Bool,
-		LogBans:       model.LogBans.Bool,
-		LogKicks:      model.LogKicks.Bool,
-		LogTimeouts:   model.LogTimeouts.Bool,
+		CleanEnabled:       model.CleanEnabled.Bool,
+		ReportEnabled:      model.ReportEnabled.Bool,
+		ReportMentionRoles: model.ReportMentionRoles,
+		ActionChannel:      actionChannel,
+		ReportChannel:      reportChannel,
+		ErrorChannel:       errorChannel,
+		LogUnbans:          model.LogUnbans.Bool,
+		LogBans:            model.LogBans.Bool,
+		LogKicks:           model.LogKicks.Bool,
+		LogTimeouts:        model.LogTimeouts.Bool,
 
 		GiveRoleCmdEnabled: model.GiveRoleCmdEnabled.Bool,
 		GiveRoleCmdModlog:  model.GiveRoleCmdModlog.Bool,

--- a/moderation/models/moderation_configs.go
+++ b/moderation/models/moderation_configs.go
@@ -63,6 +63,7 @@ type ModerationConfig struct {
 	WarnMessage                 null.String      `boil:"warn_message" json:"warn_message,omitempty" toml:"warn_message" yaml:"warn_message,omitempty"`
 	CleanEnabled                null.Bool        `boil:"clean_enabled" json:"clean_enabled,omitempty" toml:"clean_enabled" yaml:"clean_enabled,omitempty"`
 	ReportEnabled               null.Bool        `boil:"report_enabled" json:"report_enabled,omitempty" toml:"report_enabled" yaml:"report_enabled,omitempty"`
+	ReportMentionRoles          types.Int64Array `boil:"report_mention_roles" json:"report_mention_roles,omitempty" toml:"report_mention_roles" yaml:"report_mention_roles,omitempty"`
 	ActionChannel               null.String      `boil:"action_channel" json:"action_channel,omitempty" toml:"action_channel" yaml:"action_channel,omitempty"`
 	ReportChannel               null.String      `boil:"report_channel" json:"report_channel,omitempty" toml:"report_channel" yaml:"report_channel,omitempty"`
 	ErrorChannel                null.String      `boil:"error_channel" json:"error_channel,omitempty" toml:"error_channel" yaml:"error_channel,omitempty"`
@@ -121,6 +122,7 @@ var ModerationConfigColumns = struct {
 	ReportEnabled               string
 	ActionChannel               string
 	ReportChannel               string
+	ReportMentionRoles          string
 	ErrorChannel                string
 	LogUnbans                   string
 	LogBans                     string
@@ -172,6 +174,7 @@ var ModerationConfigColumns = struct {
 	ReportEnabled:               "report_enabled",
 	ActionChannel:               "action_channel",
 	ReportChannel:               "report_channel",
+	ReportMentionRoles:          "report_mention_roles",
 	ErrorChannel:                "error_channel",
 	LogUnbans:                   "log_unbans",
 	LogBans:                     "log_bans",
@@ -225,6 +228,7 @@ var ModerationConfigTableColumns = struct {
 	ReportEnabled               string
 	ActionChannel               string
 	ReportChannel               string
+	ReportMentionRoles          string
 	ErrorChannel                string
 	LogUnbans                   string
 	LogBans                     string
@@ -276,6 +280,7 @@ var ModerationConfigTableColumns = struct {
 	ReportEnabled:               "moderation_configs.report_enabled",
 	ActionChannel:               "moderation_configs.action_channel",
 	ReportChannel:               "moderation_configs.report_channel",
+	ReportMentionRoles:          "moderation_configs.report_mention_roles",
 	ErrorChannel:                "moderation_configs.error_channel",
 	LogUnbans:                   "moderation_configs.log_unbans",
 	LogBans:                     "moderation_configs.log_bans",
@@ -514,6 +519,7 @@ var ModerationConfigWhere = struct {
 	ReportEnabled               whereHelpernull_Bool
 	ActionChannel               whereHelpernull_String
 	ReportChannel               whereHelpernull_String
+	ReportMentionRoles          whereHelpertypes_Int64Array
 	ErrorChannel                whereHelpernull_String
 	LogUnbans                   whereHelpernull_Bool
 	LogBans                     whereHelpernull_Bool
@@ -565,6 +571,7 @@ var ModerationConfigWhere = struct {
 	ReportEnabled:               whereHelpernull_Bool{field: "\"moderation_configs\".\"report_enabled\""},
 	ActionChannel:               whereHelpernull_String{field: "\"moderation_configs\".\"action_channel\""},
 	ReportChannel:               whereHelpernull_String{field: "\"moderation_configs\".\"report_channel\""},
+	ReportMentionRoles:          whereHelpertypes_Int64Array{field: "\"moderation_configs\".\"report_mention_roles\""},
 	ErrorChannel:                whereHelpernull_String{field: "\"moderation_configs\".\"error_channel\""},
 	LogUnbans:                   whereHelpernull_Bool{field: "\"moderation_configs\".\"log_unbans\""},
 	LogBans:                     whereHelpernull_Bool{field: "\"moderation_configs\".\"log_bans\""},
@@ -594,9 +601,9 @@ func (*moderationConfigR) NewStruct() *moderationConfigR {
 type moderationConfigL struct{}
 
 var (
-	moderationConfigAllColumns            = []string{"guild_id", "created_at", "updated_at", "kick_enabled", "kick_cmd_roles", "delete_messages_on_kick", "kick_reason_optional", "kick_message", "ban_enabled", "ban_cmd_roles", "ban_reason_optional", "ban_message", "default_ban_delete_days", "timeout_enabled", "timeout_cmd_roles", "timeout_reason_optional", "timeout_remove_reason_optional", "timeout_message", "default_timeout_duration", "mute_enabled", "mute_cmd_roles", "mute_role", "mute_disallow_reaction_add", "mute_reason_optional", "unmute_reason_optional", "mute_manage_role", "mute_remove_roles", "mute_ignore_channels", "mute_message", "unmute_message", "default_mute_duration", "warn_commands_enabled", "warn_cmd_roles", "warn_include_channel_logs", "warn_send_to_modlog", "warn_message", "clean_enabled", "report_enabled", "action_channel", "report_channel", "error_channel", "log_unbans", "log_bans", "log_kicks", "log_timeouts", "give_role_cmd_enabled", "give_role_cmd_modlog", "give_role_cmd_roles", "delwarn_send_to_modlog", "delwarn_include_warn_reason"}
+	moderationConfigAllColumns            = []string{"guild_id", "created_at", "updated_at", "kick_enabled", "kick_cmd_roles", "delete_messages_on_kick", "kick_reason_optional", "kick_message", "ban_enabled", "ban_cmd_roles", "ban_reason_optional", "ban_message", "default_ban_delete_days", "timeout_enabled", "timeout_cmd_roles", "timeout_reason_optional", "timeout_remove_reason_optional", "timeout_message", "default_timeout_duration", "mute_enabled", "mute_cmd_roles", "mute_role", "mute_disallow_reaction_add", "mute_reason_optional", "unmute_reason_optional", "mute_manage_role", "mute_remove_roles", "mute_ignore_channels", "mute_message", "unmute_message", "default_mute_duration", "warn_commands_enabled", "warn_cmd_roles", "warn_include_channel_logs", "warn_send_to_modlog", "warn_message", "clean_enabled", "report_enabled", "action_channel", "report_channel", "report_mention_roles", "error_channel", "log_unbans", "log_bans", "log_kicks", "log_timeouts", "give_role_cmd_enabled", "give_role_cmd_modlog", "give_role_cmd_roles", "delwarn_send_to_modlog", "delwarn_include_warn_reason"}
 	moderationConfigColumnsWithoutDefault = []string{"guild_id", "created_at", "updated_at"}
-	moderationConfigColumnsWithDefault    = []string{"kick_enabled", "kick_cmd_roles", "delete_messages_on_kick", "kick_reason_optional", "kick_message", "ban_enabled", "ban_cmd_roles", "ban_reason_optional", "ban_message", "default_ban_delete_days", "timeout_enabled", "timeout_cmd_roles", "timeout_reason_optional", "timeout_remove_reason_optional", "timeout_message", "default_timeout_duration", "mute_enabled", "mute_cmd_roles", "mute_role", "mute_disallow_reaction_add", "mute_reason_optional", "unmute_reason_optional", "mute_manage_role", "mute_remove_roles", "mute_ignore_channels", "mute_message", "unmute_message", "default_mute_duration", "warn_commands_enabled", "warn_cmd_roles", "warn_include_channel_logs", "warn_send_to_modlog", "warn_message", "clean_enabled", "report_enabled", "action_channel", "report_channel", "error_channel", "log_unbans", "log_bans", "log_kicks", "log_timeouts", "give_role_cmd_enabled", "give_role_cmd_modlog", "give_role_cmd_roles", "delwarn_send_to_modlog", "delwarn_include_warn_reason"}
+	moderationConfigColumnsWithDefault    = []string{"kick_enabled", "kick_cmd_roles", "delete_messages_on_kick", "kick_reason_optional", "kick_message", "ban_enabled", "ban_cmd_roles", "ban_reason_optional", "ban_message", "default_ban_delete_days", "timeout_enabled", "timeout_cmd_roles", "timeout_reason_optional", "timeout_remove_reason_optional", "timeout_message", "default_timeout_duration", "mute_enabled", "mute_cmd_roles", "mute_role", "mute_disallow_reaction_add", "mute_reason_optional", "unmute_reason_optional", "mute_manage_role", "mute_remove_roles", "mute_ignore_channels", "mute_message", "unmute_message", "default_mute_duration", "warn_commands_enabled", "warn_cmd_roles", "warn_include_channel_logs", "warn_send_to_modlog", "warn_message", "clean_enabled", "report_enabled", "action_channel", "report_channel", "report_mention_roles", "error_channel", "log_unbans", "log_bans", "log_kicks", "log_timeouts", "give_role_cmd_enabled", "give_role_cmd_modlog", "give_role_cmd_roles", "delwarn_send_to_modlog", "delwarn_include_warn_reason"}
 	moderationConfigPrimaryKeyColumns     = []string{"guild_id"}
 	moderationConfigGeneratedColumns      = []string{}
 )

--- a/moderation/schema.go
+++ b/moderation/schema.go
@@ -79,7 +79,7 @@ ALTER TABLE moderation_configs ADD COLUMN IF NOT EXISTS delwarn_send_to_modlog B
 `, `
 ALTER TABLE moderation_configs ADD COLUMN IF NOT EXISTS delwarn_include_warn_reason BOOLEAN NOT NULL DEFAULT false;
 `, `
-ALTER TABLE moderation_configs ADD COLUMN IF NOT EXISTS report_mention_roles BIGINT[] NOT NULL DEFAULT {};
+ALTER TABLE moderation_configs ADD COLUMN IF NOT EXISTS report_mention_roles BIGINT[] NOT NULL DEFAULT '{}';
 `, `
 
 CREATE TABLE IF NOT EXISTS moderation_warnings (

--- a/moderation/schema.go
+++ b/moderation/schema.go
@@ -79,6 +79,8 @@ ALTER TABLE moderation_configs ADD COLUMN IF NOT EXISTS delwarn_send_to_modlog B
 `, `
 ALTER TABLE moderation_configs ADD COLUMN IF NOT EXISTS delwarn_include_warn_reason BOOLEAN NOT NULL DEFAULT false;
 `, `
+ALTER TABLE moderation_configs ADD COLUMN IF NOT EXISTS report_mention_roles BIGINT[] NOT NULL DEFAULT {};
+`, `
 
 CREATE TABLE IF NOT EXISTS moderation_warnings (
 	id SERIAL PRIMARY KEY,


### PR DESCRIPTION
Add configurable roles to the control panel which the Report command will mention upon a report being made.

![Screenshot 2025-04-12 at 00 09 49](https://github.com/user-attachments/assets/aa102dc8-78c8-45da-9260-d7e3d4f7a220)
![Screenshot 2025-04-12 at 00 08 42](https://github.com/user-attachments/assets/40addfee-6f5e-4c15-b2f3-cf639e7190a7)
![Screenshot 2025-04-12 at 00 08 31](https://github.com/user-attachments/assets/e6be71c5-9136-45f5-89bd-581294d8e8c3)

Signed-off-by: SoggySaussages <vmdmaharaj@gmail.com>