### PR TITLE
cmddocs: improve markdown formatter

### DIFF
--- a/common/run/gen-docs.go
+++ b/common/run/gen-docs.go
@@ -40,7 +40,11 @@ func GenCommandsDocs() {
 			nameStr += entry.Cmd.Trigger.Names[0]
 
 			// then aliases
-			aliases := strings.Join(entry.Cmd.Trigger.Names[1:], "/")
+			var as bytes.Buffer
+			for _, alias := range entry.Cmd.Trigger.Names[1:] {
+				as.WriteString("- " + alias + "\n")
+			}
+			aliases := as.String()
 
 			// arguments and switches
 			args := stdHelpFmt.ArgDefs(entry.Cmd, mockCmdData)
@@ -59,29 +63,26 @@ func GenCommandsDocs() {
 				}
 			}
 
+			anchor := strings.ReplaceAll(nameStr, " ", "-")
 			out.WriteString("### " + nameStr + "\n\n")
 			if aliases != "" {
-				out.WriteString("**Aliases:** " + aliases + "\n\n")
+				out.WriteString("#### Aliases{#" + anchor + "-aliases}\n\n" + aliases + "\n")
 			}
 
 			out.WriteString(desc)
-			out.WriteString("\n\n")
+			out.WriteString("\n")
 
-			out.WriteString("**Usage:**\n")
-			out.WriteString("```\n" + args + "\n```\n")
+			out.WriteString("#### Usage{#" + anchor + "-usage}\n\n")
+			out.WriteString("```txt\n" + args + "\n```\n")
 
 			if switches != "" {
-				out.WriteString("```\n" + switches + "\n```\n")
+				out.WriteString("\n```txt\n" + switches + "\n```\n")
 			}
-
 			out.WriteString("\n")
 		}
-
 	}
 
 	os.Stdout.Write(out.Bytes())
-
-	return
 }
 
 func GenConfigDocs() {
@@ -127,7 +128,7 @@ func GenConfigDocs() {
 		out.WriteString("\n")
 
 		properKey := strings.ToUpper(v.Name)
-		properKey = strings.Replace(properKey, ".", "_", -1)
+		properKey = strings.ReplaceAll(properKey, ".", "_")
 		out.WriteString(properKey + "\n\n")
 	}
 

--- a/common/run/run.go
+++ b/common/run/run.go
@@ -93,7 +93,7 @@ func Init() {
 		AddSyslogHooks()
 	}
 
-	if !flagRunBot && !flagRunWeb && flagRunFeeds == "" && !flagRunEverything && !flagDryRun && !flagRunBWC && !flagGenConfigDocs {
+	if !flagRunBot && !flagRunWeb && flagRunFeeds == "" && !flagRunEverything && !flagDryRun && !flagRunBWC && !flagGenConfigDocs && !FlagGenCmdDocs {
 		log.Error("Didnt specify what to run, see -h for more info")
 		os.Exit(1)
 	}

--- a/lib/dcmd/help.go
+++ b/lib/dcmd/help.go
@@ -261,6 +261,10 @@ func (s *StdHelpFormatter) Switches(cmd Cmd) (str string) {
 	for _, sw := range switches {
 		str += "[-" + strings.ToLower(sw.Name) + " " + s.ArgDef(sw) + "]\n"
 	}
+	// Trim the last newline
+	if len(str) > 0 && strings.HasSuffix(str, "\n") {
+		str = str[:len(str)-1]
+	}
 
 	return
 }
@@ -283,6 +287,10 @@ func (s *StdHelpFormatter) ArgDefs(cmd *RegisteredCommand, data *Data) (str stri
 		}
 	} else {
 		str = cmd.FormatNames(false, "/") + " " + s.ArgDefLine(defs, req)
+	}
+	// Trim the last newline
+	if len(str) > 0 && strings.HasSuffix(str, "\n") {
+		str = str[:len(str)-1]
 	}
 
 	return


### PR DESCRIPTION
<!-- Please describe the changes this PR makes -->

Improve the Markdown formatter such that
- codeblocks are surrounded by blank lines
- no additional blank line at the end of a codeblock
- headers are surrounded by blank lines
- we no longer use emphasis as headers
- aliases are now a list

Parts of the old implementation were somewhat questionable. The new
implementation is provided in the hope that the all commands page in the
documentation is somewhat clearer, both in source and rendered form.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

<!-- 
If this Pull Request requires documentation changes, consider raising a PR
to our documentation at https://github.com/botlabs-gg/yagpdb-docs-v2 as well.
Please cross-link the PR below this comment if you do so.
Alternatively, you can also just create an issue over there.
-->

See botlabs-gg/yagpdb-docs-v2#96
