### PR TITLE
templates: properly edit message flags in tmplEditMessage

### DIFF
--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -477,10 +477,11 @@ func (c *Context) tmplEditMessage(filterSpecialMentions bool) func(channel inter
 					return "", errors.New("both content and embed cannot be null")
 				}
 			}
+			msgEdit.AllowedMentions = typedMsg.AllowedMentions
+			msgEdit.Components = typedMsg.Components
 			msgEdit.Content = typedMsg.Content
 			msgEdit.Embeds = typedMsg.Embeds
-			msgEdit.Components = typedMsg.Components
-			msgEdit.AllowedMentions = typedMsg.AllowedMentions
+			msgEdit.Flags = typedMsg.Flags
 		default:
 			temp := fmt.Sprint(msg)
 			msgEdit.Content = &temp


### PR DESCRIPTION
The tmplEditMessage function does not properly transfer message flags
over to the new message object, causing some funny behaviour when, for
example, trying to set `suppress_embeds` to `true` via the
`complexMessageEdit`-builder. In other words, it does not work at all.

Copying the message flags over to the new messag fixes this.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
