### PR TITLE
automod: clarify Delete Multiple Messages effect tooltip

### DIFF
--- a/automod/effects.go
+++ b/automod/effects.go
@@ -88,7 +88,7 @@ func (del *DeleteMessagesEffect) Name() (name string) {
 }
 
 func (del *DeleteMessagesEffect) Description() (description string) {
-	return "Deletes a certain number of the users last messages in this channel"
+	return "Deletes a certain number of the infracting user's last messages in this channel"
 }
 
 func (del *DeleteMessagesEffect) UserSettings() []*SettingDef {
@@ -879,7 +879,7 @@ func (send *SendChannelMessageEffect) MergeDuplicates(data []interface{}) interf
 
 type SendModeratorAlertMessageData struct {
 	CustomMessage string `valid:",0,280,trimspace"`
-	LogChannel   int64
+	LogChannel    int64
 }
 
 type SendModeratorAlertMessageEffect struct{}
@@ -948,7 +948,7 @@ func (send *SendModeratorAlertMessageEffect) Apply(ctxData *TriggeredRuleData, s
 
 	msgEmbed := &discordgo.MessageEmbed{
 		Author: &discordgo.MessageEmbedAuthor{
-			Name: fmt.Sprintf("%s (ID: %d)", ctxData.MS.User.Username, ctxData.MS.User.ID),
+			Name:    fmt.Sprintf("%s (ID: %d)", ctxData.MS.User.Username, ctxData.MS.User.ID),
 			IconURL: ctxData.MS.User.AvatarURL("64"),
 		},
 		Footer: &discordgo.MessageEmbedFooter{
@@ -957,7 +957,7 @@ func (send *SendModeratorAlertMessageEffect) Apply(ctxData *TriggeredRuleData, s
 	}
 
 	msgEmbed.Fields = []*discordgo.MessageEmbedField{{
-		Name: "____",
+		Name:  "____",
 		Value: ctxData.MS.User.Mention(),
 	}}
 


### PR DESCRIPTION
Clarify the tooltip of the delete multiple messages effect, that it only
applies to the infracting user's messages.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
