### PR TITLE
Removed exclusive lock on the premium slots table and added a unique index on guild_id where guild_id is not null. 

### DIFF
--- a/premium/schema.go
+++ b/premium/schema.go
@@ -24,6 +24,10 @@ ALTER TABLE premium_slots ADD COLUMN IF NOT EXISTS tier INT NOT NULL DEFAULT 1;
 `, `
 ALTER TABLE premium_slots ADD COLUMN IF NOT EXISTS deletes_at TIMESTAMP WITH TIME ZONE;
 `, `
+CREATE UNIQUE INDEX IF NOT EXISTS premium_slots_guild_unique
+ON premium_slots(guild_id)
+WHERE guild_id IS NOT NULL;
+`, `
 CREATE TABLE IF NOT EXISTS premium_codes (
 	id BIGSERIAL PRIMARY KEY,
 


### PR DESCRIPTION
The exclusive lock causes timeouts in case even 2 people are trying to assign premium slots at the same time. 