### PR TITLE
use max_concurrency provided by discord gatway/bot endpoint to identify shard. 

### DIFF
--- a/lib/discordgo/gateway.go
+++ b/lib/discordgo/gateway.go
@@ -1353,10 +1353,9 @@ func (g *GatewayConnection) identify() error {
 	}
 
 	data := identifyData{
-		Token:          g.manager.session.Token,
-		Properties:     properties,
-		LargeThreshold: 250,
-		// Compress:      g.manager.session.Compress, // this is no longer needed since we use zlib-steam anyways
+		Token:              g.manager.session.Token,
+		Properties:         properties,
+		LargeThreshold:     250,
 		Shard:              nil,
 		GuildSubscriptions: true,
 		Intents:            intents,

--- a/lib/discordgo/structs.go
+++ b/lib/discordgo/structs.go
@@ -452,10 +452,10 @@ type StickerFormat int
 
 // Defines all known Sticker types.
 const (
-	StickerFormatTypePNG	StickerFormat = 1
-	StickerFormatTypeAPNG	StickerFormat = 2
-	StickerFormatTypeLottie	StickerFormat = 3
-	StickerFormatTypeGIF	StickerFormat = 4
+	StickerFormatTypePNG    StickerFormat = 1
+	StickerFormatTypeAPNG   StickerFormat = 2
+	StickerFormatTypeLottie StickerFormat = 3
+	StickerFormatTypeGIF    StickerFormat = 4
 )
 
 // StickerType is the type of Sticker.
@@ -463,8 +463,8 @@ type StickerType int
 
 // Defines Sticker types.
 const (
-	StickerTypeStandard	StickerType = 1
-	StickerTypeGuild	StickerType = 2
+	StickerTypeStandard StickerType = 1
+	StickerTypeGuild    StickerType = 2
 )
 
 // Sticker represents a Sticker object that can be sent in a Message.
@@ -479,7 +479,7 @@ type Sticker struct {
 	Available   bool          `json:"available"`
 	GuildID     int64         `json:"guild_id,string"`
 	User        *User         `json:"user"`
-	SortValue   int	          `json:"sort_value"`
+	SortValue   int           `json:"sort_value"`
 }
 
 // StickerItem represents the smallest amount of data required to render a sticker. A partial sticker object.
@@ -1478,9 +1478,10 @@ type GatewayBotResponse struct {
 }
 
 type SessionStartLimit struct {
-	Total      int   `json:"total"`
-	Remaining  int   `json:"remaining"`
-	ResetAfter int64 `json:"reset_after"`
+	Total          int   `json:"total"`
+	Remaining      int   `json:"remaining"`
+	ResetAfter     int64 `json:"reset_after"`
+	MaxConcurrency int   `json:"max_concurrency"`
 }
 
 // Block contains Discord JSON Error Response codes

--- a/lib/jdshardmanager/dshardmanager.go
+++ b/lib/jdshardmanager/dshardmanager.go
@@ -177,10 +177,6 @@ func (m *Manager) Start() error {
 	m.Unlock()
 
 	for i := 0; i < m.numShards; i++ {
-		if i != 0 {
-			// One indentify every 5 seconds
-			time.Sleep(time.Second * 5)
-		}
 
 		m.Lock()
 		err := m.startSession(i)


### PR DESCRIPTION
Currently, the bot only connects one shard every 5 seconds, which can take approximately 3 hours in cases of complete outages. The max_concurrency provided by discord allows to safely start the bot much much quicker. 