### PR TITLE
Undo making sendPunishDM execute as a go routine when kicking or banning

### DIFF
--- a/moderation/punishments.go
+++ b/moderation/punishments.go
@@ -121,7 +121,7 @@ func punish(config *Config, p Punishment, guildID int64, channel *dstate.Channel
 			return errors.New("cannot " + actionPresentTense + " a member who is ranked higher than the bot")
 		}
 
-		go sendPunishDM(config, msg, action, gs, channel, message, author, member, duration, reason, -1, executedFromCommandTemplate)
+		sendPunishDM(config, msg, action, gs, channel, message, author, member, duration, reason, -1, executedFromCommandTemplate)
 	}
 
 	logLink := ""


### PR DESCRIPTION
Making the sendPunishDM execute as a go routine when kicking or banning generates a potential problem. If a member is in the server, then is kicked/banned, they will not receive the punishment DM if they are removed from the server before the punishment template has finished executing. Not having it run as a go routine will help fix this issue.