### PR TITLE
Update adjectives.go

### DIFF
--- a/common/adjectives.go
+++ b/common/adjectives.go
@@ -99,7 +99,6 @@ var Adjectives = []string{
 	"agrarian",
 	"agreeable",
 	"aimless",
-	"airline",
 	"airsick",
 	"airy",
 	"ajar",


### PR DESCRIPTION
Remove `airline` from adjectives as it is not an adjective, but a noun. (I checked multiple sources)