### PR TITLE
customcommands/evalcc: populate .Message object

### DIFF
--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -161,6 +161,7 @@ var cmdEvalCommand = &commands.YAGCommand{
 		ctx := templates.NewContext(data.GuildData.GS, channel, data.GuildData.MS)
 		ctx.ExecutedFrom = templates.ExecutedFromEvalCC
 		ctx.Msg = data.TraditionalTriggerData.Message
+		ctx.Data["Message"] = ctx.Msg
 
 		// use stripped message content instead of parsed arg data to avoid dcmd
 		// from misinterpreting backslashes and losing spaces in input; see


### PR DESCRIPTION
Also populate the .Message object in evalcc as seen in custom commands
proper.

After some discussion with a user about this command it became clear
that .Message.ReferencedMessage is really useful in evalcc. Because
we're not totally mean about it, might as well fully populate .Message.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
