### PR TITLE
Fix UTF-8 encoding detection in ticket transcripts by adding BOM

### DIFF
--- a/tickets/tickets_commands.go
+++ b/tickets/tickets_commands.go
@@ -642,6 +642,9 @@ const TicketTXTDateFormat = "2006 Jan 02 15:04:05"
 func createTXTTranscript(ticket *models.Ticket, msgs []*discordgo.Message) *bytes.Buffer {
 	var buf bytes.Buffer
 
+	// Add UTF-8 BOM at the beginning
+	buf.Write([]byte{0xEF, 0xBB, 0xBF})
+
 	buf.WriteString(fmt.Sprintf("Transcript of ticket #%d - %s, opened by %s at %s, closed at %s.\n\n",
 		ticket.LocalID, ticket.Title, ticket.AuthorUsernameDiscrim, ticket.CreatedAt.UTC().Format(TicketTXTDateFormat), ticket.ClosedAt.Time.UTC().Format(TicketTXTDateFormat)))
 


### PR DESCRIPTION
## Fix UTF-8 encoding detection in ticket transcripts

**Problem:** 
TXT transcript files generated without a Byte Order Mark can be misinterpreted by Discord's encoding detection algorithm. Non-ASCII characters like `þ` display incorrectly as `Ã¾` because the UTF-8 bytes are being read as Windows-1252.

**Solution:**
Add the UTF-8 BOM (bytes `0xEF 0xBB 0xBF`) at the start of transcript files to explicitly signal UTF-8 encoding.