### PR TITLE
moderation: record moderator in audit log for bulk delete

### DIFF
--- a/lib/discordgo/restapi.go
+++ b/lib/discordgo/restapi.go
@@ -1811,7 +1811,16 @@ func (s *Session) ChannelMessageDelete(channelID, messageID int64) (err error) {
 // channelID : The ID of the channel for the messages to delete.
 // messages  : The IDs of the messages to be deleted. A slice of message IDs. A maximum of 100 messages.
 func (s *Session) ChannelMessagesBulkDelete(channelID int64, messages []int64) (err error) {
+	return s.doChannelMessagesBulkDelete(channelID, messages, "")
+}
 
+// ChannelMessagesBulkDeleteWithReason bulk deletes the messages from the channel for the provided messageIDs, with an additional reason
+// for the X-Audit-Log-Reason header.
+func (s *Session) ChannelMessagesBulkDeleteWithReason(channelID int64, messages []int64, reason string) (err error) {
+	return s.doChannelMessagesBulkDelete(channelID, messages, reason)
+}
+
+func (s *Session) doChannelMessagesBulkDelete(channelID int64, messages []int64, reason string) (err error) {
 	if len(messages) == 0 {
 		return
 	}
@@ -1829,7 +1838,12 @@ func (s *Session) ChannelMessagesBulkDelete(channelID int64, messages []int64) (
 		Messages IDSlice `json:"messages"`
 	}{messages}
 
-	_, err = s.RequestWithBucketID("POST", EndpointChannelMessagesBulkDelete(channelID), data, nil, EndpointChannelMessagesBulkDelete(channelID))
+	headers := make(map[string]string)
+	if reason != "" {
+		headers["X-Audit-Log-Reason"] = url.PathEscape(reason)
+	}
+
+	_, err = s.RequestWithBucketID("POST", EndpointChannelMessagesBulkDelete(channelID), data, headers, EndpointChannelMessagesBulkDelete(channelID))
 	return
 }
 

--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -793,7 +793,8 @@ var ModerationCommands = []*commands.YAGCommand{
 				err = common.BotSession.ChannelMessageDelete(parsed.ChannelID, toDelete[0])
 				resp = "Deleted 1 message! :')"
 			default:
-				err = common.BotSession.ChannelMessagesBulkDelete(parsed.ChannelID, toDelete)
+				reason := fmt.Sprintf("Deleted by %s", parsed.Author.String())
+				err = common.BotSession.ChannelMessagesBulkDeleteWithReason(parsed.ChannelID, toDelete, reason)
 				resp = fmt.Sprintf("Deleted %d messages! :')", numDeleted)
 			}
 
@@ -1055,7 +1056,7 @@ var ModerationCommands = []*commands.YAGCommand{
 				if config.DelwarnIncludeWarnReason {
 					reason = fmt.Sprintf("%s\n~~%s~~", reason, warning.Message)
 				}
-				
+
 				err = CreateModlogEmbed(config, parsed.Author, MADelwarn, user, reason, "")
 				if err != nil {
 					return "Failed sending modlog, warning deleted", err
@@ -1401,6 +1402,7 @@ type MessagesWithAttachmentsFilter struct{}
 func (*MessagesWithAttachmentsFilter) Matches(msg *dstate.MessageState) (delete bool) {
 	return len(msg.GetMessageAttachments()) > 0
 }
+
 // Only delete bot messages.
 type BotMessagesFilter struct{}
 


### PR DESCRIPTION
This sets the `X-Audit-Log-Reason` header for bulk deletions via the 
`clean` command to `Deleted by $AUTHOR`.

Currently, it seems the header is neither respected nor a reason
displayed when viewing the audit log for this action, but we'll add this
functionality and wait for Discord to work their magic.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
