### PR TITLE
discordgo: use new pins endpoints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,8 @@ jobs: # basic units of work in a run
       - save_cache: # Store cache in the /go/pkg directory
           key: v1-pkg-cache
           paths:
-            - "$HOME/go/pkg"
+            - "~/go/pkg"
 
       - store_artifacts:
-          path: $HOME/go/bin/
+          path: ~/go/bin/
           destination: binaries

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -1804,7 +1804,7 @@ func (c *Context) tmplGetChannelPins(pinCount bool) func(channel interface{}) (i
 			return len(msg), nil
 		}
 
-		pinnedMessages := make([]discordgo.Message, 0, len(msg))
+		pinnedMessages := make([]discordgo.MessagePin, 0, len(msg))
 		for _, m := range msg {
 			pinnedMessages = append(pinnedMessages, *m)
 		}

--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -161,6 +161,7 @@ var cmdEvalCommand = &commands.YAGCommand{
 		ctx := templates.NewContext(data.GuildData.GS, channel, data.GuildData.MS)
 		ctx.ExecutedFrom = templates.ExecutedFromEvalCC
 		ctx.Msg = data.TraditionalTriggerData.Message
+		ctx.Data["Message"] = ctx.Msg
 
 		// use stripped message content instead of parsed arg data to avoid dcmd
 		// from misinterpreting backslashes and losing spaces in input; see

--- a/lib/dca/encode.go
+++ b/lib/dca/encode.go
@@ -212,7 +212,6 @@ func (e *EncodeSession) run() {
 		"-f", "ogg",
 		"-vbr", vbrStr,
 		"-compression_level", strconv.Itoa(e.options.CompressionLevel),
-		"-vol", strconv.Itoa(e.options.Volume),
 		"-ar", strconv.Itoa(e.options.FrameRate),
 		"-ac", strconv.Itoa(e.options.Channels),
 		"-b:a", strconv.Itoa(e.options.Bitrate * 1000),
@@ -223,10 +222,12 @@ func (e *EncodeSession) run() {
 		"-ss", strconv.Itoa(e.options.StartTime),
 	}
 
+	// Build audio filter with volume control
+	audioFilter := fmt.Sprintf("volume=%d/256", e.options.Volume)
 	if e.options.AudioFilter != "" {
-		// Lit af
-		args = append(args, "-af", e.options.AudioFilter)
+		audioFilter = e.options.AudioFilter + "," + audioFilter
 	}
+	args = append(args, "-af", audioFilter)
 
 	args = append(args, "pipe:1")
 

--- a/lib/discordgo/endpoints.go
+++ b/lib/discordgo/endpoints.go
@@ -41,7 +41,7 @@ var (
 	EndpointCDNSplashes     string
 	EndpointCDNChannelIcons string
 	EndpointCDNBanners      string
-	EndpointCDNRoleIcons	string
+	EndpointCDNRoleIcons    string
 
 	EndpointAuth           string
 	EndpointLogin          string
@@ -85,11 +85,11 @@ var (
 	EndpointGuildMemberMe             = func(gID int64) string { return "" }
 	EndpointGuildMemberVoiceState     = func(gID, uID int64) string { return "" }
 	EndpointGuildMemberRole           = func(gID, uID, rID int64) string { return "" }
-	EndpointGuildBans            = func(gID int64) string { return "" }
-	EndpointGuildBan             = func(gID, uID int64) string { return "" }
-	EndpointGuildIntegrations    = func(gID int64) string { return "" }
-	EndpointGuildIntegration     = func(gID, iID int64) string { return "" }
-	EndpointGuildIntegrationSync = func(gID, iID int64) string {
+	EndpointGuildBans                 = func(gID int64) string { return "" }
+	EndpointGuildBan                  = func(gID, uID int64) string { return "" }
+	EndpointGuildIntegrations         = func(gID int64) string { return "" }
+	EndpointGuildIntegration          = func(gID, iID int64) string { return "" }
+	EndpointGuildIntegrationSync      = func(gID, iID int64) string {
 		return ""
 	}
 	EndpointGuildRoles          = func(gID int64) string { return "" }
@@ -342,8 +342,8 @@ func CreateEndpoints(base string) {
 	EndpointChannelMessage = func(cID, mID int64) string { return EndpointChannels + StrID(cID) + "/messages/" + StrID(mID) }
 	EndpointChannelMessageAck = func(cID, mID int64) string { return EndpointChannels + StrID(cID) + "/messages/" + StrID(mID) + "/ack" }
 	EndpointChannelMessagesBulkDelete = func(cID int64) string { return EndpointChannel(cID) + "/messages/bulk-delete" }
-	EndpointChannelMessagesPins = func(cID int64) string { return EndpointChannel(cID) + "/pins" }
-	EndpointChannelMessagePin = func(cID, mID int64) string { return EndpointChannel(cID) + "/pins/" + StrID(mID) }
+	EndpointChannelMessagesPins = func(cID int64) string { return EndpointChannel(cID) + "/messages/pins" }
+	EndpointChannelMessagePin = func(cID, mID int64) string { return EndpointChannel(cID) + "/messages/pins/" + StrID(mID) }
 	EndpointChannelMessageCrosspost = func(cID, mID int64) string { return EndpointChannel(cID) + "/messages/" + StrID(mID) + "/crosspost" }
 	EndpointChannelMessageThread = func(cID, mID int64) string { return EndpointChannelMessage(cID, mID) + "/threads" }
 	EndpointThreadMembers = func(tID int64) string { return EndpointChannel(tID) + "/thread-members" }
@@ -376,7 +376,7 @@ func CreateEndpoints(base string) {
 	}
 
 	EndpointRoleIcon = func(rID int64, iID string) string { return EndpointCDNRoleIcons + StrID(rID) + "/" + iID + ".png" }
-	
+
 	EndpointRelationships = func() string { return EndpointUsers + "@me" + "/relationships" }
 	EndpointRelationship = func(uID int64) string { return EndpointRelationships() + "/" + StrID(uID) }
 	EndpointRelationshipsMutual = func(uID int64) string { return EndpointUsers + StrID(uID) + "/relationships" }

--- a/lib/discordgo/message.go
+++ b/lib/discordgo/message.go
@@ -17,6 +17,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -177,6 +178,16 @@ type Message struct {
 
 type MessageSnapshot struct {
 	Message *Message `json:"message"`
+}
+
+type MessagePin struct {
+	PinnedAt *time.Time `json:"pinned_at"`
+	Message  *Message   `json:"message"`
+}
+
+type MessagePinsResponse struct {
+	Items   []*MessagePin `json:"items"`
+	HasMore bool          `json:"has_more"`
 }
 
 func (m *Message) GetMessageContents() []string {

--- a/lib/discordgo/restapi.go
+++ b/lib/discordgo/restapi.go
@@ -1868,7 +1868,7 @@ func (s *Session) ChannelMessageUnpin(channelID, messageID int64) (err error) {
 // ChannelMessagesPinned returns an array of Message structures for pinned messages
 // within a given channel
 // channelID : The ID of a Channel.
-func (s *Session) ChannelMessagesPinned(channelID int64) (st []*Message, err error) {
+func (s *Session) ChannelMessagesPinned(channelID int64) (st []*MessagePin, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointChannelMessagesPins(channelID), nil, nil, EndpointChannelMessagesPins(channelID))
 
@@ -1876,8 +1876,13 @@ func (s *Session) ChannelMessagesPinned(channelID int64) (st []*Message, err err
 		return
 	}
 
-	err = unmarshal(body, &st)
-	return
+	var r MessagePinsResponse
+	err = unmarshal(body, &r)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.Items, nil
 }
 
 // ChannelFileSend sends a file to the given channel.

--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -1388,10 +1388,10 @@ type IgnorePinnedMessagesFilter struct {
 	PinnedMsgIDs map[int64]struct{}
 }
 
-func NewIgnorePinnedMessagesFilter(pinned []*discordgo.Message) *IgnorePinnedMessagesFilter {
+func NewIgnorePinnedMessagesFilter(pinned []*discordgo.MessagePin) *IgnorePinnedMessagesFilter {
 	ids := make(map[int64]struct{})
-	for _, msg := range pinned {
-		ids[msg.ID] = struct{}{}
+	for _, pin := range pinned {
+		ids[pin.Message.ID] = struct{}{}
 	}
 	return &IgnorePinnedMessagesFilter{ids}
 }


### PR DESCRIPTION
<!-- Please describe the changes this PR makes -->

Migrate to the new paginated pins endpoint Discord recently rolled out.

At this stage, the tmplGetChannelPins still needs the before parameter,
as does the actual function making the API call. As always suggestions
for improvement are welcome, this is my current best effort.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

----

<!-- 
If this Pull Request requires documentation changes, consider raising a PR
to our documentation at https://github.com/botlabs-gg/yagpdb-docs-v2 as well.
Please cross-link the PR below this comment if you do so.
Alternatively, you can also just create an issue over there.
-->

This is going to require documentation changes, as well as a proper 
announcement of this change, as it is -- in this state -- a breaking
change.
