### PR TITLE
Fixed a panic I noticed in logs for improper parsing of origin host

### DIFF
--- a/web/middleware.go
+++ b/web/middleware.go
@@ -158,8 +158,17 @@ func RequireSessionMiddleware(inner http.Handler) http.Handler {
 			split := strings.SplitN(origin, ":", 3)
 			hostSplit := strings.SplitN(common.ConfHost.GetString(), ":", 2)
 
-			if len(split) < 2 || !strings.EqualFold("//"+hostSplit[0], split[1]) {
-				CtxLogger(r.Context()).Error("Mismatched origin: ", hostSplit[0]+" : "+split[1])
+			expectedHost := ""
+			if len(hostSplit) > 0 {
+				expectedHost = "//" + hostSplit[0]
+			}
+			originHost := ""
+			if len(split) > 1 {
+				originHost = split[1]
+			}
+
+			if originHost == "" || !strings.EqualFold(expectedHost, originHost) {
+				CtxLogger(r.Context()).Error("Mismatched origin: ", expectedHost+" : "+originHost)
 				WriteErrorResponse(w, r, "Bad origin", http.StatusUnauthorized)
 				return
 			}
@@ -179,8 +188,17 @@ func CSRFProtectionMW(inner http.Handler) http.Handler {
 			split := strings.SplitN(origin, ":", 3)
 			hostSplit := strings.SplitN(common.ConfHost.GetString(), ":", 2)
 
-			if len(split) < 2 || !strings.EqualFold("//"+hostSplit[0], split[1]) {
-				CtxLogger(r.Context()).Error("Mismatched origin: ", hostSplit[0]+" : "+split[1])
+			expectedHost := ""
+			if len(hostSplit) > 0 {
+				expectedHost = "//" + hostSplit[0]
+			}
+			originHost := ""
+			if len(split) > 1 {
+				originHost = split[1]
+			}
+
+			if originHost == "" || !strings.EqualFold(expectedHost, originHost) {
+				CtxLogger(r.Context()).Error("Mismatched origin: ", expectedHost+" : "+originHost)
 				WriteErrorResponse(w, r, "Bad origin", http.StatusUnauthorized)
 				return
 			}


### PR DESCRIPTION
Noticed the below panic in logs, this happens when the origin header has malformed content. 
```
level=error msg="http: panic serving  runtime error: index out of range [1] with length 1\ngoroutine 814312 [running]:\nnet/http.(*conn).serve.func1()\n\t/usr/local/go/src/net/http/server.go:1943 +0xd3\npanic({0x177e720?, 0xc00b9df3e0?})\n\t/usr/local/go/src/runtime/panic.go:783 +0x132\ngithub.com/botlabs-gg/yagpdb/v2/web.CSRFProtectionMW.func1({0x462d5b0, 0xc0071f0cb0}, 0xc005288f00)\n\t/go/pkg/mod/github.com/botlabs-gg/yagpdb/v2@v2.64.1/web/middleware.go:183 +0x2d5\nnet/http.HandlerFunc.ServeHTTP(0x461f2c0?, {0x462d5b0?, 0xc0071f0cb0?}, 0x460fa78?)\n\t/usr/local/go/src/net/http/server.go:2322 +0x29\ngithub.com/botlabs-gg/yagpdb/v2/web.setupRootMux.SkipStaticMW.func7.1({0x462d5b0, 0xc0071f0cb0}, 0xc005288f00)\n\t/go/pkg/mod/github.com/botlabs-gg/yagpdb/v2@v2.64.1/web/middleware.go:833 +0x95\nnet/http.HandlerFunc.ServeHTTP(0x4630198?, {0x462d5b0?, 0xc0071f0cb0?}, 0x460fb30?)\n\t/usr/local/go/src/net/http/server.go:2322 +0x29\ngithub.com/botlabs-gg/yagpdb/v2/web.UserInfoMiddleware.func1({0x462d5b0, 0xc0071f0cb0}, 0xc005288f00)\n\t/go/pkg/mod/github.com/botlabs-gg/yagpdb/v2@v2.64.1/web/middleware.go:203 +0x262\nnet/http.HandlerFunc.ServeHTTP(0x461f2c0?, {0x462d5b0?, 0xc0071f0cb0?}, 0xc001500008?)\n\t/usr/local/go/src/net/http/server.go:2322 +0x29\ngithub.com/botlabs-gg/yagpdb/v2/web.setupRootMux.SkipStaticMW.func6.1({0x462d5b0, 0xc0071f0cb0}, 0xc005288f00)\n\t/go/pkg/mod/github.com/botlabs-gg/yagpdb/v2@v2.64.1/web/middleware.go:833 +0x95\nnet/http.HandlerFunc.ServeHTTP(0xc00fb15268?, {0x462d5b0?, 0xc0071f0cb0?}, 0xc00fb15298?)\n\t/usr/local/go/src/net/http/server.go:2322 +0x29\ngithub.com/botlabs-gg/yagpdb/v2/web.SessionMiddleware.func1.1()\n\t/go/pkg/mod/github.com/botlabs-gg/yagpdb/v2@v2.64.1/web/middleware.go:115 +0x108\ngithub.com/botlabs-gg/yagpdb/v2/web.SessionMiddleware.func1({0x462d5b0?, 0xc0071f0cb0?}, 0xc005288dc0)\n\t/go/pkg/mod/github.com/botlabs-gg/yagpdb/v2@v2.64.1/web/middleware.go:125 +0x219\nnet/http.HandlerFunc.ServeHTTP(0x461f2c0?, {0x462d5b0?, 0xc0071f0cb0?}, 0xc001500008?)\n\t/usr/local/go/src/net/http/server.go:2322 +0x29\ngithub.com/botlabs-gg/yagpdb/v2/web.setupRootMux.SkipStaticMW.func5.1({0x462d5b0, 0xc0071f0cb0}, 0xc005288dc0)\n\t/go/pkg/mod/github.com/botlabs-gg/yagpdb/v2@v2.64.1/web/middleware.go:833 +0x95\nnet/http.HandlerFunc.ServeHTTP(0x4630198?, {0x462d5b0?, 0xc0071f0cb0?}, 0x7?)\n\t/usr/local/go/src/net/http/server.go:2322 +0x29\ngithub.com/botlabs-gg/yagpdb/v2/web.BaseTemplateDataMiddleware.func1({0x462d5b0, 0xc0071f0cb0}, 0xc005288c80)\n\t/go/pkg/mod/github.com/botlabs-gg/yagpdb/v2@v2.64.1/web/middleware.go:103 +0x64e\nnet/http.HandlerFunc.ServeHTTP(0x461f2c0?, {0x462d5b0?, 0xc0071f0cb0?}, 0xc001500008?)\n\t/usr/local/go/src/net/http/server.go:2322 +0x29\ngithub.com/botlabs-gg/yagpdb/v2/web.setupRootMux.SkipStaticMW.func4.1({0x462d5b0, 0xc0071f0cb0}, 0xc005288c80)\n\t/go/pkg/mod/github.com/botlabs-gg/yagpdb/v2@v2.64.1/web/middleware.go:833 +0x95\nnet/http.HandlerFunc.ServeHTTP(0x17602c0?, {0x462d5b0?, 0xc0071f0cb0?}, 0x19?)\n\t/usr/local/go/src/net/http/server.go:2322 +0x29\ngithub.com/botlabs-gg/yagpdb/v2/web.MiscMiddleware.func1({0x462d5b0, 0xc0071f0cb0}, 0xc005288b40)\n\t/go/pkg/mod/github.com/botlabs-gg/yagpdb/v2@v2.64.1/web/middleware.go:62 +0x450\nnet/http.HandlerFunc.ServeHTTP(0x461f2c0?, {0x462d5b0?, 0xc0071f0cb0?}, 0xc001500008?)\n\t/usr/local/go/src/net/http/server.go:2322 +0x29\ngithub.com/botlabs-gg/yagpdb/v2/web.setupRootMux.SkipStaticMW.func3.1({0x462d5b0, 0xc0071f0cb0}, 0xc005288b40)\n\t/go/pkg/mod/github.com/botlabs-gg/yagpdb/v2@v2.64.1/web/middleware.go:833 +0x95\nnet/http.HandlerFunc.ServeHTTP(0x0?, {0x462d5b0?, 0xc0071f0cb0?}, 0x4?)\n\t/usr/local/go/src/net/http/server.go:2322 +0x29\ngithub.com/NYTimes/gziphandler.GzipHandlerWithOpts.func1.1({0x462c7d0, 0xc00dd3a4b0}, 0xc005288b40)\n\t/go/pkg/mod/github.com/!n!y!times/gziphandler@v1.1.1/gzip.go:336 +0x27c\nnet/http.HandlerFunc.ServeHTTP(0x461f2c0?, {0x462c7d0?, 0xc00dd3a4b0?}, 0xa?)\n\t/usr/local/go/src/net/http/server.go:2322 +0x29\ngithub.com/botlabs-gg/yagpdb/v2/web.setupRootMux.SkipStaticMW.func2.1({0x462c7d0, 0xc00dd3a4b0}, 0xc005288b40)\n\t/go/pkg/mod/github.com/botlabs-gg/yagpdb/v2@v2.64.1/web/middleware.go:833 +0x95\nnet/http.HandlerFunc.ServeHTTP(0xc000a786a8?, {0x462c7d0?, 0xc00dd3a4b0?}, 0x53528e0?)\n\t/usr/local/go/src/net/http/server.go:2322 +0x29\ngoji%2eio.(*Mux).ServeHTTP(0xc000a78680, {0x462c7d0, 0xc00dd3a4b0}, 0xc002533e00?)\n\t/go/pkg/mod/goji.io@v2.0.2+incompatible/mux.go:74 +0x170\nnet/http.serverHandler.ServeHTTP({0xc005be7500?}, {0x462c7d0?, 0xc00dd3a4b0?}, 0x6?)\n\t/usr/local/go/src/net/http/server.go:3340 +0x8e\nnet/http.(*conn).serve(0xc00dde6cf0, {0x4630198, 0xc000b14420})\n\t/usr/local/go/src/net/http/server.go:2109 +0x665\ncreated by net/http.(*Server).Serve in goroutine 164\n\t/usr/local/go/src/net/http/server.go:3493 +0x485" stck="http.(*Server).logf:server.go:3679"
```