### PR TITLE
customcommands: enable dcct as a slash command

### DIFF
--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -197,7 +197,7 @@ var cmdDiagnoseCCTriggers = &commands.YAGCommand{
 		{Name: "input", Type: dcmd.String},
 	},
 	RequireDiscordPerms: []int64{discordgo.PermissionManageGuild},
-	SlashCommandEnabled: false,
+	SlashCommandEnabled: true,
 	DefaultEnabled:      true,
 	RunFunc: func(data *dcmd.Data) (interface{}, error) {
 		cmds, err := BotCachedGetCommandsWithMessageTriggers(data.GuildData.GS.ID, data.Context())


### PR DESCRIPTION
This allows users to at least bypass silly permission restrictions for
debugging their custom command triggers.

Joe suggested it, I was faster than him.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
