### PR TITLE
templates: allow more than two args for bitwiseAnd

### DIFF
--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -1124,8 +1124,11 @@ func tmplLog(arguments ...interface{}) (float64, error) {
 	return logarithm, nil
 }
 
-func tmplBitwiseAnd(arg1, arg2 interface{}) int {
-	return tmplToInt(arg1) & tmplToInt(arg2)
+func tmplBitwiseAnd(args ...interface{}) (res int) {
+	for _, arg := range args {
+		res &= tmplToInt(arg)
+	}
+	return
 }
 
 func tmplBitwiseOr(args ...interface{}) (res int) {


### PR DESCRIPTION
As title says.

While we're here, some food for thought; does it also make sense to do
the same for the other bitwise operations, excluding NOT?
If so, I can just add those to this PR as well.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
