### PR TITLE
evalcc: raise ops limit

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -326,8 +326,8 @@ func (c *Context) Parse(source string) (*template.Template, error) {
 const (
 	MaxOpsNormal      = 1000000
 	MaxOpsPremium     = 2500000
-	MaxOpsEvalNormal  = 5000
-	MaxOpsEvalPremium = 10000
+	MaxOpsEvalNormal  = 200000
+	MaxOpsEvalPremium = 500000
 )
 
 func (c *Context) Execute(source string) (string, error) {


### PR DESCRIPTION
Raise the ops limit on evalcc to 200k and 500k respectively; it can be
argued that, because evalcc is about a fifth of a custom command, the
ops limit should be a fifth of a custom command, as well.

For reference, the generic api call counter is already at 20, which is a
fifth of the normal custom command api call limit.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
