### PR TITLE
Update library `dice` to the latest version

### DIFF
--- a/lib/dice/dice.go
+++ b/lib/dice/dice.go
@@ -1,3 +1,26 @@
+// Package dice provides a library for rolling tabletop role-playing style dice
+// via a text description similar to that used in such games.
+//
+// Examples
+//
+//	dice.Roll("3d6") // Roll and sum 3 six-sided dice
+//	dice.Roll("1d20+2") // Roll a twenty-sided die and add 2
+//
+// # Supported formats
+//
+// Standard: `xdy[[k|d][h|l]z][+/-c]` - rolls and sums x y-sided dice,
+// keeping or dropping the lowest or highest z dice and optionally adding
+// or subtracting c. Example: 4d6kh3+4
+//
+// Fudge: `xdf[+/-c]` - rolls and sums x fudge dice (Dice that return
+// numbers between -1 and 1), and optionally adding or subtracting c.
+// Example: 4df+4
+//
+// Versus: `xdy[e|r]vt` - rolls x y-sided dice, counting the number that
+// roll t or greater.
+//
+// EotE: `xc [xc ...]` - rolls x dice of color c (b, blk, g, p, r, w, y)
+// and returns the aggregate result.
 package dice
 
 import (
@@ -15,6 +38,15 @@ var (
 	ErrTooManyLoops = errors.New("Too many loops, you either specified too many dices or sides")
 )
 
+// RollResult is an interface to describe a dice roll and its outcome.
+//
+// RollResult contains [fmt.Stringer], and calling `String()` on a RollResult
+// will get a textual description of the roll outcome.
+//
+// Description returns a textual description of the roll. This is often the
+// same as the input to [dice.Roll].
+//
+// Int will get the result of the roll as an integer.
 type RollResult interface {
 	fmt.Stringer
 	Description() string
@@ -43,6 +75,8 @@ func addRollHandler(handler roller) {
 	sil - regexp.MustCompile(`([0-9]+)d([0-9]+)(e)?s$`)
 */
 
+// Roll parses the given description and calls the appropriate roller implementation,
+// if found. Returns the result plus any extra trailing text if successful.
 func Roll(desc string) (RollResult, string, error) {
 	for _, rollHandler := range rollHandlers {
 		rollHandler.Pattern().Longest()

--- a/lib/dice/dice_test.go
+++ b/lib/dice/dice_test.go
@@ -21,6 +21,22 @@ func TestRoll(t *testing.T) {
 		t.Fatalf("err not detected in %s", roll)
 	}
 
+	roll = "4d0"
+	_, _, err = Roll(roll)
+	if err != nil {
+		t.Logf("err '%v' properly detected in %s", err, roll)
+	} else {
+		t.Fatalf("err not detected in %s", roll)
+	}
+
+	roll = "4d0v5"
+	_, _, err = Roll(roll)
+	if err != nil {
+		t.Logf("err '%v' properly detected in %s", err, roll)
+	} else {
+		t.Fatalf("err not detected in %s", roll)
+	}
+
 	roll = "3b4bl"
 	_, reason, err := Roll(roll)
 	if reason == "4bl" {
@@ -34,6 +50,39 @@ func TestRoll(t *testing.T) {
 	res, _, _ = Roll(roll)
 	if _, ok := res.(VsResult); !ok {
 		t.Fatalf("%s is not a VsResult", roll)
+	}
+
+	// Trying to keep or drop too many dice
+	roll = "2d6k5"
+	_, _, err = Roll(roll)
+	if err != nil {
+		t.Logf("err '%v' properly detected in %s", err, roll)
+	} else {
+		t.Fatalf("err not detected in %s", roll)
+	}
+
+	roll = "2d6kl5"
+	_, _, err = Roll(roll)
+	if err != nil {
+		t.Logf("err '%v' properly detected in %s", err, roll)
+	} else {
+		t.Fatalf("err not detected in %s", roll)
+	}
+
+	roll = "2d6dh5"
+	_, _, err = Roll(roll)
+	if err != nil {
+		t.Logf("err '%v' properly detected in %s", err, roll)
+	} else {
+		t.Fatalf("err not detected in %s", roll)
+	}
+
+	roll = "2d6dl5"
+	_, _, err = Roll(roll)
+	if err != nil {
+		t.Logf("err '%v' properly detected in %s", err, roll)
+	} else {
+		t.Fatalf("err not detected in %s", roll)
 	}
 }
 

--- a/lib/dice/dice_test.go
+++ b/lib/dice/dice_test.go
@@ -3,7 +3,7 @@ package dice_test
 import (
 	"testing"
 
-	. "github.com/justinian/dice"
+	. "github.com/botlabs-gg/yagpdb/v2/lib/dice"
 )
 
 func TestRoll(t *testing.T) {

--- a/lib/dice/eote_test.go
+++ b/lib/dice/eote_test.go
@@ -1,7 +1,7 @@
 package dice_test
 
 import (
-	. "github.com/justinian/dice"
+	. "github.com/botlabs-gg/yagpdb/v2/lib/dice"
 	. "gopkg.in/check.v1"
 )
 

--- a/lib/dice/std.go
+++ b/lib/dice/std.go
@@ -23,7 +23,11 @@ type StdResult struct {
 }
 
 func (r StdResult) String() string {
-	return fmt.Sprintf("%d %v (%v)", r.Total, r.Rolls, r.Dropped)
+	if len(r.Dropped) > 0 {
+		return fmt.Sprintf("%d %v (%v)", r.Total, r.Rolls, r.Dropped)
+	} else {
+		return fmt.Sprintf("%d %v", r.Total, r.Rolls)
+	}
 }
 
 func (r StdResult) Int() int {
@@ -85,19 +89,33 @@ func (StdRoller) Roll(matches []string) (RollResult, error) {
 	case "k":
 		fallthrough
 	case "kh":
-		result.Dropped = result.Rolls[:size-num]
-		result.Rolls = result.Rolls[size-num:]
+		slice := size - num
+		if slice < 0 {
+			return nil, errors.New("Can't keep more dice than rolled")
+		}
+		result.Dropped = result.Rolls[:slice]
+		result.Rolls = result.Rolls[slice:]
 	case "d":
 		fallthrough
 	case "dl":
+		if num > size {
+			return nil, errors.New("Can't drop more dice than rolled")
+		}
 		result.Dropped = result.Rolls[:num]
 		result.Rolls = result.Rolls[num:]
 	case "kl":
+		if num > size {
+			return nil, errors.New("Can't keep more dice than rolled")
+		}
 		result.Dropped = result.Rolls[num:]
 		result.Rolls = result.Rolls[:num]
 	case "dh":
-		result.Dropped = result.Rolls[size-num:]
-		result.Rolls = result.Rolls[:size-num]
+		slice := size - num
+		if slice < 0 {
+			return nil, errors.New("Can't drop more dice than rolled")
+		}
+		result.Dropped = result.Rolls[slice:]
+		result.Rolls = result.Rolls[:slice]
 	}
 
 	for i := 0; i < len(result.Rolls); i++ {

--- a/lib/dice/std_test.go
+++ b/lib/dice/std_test.go
@@ -3,7 +3,7 @@ package dice_test
 import (
 	"testing"
 
-	. "github.com/justinian/dice"
+	. "github.com/botlabs-gg/yagpdb/v2/lib/dice"
 	. "gopkg.in/check.v1"
 )
 

--- a/lib/dice/std_test.go
+++ b/lib/dice/std_test.go
@@ -95,7 +95,7 @@ func (s *stdSuite) TestBonus(c *C) {
 	res := r.(StdResult)
 
 	c.Assert(err, IsNil)
-	c.Assert(res.String(), Equals, "2 [1] ([])")
+	c.Assert(res.String(), Equals, "2 [1]")
 }
 
 func (s *stdSuite) TestNumTooBig(c *C) {

--- a/lib/dice/versus_test.go
+++ b/lib/dice/versus_test.go
@@ -1,7 +1,7 @@
 package dice_test
 
 import (
-	. "github.com/justinian/dice"
+	. "github.com/botlabs-gg/yagpdb/v2/lib/dice"
 	. "gopkg.in/check.v1"
 )
 


### PR DESCRIPTION
Fixes an issue with `/roll rpg-dice` where it was possible to make YAGPDB to never answer and eventually timeout due to a bug in this library that has since been solved there. For more info, see `dice_test.go:55`

Since the used version of the library is based on a fork, I also made sure to keep all custom changes to the code.

To replicate the issue, try to input the following command to YAGPDB:
```
/roll rpg-dice:1d1k2
```