### PR TITLE
templates: fix bitwiseAnd

### DIFF
--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -1124,11 +1124,12 @@ func tmplLog(arguments ...interface{}) (float64, error) {
 	return logarithm, nil
 }
 
-func tmplBitwiseAnd(args ...interface{}) (res int) {
+func tmplBitwiseAnd(arg0 interface{}, args ...interface{}) int {
+	res := tmplToInt(arg0)
 	for _, arg := range args {
 		res &= tmplToInt(arg)
 	}
-	return
+	return res
 }
 
 func tmplBitwiseOr(args ...interface{}) (res int) {


### PR DESCRIPTION
Since #1937, `bitwiseAnd` (erroneously) always returns 0. The issue is that the named result `res int` is zero-initialized at the start of the function, and `0 & n == 0` for any `n`.

Fix the function by initializing `res` to the first argument instead.

There is an additional behavior change here in that calling `bitwiseAnd` with zero arguments is now forbidden. However, it makes no sense to call `bitwiseAnd` with no arguments anyway and the original implementation prior to #1937 required exactly two args, so I don't imagine this will break any users in practice.