### PR TITLE
return message id from sendMessage, sendResponse, sendMessageNoEscape, sendResponseNoEscape

### DIFF
--- a/bot/discordevents.go
+++ b/bot/discordevents.go
@@ -336,7 +336,7 @@ func handleDmGuildInfoInteraction(evt *eventsystem.EventData) {
 		content = fmt.Sprintf("This DM was sent from server\nID: **%d**, \nName: **%s**", guild_id, gs.Name)
 	}
 	response.Data.Content = content
-	err = evt.Session.CreateInteractionResponse(ic.ID, ic.Token, &response)
+	_, err = evt.Session.CreateInteractionResponse(ic.ID, ic.Token, &response)
 	logger.WithError(err).Printf("Interaction Response!")
 }
 

--- a/bot/paginatedmessages/paginatedinteractions.go
+++ b/bot/paginatedmessages/paginatedinteractions.go
@@ -178,7 +178,7 @@ func (p *PaginatedMessage) HandlePageButtonClick(ic *discordgo.InteractionCreate
 	defer p.mu.Unlock()
 
 	// Pong the interaction
-	err := common.BotSession.CreateInteractionResponse(ic.ID, ic.Token, &discordgo.InteractionResponse{
+	_, err := common.BotSession.CreateInteractionResponse(ic.ID, ic.Token, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseDeferredMessageUpdate,
 	})
 	if err != nil {

--- a/commands/plugin_bot.go
+++ b/commands/plugin_bot.go
@@ -186,7 +186,7 @@ func YAGCommandMiddleware(inner dcmd.RunFunc) dcmd.RunFunc {
 			if yc.IsResponseEphemeral || settings.AlwaysEphemeral {
 				response.Data = &discordgo.InteractionResponseData{Flags: 64}
 			}
-			err := data.Session.CreateInteractionResponse(data.SlashCommandTriggerData.Interaction.ID, data.SlashCommandTriggerData.Interaction.Token, &response)
+			_, err := data.Session.CreateInteractionResponse(data.SlashCommandTriggerData.Interaction.ID, data.SlashCommandTriggerData.Interaction.Token, &response)
 			if err != nil {
 				return nil, err
 			}

--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -523,7 +523,7 @@ func (c *Context) SendResponse(content string) (m *discordgo.Message, err error)
 
 	switch sendType {
 	case sendMessageInteractionResponse:
-		err = common.BotSession.CreateInteractionResponse(c.CurrentFrame.Interaction.ID, c.CurrentFrame.Interaction.Token, &discordgo.InteractionResponse{
+		_, err := common.BotSession.CreateInteractionResponse(c.CurrentFrame.Interaction.ID, c.CurrentFrame.Interaction.Token, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseChannelMessageWithSource,
 			Data: &discordgo.InteractionResponseData{
 				Content:         msgSend.Content,
@@ -663,8 +663,6 @@ func baseContextFuncs(c *Context) {
 	c.addContextFunc("deleteResponse", c.tmplDelResponse)
 	c.addContextFunc("deleteTrigger", c.tmplDelTrigger)
 
-	c.addContextFunc("editComponentMessage", c.tmplEditComponentsMessage(true))
-	c.addContextFunc("editComponentMessageNoEscape", c.tmplEditComponentsMessage(false))
 	c.addContextFunc("editMessage", c.tmplEditMessage(true))
 	c.addContextFunc("editMessageNoEscape", c.tmplEditMessage(false))
 	c.addContextFunc("getMessage", c.tmplGetMessage)
@@ -675,15 +673,10 @@ func baseContextFuncs(c *Context) {
 
 	// Message send functions
 	c.addContextFunc("sendDM", c.tmplSendDM)
-	c.addContextFunc("sendComponentMessageRetID", c.tmplSendComponentsMessage(true, true))
-	c.addContextFunc("sendComponentMessage", c.tmplSendComponentsMessage(true, false))
-	c.addContextFunc("sendComponentMessageNoEscape", c.tmplSendComponentsMessage(false, false))
-	c.addContextFunc("sendComponentMessageNoEscapeRetID", c.tmplSendComponentsMessage(false, true))
-	c.addContextFunc("sendComponentMessageRetID", c.tmplSendComponentsMessage(true, true))
-	c.addContextFunc("sendMessage", c.tmplSendMessage(true, false))
-	c.addContextFunc("sendMessageNoEscape", c.tmplSendMessage(false, false))
-	c.addContextFunc("sendMessageNoEscapeRetID", c.tmplSendMessage(false, true))
-	c.addContextFunc("sendMessageRetID", c.tmplSendMessage(true, true))
+	c.addContextFunc("sendMessage", c.tmplSendMessage(true))
+	c.addContextFunc("sendMessageNoEscape", c.tmplSendMessage(false))
+	c.addContextFunc("sendMessageNoEscapeRetID", c.tmplSendMessage(false))
+	c.addContextFunc("sendMessageRetID", c.tmplSendMessage(true))
 
 	c.addContextFunc("sendTemplate", c.tmplSendTemplate)
 	c.addContextFunc("sendTemplateDM", c.tmplSendTemplateDM)

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -327,7 +327,7 @@ func (c *Context) checkSafeDictNoRecursion(d Dict, n int) bool {
 	return true
 }
 
-func (c *Context) tmplSendMessage(filterSpecialMentions bool, returnID bool) func(channel interface{}, msg interface{}) interface{} {
+func (c *Context) tmplSendMessage(filterSpecialMentions bool) func(channel interface{}, msg interface{}) interface{} {
 
 	return func(channel interface{}, msg interface{}) interface{} {
 		if c.IncreaseCheckGenericAPICall() {
@@ -404,7 +404,7 @@ func (c *Context) tmplSendMessage(filterSpecialMentions bool, returnID bool) fun
 
 		m, err = common.BotSession.ChannelMessageSendComplex(cid, msgSend)
 
-		if err == nil && returnID {
+		if err == nil {
 			return m.ID
 		}
 
@@ -485,103 +485,6 @@ func (c *Context) tmplEditMessage(filterSpecialMentions bool) func(channel inter
 		}
 
 		_, err = common.BotSession.ChannelMessageEditComplex(msgEdit)
-		if err != nil {
-			return "", err
-		}
-
-		return "", nil
-	}
-}
-
-func (c *Context) tmplSendComponentsMessage(filterSpecialMentions bool, returnID bool) func(channel interface{}, values ...interface{}) (interface{}, error) {
-
-	return func(channel interface{}, values ...interface{}) (interface{}, error) {
-		if c.IncreaseCheckGenericAPICall() {
-			return nil, errors.New("too many calls")
-		}
-
-		cid := c.ChannelArg(channel)
-		if cid == 0 {
-			return nil, errors.New("invalid channel")
-		}
-
-		var m *discordgo.Message
-
-		var err error
-
-		if len(values) < 1 {
-			return nil, errors.New("no values passed")
-		}
-
-		compBuilder, err := CreateComponentBuilder(values...)
-		if err != nil {
-			return nil, err
-		}
-
-		msg, err := compBuilder.ToComplexMessage()
-		if err != nil {
-			return nil, err
-		}
-
-		if msg.Reference != nil {
-			msg.Reference.GuildID = c.GS.ID
-			msg.Reference.ChannelID = cid
-		}
-
-		var repliedUser bool
-		parseMentions := []discordgo.AllowedMentionType{discordgo.AllowedMentionTypeUsers}
-		if !filterSpecialMentions {
-			parseMentions = append(parseMentions, discordgo.AllowedMentionTypeRoles, discordgo.AllowedMentionTypeEveryone)
-			repliedUser = true
-			msg.AllowedMentions = discordgo.AllowedMentions{Parse: parseMentions, RepliedUser: repliedUser}
-		}
-
-		m, err = common.BotSession.ChannelMessageSendComplex(cid, msg)
-
-		if err == nil && returnID {
-			return m.ID, nil
-		}
-
-		return "", err
-	}
-}
-
-func (c *Context) tmplEditComponentsMessage(filterSpecialMentions bool) func(channel interface{}, msgID interface{}, values ...interface{}) (interface{}, error) {
-	return func(channel interface{}, msgID interface{}, values ...interface{}) (interface{}, error) {
-		if c.IncreaseCheckGenericAPICall() {
-			return "", ErrTooManyAPICalls
-		}
-
-		cid := c.ChannelArgNoDM(channel)
-		if cid == 0 {
-			return "", errors.New("unknown channel")
-		}
-
-		if len(values) < 1 {
-			return nil, errors.New("no values passed")
-		}
-
-		compBuilder, err := CreateComponentBuilder(values...)
-		if err != nil {
-			return nil, err
-		}
-
-		mID := ToInt64(msgID)
-		msg, err := compBuilder.ToComplexMessageEdit()
-		if err != nil {
-			return nil, err
-		}
-		msg.ID = mID
-		msg.Channel = cid
-		var repliedUser bool
-		parseMentions := []discordgo.AllowedMentionType{discordgo.AllowedMentionTypeUsers}
-		if !filterSpecialMentions {
-			parseMentions = append(parseMentions, discordgo.AllowedMentionTypeRoles, discordgo.AllowedMentionTypeEveryone)
-			repliedUser = true
-			msg.AllowedMentions = discordgo.AllowedMentions{Parse: parseMentions, RepliedUser: repliedUser}
-		}
-
-		_, err = common.BotSession.ChannelMessageEditComplex(msg)
 		if err != nil {
 			return "", err
 		}

--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -931,7 +931,7 @@ func deferResponseToCCs(interaction *templates.CustomCommandInteraction, ccs []*
 	}
 
 	if def.Type != 0 {
-		err := common.BotSession.CreateInteractionResponse(interaction.ID, interaction.Token, def)
+		_, err := common.BotSession.CreateInteractionResponse(interaction.ID, interaction.Token, def)
 		if err != nil {
 			logger.WithField("guild", interaction.GuildID).WithError(err).Error("Error deferring response")
 		}

--- a/lib/cardsagainstdiscord/game.go
+++ b/lib/cardsagainstdiscord/game.go
@@ -905,7 +905,7 @@ func (g *Game) HandleInteractionAdd(ic *discordgo.InteractionCreate) {
 
 	if g.State != GameStatePickingResponses {
 		// Pong the interaction
-		err := g.Session.CreateInteractionResponse(ic.ID, ic.Token, &discordgo.InteractionResponse{
+		_, err := g.Session.CreateInteractionResponse(ic.ID, ic.Token, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseDeferredMessageUpdate,
 		})
 		if err != nil {
@@ -1076,7 +1076,7 @@ func (g *Game) HandleMessageCreate(ic *discordgo.InteractionCreate) {
 				msg += fmt.Sprintf("go to <#%d> and wait for the other players to finish their selections, the winner will be picked there", g.MasterChannel)
 			}
 
-			err := g.Session.CreateInteractionResponse(ic.ID, ic.Token, &discordgo.InteractionResponse{
+			_, err := g.Session.CreateInteractionResponse(ic.ID, ic.Token, &discordgo.InteractionResponse{
 				Type: discordgo.InteractionResponseChannelMessageWithSource,
 				Data: &discordgo.InteractionResponseData{
 					Embeds: []*discordgo.MessageEmbed{{Description: msg}},
@@ -1249,7 +1249,7 @@ func (g *Game) playerPickedResponseReaction(player *Player, response string, ic 
 	card := player.Cards[emojiIndex]
 	if card != BlankCard {
 		// Pong the interaction
-		err := g.Session.CreateInteractionResponse(ic.ID, ic.Token, &discordgo.InteractionResponse{
+		_, err := g.Session.CreateInteractionResponse(ic.ID, ic.Token, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseDeferredMessageUpdate,
 		})
 		if err != nil {

--- a/lib/dcmd/data.go
+++ b/lib/dcmd/data.go
@@ -186,7 +186,7 @@ func (d *Data) SendFollowupMessage(reply interface{}, allowedMentions discordgo.
 			if d.SlashCommandTriggerData.Interaction.Type != discordgo.InteractionApplicationCommandAutocomplete {
 				return nil, errors.New("Cannot use autocomplete with interaction type: " + d.SlashCommandTriggerData.Interaction.Type.String())
 			}
-			err := d.Session.CreateInteractionResponse(d.SlashCommandTriggerData.Interaction.ID, d.SlashCommandTriggerData.Interaction.Token, &discordgo.InteractionResponse{
+			_, err := d.Session.CreateInteractionResponse(d.SlashCommandTriggerData.Interaction.ID, d.SlashCommandTriggerData.Interaction.Token, &discordgo.InteractionResponse{
 				Type: discordgo.InteractionApplicationCommandAutocompleteResult,
 				Data: &discordgo.InteractionResponseData{
 					Choices: t,

--- a/lib/discordgo/interactions.go
+++ b/lib/discordgo/interactions.go
@@ -586,3 +586,12 @@ func VerifyInteraction(r *http.Request, key ed25519.PublicKey) bool {
 
 	return ed25519.Verify(key, msg.Bytes(), sig)
 }
+
+type InteractionCallbackResponse struct {
+	ID                       int64           `json:"id,string"`
+	Type                     InteractionType `json:"type,omitempty"`
+	ActivityInstanceID       int64           `json:"activity_instance_id,string,omitempty"`
+	ResponseMessageID        int64           `json:"response_message_id,string,omitempty"`
+	ResponseMessageLoading   bool            `json:"response_message_loading,omitempty"`
+	ResponseMessageEphemeral bool            `json:"response_message_ephemeral,omitempty"`
+}

--- a/rsvp/plugin_bot.go
+++ b/rsvp/plugin_bot.go
@@ -655,7 +655,7 @@ func (p *Plugin) handleInteractionCreate(evt *eventsystem.EventData) {
 	}
 
 	// Pong the interaction
-	err := common.BotSession.CreateInteractionResponse(ic.ID, ic.Token, &discordgo.InteractionResponse{
+	_, err := common.BotSession.CreateInteractionResponse(ic.ID, ic.Token, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseDeferredMessageUpdate,
 	})
 	if err != nil {

--- a/tickets/tickets_bot.go
+++ b/tickets/tickets_bot.go
@@ -474,15 +474,15 @@ func (p *Plugin) handleInteractionCreate(evt *eventsystem.EventData) (retry bool
 		response = errorResponse
 	}
 
-	respErr := common.BotSession.CreateInteractionResponse(ic.ID, ic.Token, response)
-	if respErr != nil {
+	_, err = common.BotSession.CreateInteractionResponse(ic.ID, ic.Token, response)
+	if err != nil {
 		// try again as a followup, if that still fails, return the original error
 		_, followupErr := common.BotSession.CreateFollowupMessage(ic.ApplicationID, ic.Token, &discordgo.WebhookParams{
 			Content: response.Data.Content,
 			Flags:   int64(response.Data.Flags),
 		})
 		if followupErr != nil {
-			return bot.CheckDiscordErrRetry(respErr), respErr
+			return bot.CheckDiscordErrRetry(err), err
 		}
 	}
 	return false, err

--- a/trivia/trivia_bot.go
+++ b/trivia/trivia_bot.go
@@ -333,7 +333,7 @@ func (t *triviaSession) handleInteractionAdd(evt *eventsystem.EventData) {
 	// Editing the embed can sometime get ratelimited
 	if t.ended || time.Since(t.startedAt) > TriviaDuration {
 		response.Data.Content = "You're too slow, trivia has already ended."
-		err = evt.Session.CreateInteractionResponse(ic.ID, ic.Token, &response)
+		_, err = evt.Session.CreateInteractionResponse(ic.ID, ic.Token, &response)
 		if err != nil {
 			logger.WithError(err).Error("Failed creating interaction response")
 		}
@@ -344,7 +344,7 @@ func (t *triviaSession) handleInteractionAdd(evt *eventsystem.EventData) {
 	for _, v := range t.SelectedOptions {
 		if v.User.ID == ic.Member.User.ID {
 			response.Data.Content = fmt.Sprintf("You've already picked an answer: `%s`, I am going to ignore this 😒", t.Question.Options[v.Option])
-			err = evt.Session.CreateInteractionResponse(ic.ID, ic.Token, &response)
+			_, err = evt.Session.CreateInteractionResponse(ic.ID, ic.Token, &response)
 			if err != nil {
 				logger.WithError(err).Error("Failed creating interaction response")
 			}
@@ -371,7 +371,7 @@ func (t *triviaSession) handleInteractionAdd(evt *eventsystem.EventData) {
 	}
 	response.Type = discordgo.InteractionResponseDeferredMessageUpdate
 	response.Data.Content = ""
-	err = evt.Session.CreateInteractionResponse(ic.ID, ic.Token, &response)
+	_, err = evt.Session.CreateInteractionResponse(ic.ID, ic.Token, &response)
 	if err != nil {
 		logger.WithError(err).Error("Failed creating interaction response")
 	}


### PR DESCRIPTION
This removes the unnecessary check to return the message id, making the "RetID" variants redundant, also removes the deprecated and undocumented sendComponent and editComponent and their variants. 