### PR TITLE
logs/whois: avoid empty roles field value

### DIFF
--- a/logs/plugin_bot.go
+++ b/logs/plugin_bot.go
@@ -176,6 +176,9 @@ var cmdWhois = &commands.YAGCommand{
 			}
 			fmt.Fprintf(&sb, "<@&%d> ", role)
 		}
+		if sb.Len() == 0 {
+			sb.WriteString("None")
+		}
 
 		embed := &discordgo.MessageEmbed{
 			Title: fmt.Sprintf("%s %s", member.User.String(), nick),


### PR DESCRIPTION
In the case where a user has no roles, the resulting Roles field value remains as an empty string which causes an error. This sets the value to `None` if there are no roles present.