### PR TITLE
templates: consider all bases for toInt/toInt64

### DIFF
--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -1376,7 +1376,7 @@ func shuffle(seq interface{}) (interface{}, error) {
 	return shuffled.Interface(), nil
 }
 
-func tmplToInt(from interface{}) int {
+func tmplToInt(from any) int {
 	t := reflect.ValueOf(from)
 	switch {
 	case t.CanInt():
@@ -1386,14 +1386,15 @@ func tmplToInt(from interface{}) int {
 	case t.CanUint():
 		return int(t.Uint())
 	case t.Kind() == reflect.String:
-		parsed, _ := strconv.ParseInt(t.String(), 10, 64)
+		// base 0 to infer hex, octal, etc. from string prefix
+		parsed, _ := strconv.ParseInt(t.String(), 0, 64)
 		return int(parsed)
 	default:
 		return 0
 	}
 }
 
-func ToInt64(from interface{}) int64 {
+func ToInt64(from any) int64 {
 	t := reflect.ValueOf(from)
 	switch {
 	case t.CanInt():
@@ -1403,7 +1404,7 @@ func ToInt64(from interface{}) int64 {
 	case t.CanUint():
 		return int64(t.Uint())
 	case t.Kind() == reflect.String:
-		parsed, _ := strconv.ParseInt(t.String(), 10, 64)
+		parsed, _ := strconv.ParseInt(t.String(), 0, 64)
 		return parsed
 	default:
 		return 0


### PR DESCRIPTION
Currently, toInt(64) returns 0 for strings like 0xDEADBEEF, when it
should parse those without any issues.
The problem stems from the string case of these functions wherein
strconv.ParseInt is called with a fixed base of 10.
However, strconv.ParseInt can infer the base by inspecting the string
prefix, given that the base argument is set to 0.[0]
Make toInt(64) account for other bases by setting the base argument for
strconv.ParseInt to 0.
While we're here, also modernise `inferface{}` to `any`.

[0]: https://pkg.go.dev/strconv#ParseInt

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
