### PR TITLE
lib/template: don't evaluate '.' as float64

### DIFF
--- a/lib/template/exec.go
+++ b/lib/template/exec.go
@@ -712,7 +712,9 @@ func (s *state) idealConstant(constant *parse.NumberNode) reflect.Value {
 	switch {
 	case constant.IsComplex:
 		return reflect.ValueOf(constant.Complex128) // incontrovertible.
-	case constant.IsFloat && !isHexInt(constant.Text) && strings.ContainsAny(constant.Text, ".eEpP"):
+	case constant.IsFloat &&
+		!isHexInt(constant.Text) && !isRuneInt(constant.Text) &&
+		strings.ContainsAny(constant.Text, ".eEpP"):
 		return reflect.ValueOf(constant.Float64)
 	case constant.IsInt:
 		n := int(constant.Int64)
@@ -724,6 +726,10 @@ func (s *state) idealConstant(constant *parse.NumberNode) reflect.Value {
 		s.errorf("%s overflows int", constant.Text)
 	}
 	return zero
+}
+
+func isRuneInt(s string) bool {
+	return len(s) > 0 && s[0] == '\''
 }
 
 func isHexInt(s string) bool {

--- a/lib/template/exec_test.go
+++ b/lib/template/exec_test.go
@@ -715,6 +715,12 @@ var execTests = []execTest{
 	{"bug17c", "{{len .NonEmptyInterfacePtS}}", "2", tVal, true},
 	{"bug17d", "{{index .NonEmptyInterfacePtS 0}}", "a", tVal, true},
 	{"bug17e", "{{range .NonEmptyInterfacePtS}}-{{.}}-{{end}}", "-a--b-", tVal, true},
+
+	// More variadic function corner cases. Some runes would get evaluated
+	// as constant floats instead of ints. Issue 34483.
+	{"bug18a", "{{eq . '.'}}", "true", '.', true},
+	{"bug18b", "{{eq . 'e'}}", "true", 'e', true},
+	{"bug18c", "{{eq . 'P'}}", "true", 'P', true},
 }
 
 func zeroArgs() string {


### PR DESCRIPTION
This is taken directly from upstream at https://github.com/golang/go/commit/0f7b4e72a054f974489d8342cdae5a6a7ba7a31b
with minor testing on my end via `evalcc`

Unfortunately the patch does not apply cleanly to our codebase, so I had
to resort to copy-and-paste, thereby obscuring authorship.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
