### PR TITLE
logs/whois: show roles of target member

### DIFF
--- a/logs/plugin_bot.go
+++ b/logs/plugin_bot.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"emperror.dev/errors"
@@ -167,6 +168,15 @@ var cmdWhois = &commands.YAGCommand{
 			}
 		}
 
+		var sb strings.Builder
+		for i, role := range member.Member.Roles {
+			if i == 25 {
+				sb.WriteString("... and more")
+				break
+			}
+			fmt.Fprintf(&sb, "<@&%d> ", role)
+		}
+
 		embed := &discordgo.MessageEmbed{
 			Title: fmt.Sprintf("%s %s", member.User.String(), nick),
 			Fields: []*discordgo.MessageEmbedField{
@@ -204,6 +214,11 @@ var cmdWhois = &commands.YAGCommand{
 					Name:   "Status",
 					Value:  memberStatus,
 					Inline: true,
+				},
+				{
+					Name:   "Roles",
+					Value:  sb.String(),
+					Inline: false,
 				},
 			},
 			Thumbnail: &discordgo.MessageEmbedThumbnail{


### PR DESCRIPTION
Show roles of the target member in the response of `whois` as well.
This one was often requested, I'm just sending this patch to make these
requests stop (there were quite a lot).

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

---

| Before | After |
| ------ | ----- |
| ![before](https://github.com/user-attachments/assets/a1dc3610-47a4-453a-80f9-a29d919a5f48) | ![after](https://github.com/user-attachments/assets/d40689ff-15b3-47a9-9027-f3318f6a96b6) |
