### PR TITLE
notifications: fill ctx.Msg with proper member data

### DIFF
--- a/notifications/plugin_bot.go
+++ b/notifications/plugin_bot.go
@@ -173,6 +173,13 @@ func sendTemplate(gs *dstate.GuildSet, cs *dstate.ChannelState, tmpl string, ms 
 	}
 	ctx.DisabledContextFuncs = disableFuncs
 
+	// Construct a fake message so that things like exec and execAdmin work as expected.
+	ctx.Msg = new(discordgo.Message)
+	ctx.Msg.Author = &ms.User
+	ctx.Msg.Member = ms.DgoMember()
+	ctx.Msg.ChannelID = cs.ID
+	ctx.Msg.GuildID = gs.ID
+
 	msg, err := ctx.Execute(tmpl)
 	if err != nil {
 		logger.WithError(err).WithField("guild", gs.ID).Warnf("Failed parsing/executing %s template", name)


### PR DESCRIPTION
Fill ctx.Msg with proper member data instead of falling back to bot data
via ctx.Execute.

When users call exec with a command that would normally use the
triggering member, e.g. `whois`, in their custom join/leave messages,
the bot instead replies with info about itself, rather than the member
that joined/left (going by the example).

```
{{ sendMessage nil (exec "whois") }}
```

This is clearly unintuitive (and probably unintended) behaviour: in a
normal custom command, calling `whois` works as expected, the bot
replies with info about the triggering member.

We can fix this by simply doing what ctx.Execute does, but with sensible
data: construct a fake message to provide ctx.Msg such that exec and
execAdmin alike can consume that data and show the behaviour users would
expect.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
