### PR TITLE
Add support for editing target user's nickname in templates

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -739,6 +739,7 @@ func baseContextFuncs(c *Context) {
 	c.addContextFunc("getMember", c.tmplGetMember)
 	c.addContextFunc("getMemberVoiceState", c.tmplGetMemberVoiceState)
 	c.addContextFunc("editNickname", c.tmplEditNickname)
+	c.addContextFunc("editTargetNickname", c.tmplEditTargetNickname)
 
 	// Thread functions
 	c.addContextFunc("addThreadMember", c.tmplThreadMemberAdd)

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -1897,7 +1897,7 @@ func (c *Context) tmplOnlineCountBots() (int, error) {
 	return 0, nil
 }
 
-func (c *Context) tmplEditNickname(Nickname string) (string, error) {
+func (c *Context) tmplEditTargetNickname(target interface{}, Nickname string) (string, error) {
 	if c.IncreaseCheckCallCounter("edit_nick", 2) {
 		return "", ErrTooManyCalls
 	}
@@ -1906,16 +1906,25 @@ func (c *Context) tmplEditNickname(Nickname string) (string, error) {
 		return "", nil
 	}
 
-	if strings.Compare(c.MS.Member.Nick, Nickname) == 0 {
+	targetID := TargetUserID(target)
+	if targetID == 0 {
 		return "", nil
 	}
 
-	err := common.BotSession.GuildMemberNickname(c.GS.ID, c.MS.User.ID, Nickname)
+	if targetID == c.MS.User.ID && strings.Compare(c.MS.Member.Nick, Nickname) == 0 {
+		return "", nil
+	}
+
+	err := common.BotSession.GuildMemberNickname(c.GS.ID, targetID, Nickname)
 	if err != nil {
 		return "", err
 	}
 
 	return "", nil
+}
+
+func (c *Context) tmplEditNickname(Nickname string) (string, error) {
+	return c.tmplEditTargetNickname(c.MS.User.ID, Nickname)
 }
 
 func (c *Context) tmplSort(input interface{}, args ...interface{}) (interface{}, error) {


### PR DESCRIPTION
We have a case where we want to change a member's nickname as admins.
The only available way is through [`editNickname`](https://help.yagpdb.xyz/docs/reference/templates/functions/#editnickname), but it only works for the member who triggered the command.
This PR adds `editTargetNickname` to allow changing someone else's nickname by mention or ID.
Should I submit a separate PR to update the docs as well?