### PR TITLE
Fix typo in the error message on line 84 (` replaced with ')

### DIFF
--- a/common/parseduration.go
+++ b/common/parseduration.go
@@ -81,7 +81,7 @@ func parseDurationComponent(numStr, modifierStr string) (time.Duration, error) {
 	case strings.HasPrefix(modifierStr, "y"):
 		parsedDur = parsedDur * time.Hour * 24 * 365
 	default:
-		return 0, errors.New("couldn't figure out what '" + numStr + modifierStr + "` was")
+		return 0, errors.New("couldn't figure out what '" + numStr + modifierStr + "' was")
 	}
 
 	return parsedDur, nil


### PR DESCRIPTION
The error message on line 84 has a backtick (`) instead of a single quote ('), which is inconsistent with the rest of the error message. Although this has no impact on functionality, this can cause formatting issues. If users use backticks anywhere in their response for parseArgs, the response may look messy.