### PR TITLE
Revert "use max_concurrency provided by discord gatway/bot endpoint to identify shard. "

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -260,42 +260,21 @@ type identifyRatelimiter struct {
 	lastRatelimitAt      time.Time
 }
 
-var identifyMaxConcurrency int
-var identifyConcurrencyOnce sync.Once
-
-func (rl *identifyRatelimiter) getIdentifyMaxConcurrency() int {
-	identifyConcurrencyOnce.Do(func() {
-		identifyMaxConcurrency = 1
-		s, err := discordgo.New(common.GetBotToken())
-		if err != nil {
-			logger.WithError(err).Warn("failed to create session to fetch gateway bot info")
-			return
-		}
-		resp, err := s.GatewayBot()
-		if err != nil {
-			logger.WithError(err).Warn("failed to fetch gateway bot info")
-			return
-		}
-		if resp != nil && resp.SessionStartLimit.MaxConcurrency > 0 {
-			identifyMaxConcurrency = resp.SessionStartLimit.MaxConcurrency
-		}
-		logger.Infof("Gateway identify max_concurrency: %d", identifyMaxConcurrency)
-	})
-	return identifyMaxConcurrency
-}
-
 func (rl *identifyRatelimiter) RatelimitIdentify(shardID int) {
-	mc := rl.getIdentifyMaxConcurrency()
-	// total buckets is equal to the value of max_concurrency.
-	bucket := shardID % mc
-	key := "yagpdb.gateway.identify.bucket." + strconv.Itoa(bucket)
-
+	const key = "yagpdb.gateway.identify.limit"
 	for {
+
+		if rl.checkSameBucket(shardID) {
+			return
+		}
+
+		// The ratelimit is 1 identify every 5 seconds, but with exactly that limit we will still encounter invalid session
+		// closes, probably due to small variances in networking and scheduling latencies
+		// Adding a extra 100ms fixes this completely, but to be on the safe side we add a extra 50ms
 		var resp string
-		//instead of a global ratelimit of 1 identify per 5 seconds, we have a bucket ratelimit of 1 identify per 5 seconds per bucket.
 		err := common.RedisPool.Do(radix.Cmd(&resp, "SET", key, "1", "PX", "5100", "NX"))
 		if err != nil {
-			logger.WithError(err).Errorf("failed ratelimiting gateway for bucket %d", bucket)
+			logger.WithError(err).Error("failed ratelimiting gateway")
 			time.Sleep(time.Second)
 			continue
 		}
@@ -309,12 +288,113 @@ func (rl *identifyRatelimiter) RatelimitIdentify(shardID int) {
 			return
 		}
 
-		// otherwise a identify was sent by someone on this bucket else last 5 seconds
+		// otherwise a identify was sent by someone else last 5 seconds
 		time.Sleep(time.Second)
 	}
 }
 
+func (rl *identifyRatelimiter) checkSameBucket(shardID int) bool {
+	if !common.ConfLargeBotShardingEnabled.GetBool() {
+		// only works with large bot sharding enabled
+		return false
+	}
+
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	if rl.lastRatelimitAt.IsZero() {
+		return false
+	}
+
+	// normally 16, but thats a bit too fast for us, so we use 4
+	bucketSize := common.ConfShardBucketSize.GetInt()
+	currentBucket := shardID / bucketSize
+	lastBucket := rl.lastShardRatelimited / bucketSize
+
+	if currentBucket != lastBucket {
+		return false
+	}
+
+	if time.Since(rl.lastRatelimitAt) > time.Second*5 {
+		return false
+	}
+
+	// same large bot sharding bucket
+	return true
+}
+
+// var (
+// 	metricsCacheHits = promauto.NewCounter(prometheus.CounterOpts{
+// 		Name: "yagpdb_state_cache_hits_total",
+// 		Help: "Cache hits in the satte cache",
+// 	})
+
+// 	metricsCacheMisses = promauto.NewCounter(prometheus.CounterOpts{
+// 		Name: "yagpdb_state_cache_misses_total",
+// 		Help: "Cache misses in the sate cache",
+// 	})
+
+// 	metricsCacheEvictions = promauto.NewCounter(prometheus.CounterOpts{
+// 		Name: "yagpdb_state_cache_evicted_total",
+// 		Help: "Cache evictions",
+// 	})
+
+// 	metricsCacheMemberEvictions = promauto.NewCounter(prometheus.CounterOpts{
+// 		Name: "yagpdb_state_members_evicted_total",
+// 		Help: "Members evicted from state cache",
+// 	})
+// )
+
 var confStateRemoveOfflineMembers = config.RegisterOption("yagpdb.state.remove_offline_members", "Remove offline members from state", true)
+
+// func setupState() {
+// 	// Things may rely on state being available at this point for initialization
+// 	State = dstate.NewState()
+// 	State.MaxChannelMessages = 1000
+// 	State.MaxMessageAge = time.Hour
+// 	// State.Debug = true
+// 	State.ThrowAwayDMMessages = true
+// 	State.TrackPrivateChannels = false
+// 	State.CacheExpirey = time.Hour * 2
+
+// 	if confStateRemoveOfflineMembers.GetBool() {
+// 		State.RemoveOfflineMembers = true
+// 	}
+
+// 	go State.RunGCWorker()
+
+// 	eventsystem.DiscordState = State
+
+// 	// track cache hits/misses
+// 	go func() {
+// 		lastHits := int64(0)
+// 		lastMisses := int64(0)
+// 		lastEvictionsCache := int64(0)
+// 		lastEvictionsMembers := int64(0)
+
+// 		ticker := time.NewTicker(time.Minute)
+// 		for {
+// 			<-ticker.C
+
+// 			stats := State.StateStats()
+// 			deltaHits := stats.CacheHits - lastHits
+// 			deltaMisses := stats.CacheMisses - lastMisses
+// 			lastHits = stats.CacheHits
+// 			lastMisses = stats.CacheMisses
+
+// 			metricsCacheHits.Add(float64(deltaHits))
+// 			metricsCacheMisses.Add(float64(deltaMisses))
+
+// 			metricsCacheEvictions.Add(float64(stats.UserCachceEvictedTotal - lastEvictionsCache))
+// 			metricsCacheMemberEvictions.Add(float64(stats.MembersRemovedTotal - lastEvictionsMembers))
+
+// 			lastEvictionsCache = stats.UserCachceEvictedTotal
+// 			lastEvictionsMembers = stats.MembersRemovedTotal
+
+// 			// logger.Debugf("guild cache Hits: %d Misses: %d", deltaHits, deltaMisses)
+// 		}
+// 	}()
+// }
 
 var StateLimitsF func(guildID int64) (int, time.Duration) = func(guildID int64) (int, time.Duration) {
 	return 1000, time.Hour

--- a/lib/discordgo/gateway.go
+++ b/lib/discordgo/gateway.go
@@ -1356,9 +1356,10 @@ func (g *GatewayConnection) identify() error {
 	}
 
 	data := identifyData{
-		Token:              g.manager.session.Token,
-		Properties:         properties,
-		LargeThreshold:     250,
+		Token:          g.manager.session.Token,
+		Properties:     properties,
+		LargeThreshold: 250,
+		// Compress:      g.manager.session.Compress, // this is no longer needed since we use zlib-steam anyways
 		Shard:              nil,
 		GuildSubscriptions: true,
 		Intents:            intents,

--- a/lib/discordgo/structs.go
+++ b/lib/discordgo/structs.go
@@ -452,10 +452,10 @@ type StickerFormat int
 
 // Defines all known Sticker types.
 const (
-	StickerFormatTypePNG    StickerFormat = 1
-	StickerFormatTypeAPNG   StickerFormat = 2
-	StickerFormatTypeLottie StickerFormat = 3
-	StickerFormatTypeGIF    StickerFormat = 4
+	StickerFormatTypePNG	StickerFormat = 1
+	StickerFormatTypeAPNG	StickerFormat = 2
+	StickerFormatTypeLottie	StickerFormat = 3
+	StickerFormatTypeGIF	StickerFormat = 4
 )
 
 // StickerType is the type of Sticker.
@@ -463,8 +463,8 @@ type StickerType int
 
 // Defines Sticker types.
 const (
-	StickerTypeStandard StickerType = 1
-	StickerTypeGuild    StickerType = 2
+	StickerTypeStandard	StickerType = 1
+	StickerTypeGuild	StickerType = 2
 )
 
 // Sticker represents a Sticker object that can be sent in a Message.
@@ -479,7 +479,7 @@ type Sticker struct {
 	Available   bool          `json:"available"`
 	GuildID     int64         `json:"guild_id,string"`
 	User        *User         `json:"user"`
-	SortValue   int           `json:"sort_value"`
+	SortValue   int	          `json:"sort_value"`
 }
 
 // StickerItem represents the smallest amount of data required to render a sticker. A partial sticker object.
@@ -1497,10 +1497,9 @@ type GatewayBotResponse struct {
 }
 
 type SessionStartLimit struct {
-	Total          int   `json:"total"`
-	Remaining      int   `json:"remaining"`
-	ResetAfter     int64 `json:"reset_after"`
-	MaxConcurrency int   `json:"max_concurrency"`
+	Total      int   `json:"total"`
+	Remaining  int   `json:"remaining"`
+	ResetAfter int64 `json:"reset_after"`
 }
 
 // Block contains Discord JSON Error Response codes

--- a/lib/jdshardmanager/dshardmanager.go
+++ b/lib/jdshardmanager/dshardmanager.go
@@ -177,6 +177,10 @@ func (m *Manager) Start() error {
 	m.Unlock()
 
 	for i := 0; i < m.numShards; i++ {
+		if i != 0 {
+			// One indentify every 5 seconds
+			time.Sleep(time.Second * 5)
+		}
 
 		m.Lock()
 		err := m.startSession(i)


### PR DESCRIPTION
Reverts botlabs-gg/yagpdb#1941 as this potentially caused the bot to get ratelimited. 