### PR TITLE
Corrected line 84 (changed back tick to single quote)

### DIFF
--- a/common/parseduration.go
+++ b/common/parseduration.go
@@ -81,7 +81,7 @@ func parseDurationComponent(numStr, modifierStr string) (time.Duration, error) {
 	case strings.HasPrefix(modifierStr, "y"):
 		parsedDur = parsedDur * time.Hour * 24 * 365
 	default:
-		return 0, errors.New("couldn't figure out what '" + numStr + modifierStr + "` was")
+		return 0, errors.New("couldn't figure out what '" + numStr + modifierStr + "' was")
 	}
 
 	return parsedDur, nil


### PR DESCRIPTION
The error that outputs on line 84 has a back tick (`) where a single quote (') should be. This causes some strange visual effects in Discord when another back tick appears in the response.