### PR TITLE
typo fix: `cutsom` to `custom`

### DIFF
--- a/tickets/tickets_commands.go
+++ b/tickets/tickets_commands.go
@@ -278,7 +278,7 @@ func (p *Plugin) AddCommands() {
 		RequireDiscordPerms: []int64{discordgo.PermissionManageGuild},
 		ArgSwitches: []*dcmd.ArgDef{
 			{Name: "message", Help: "ID to attach menu to", Type: dcmd.BigInt},
-			{Name: "disable-custom", Help: "Disable Cutsom Reason button", Default: false},
+			{Name: "disable-custom", Help: "Disable Custom Reason button", Default: false},
 			{Name: "button-1", Help: "Predefined reason for button 1", Type: dcmd.String},
 			{Name: "button-2", Help: "Predefined reason for button 2", Type: dcmd.String},
 			{Name: "button-3", Help: "Predefined reason for button 3", Type: dcmd.String},


### PR DESCRIPTION
Fixes a typo in the argument description for tickets menucreate

<!-- Please describe the changes this PR makes -->

<!-- 
If this Pull Request requires documentation changes, consider raising a PR
to our documentation at https://github.com/botlabs-gg/yagpdb-docs-v2 as well.
Please cross-link the PR below this comment if you do so.
Alternatively, you can also just create an issue over there.
-->
