### PR TITLE
customcommands: add memberAbove function

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -768,6 +768,7 @@ func baseContextFuncs(c *Context) {
 	c.addContextFunc("getMember", c.tmplGetMember)
 	c.addContextFunc("getMemberVoiceState", c.tmplGetMemberVoiceState)
 	c.addContextFunc("editNickname", c.tmplEditNickname)
+	c.addContextFunc("memberAbove", c.tmplMemberAbove)
 
 	// Thread functions
 	c.addContextFunc("addThreadMember", c.tmplThreadMemberAdd)

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -1054,6 +1054,26 @@ func (c *Context) tmplGetMember(target interface{}) (*discordgo.Member, error) {
 	return member.DgoMember(), nil
 }
 
+// memberAbove returns whether member a is higher than member b in the guild hierarchy.
+func (c *Context) tmplMemberAbove(a, b *discordgo.Member) (bool, error) {
+	if c.IncreaseCheckGenericAPICall() {
+		return false, ErrTooManyAPICalls
+	}
+
+	if a == nil {
+		return false, nil
+	}
+
+	if b == nil {
+		return true, nil
+	}
+
+	aState := dstate.MemberStateFromMember(a)
+	bState := dstate.MemberStateFromMember(b)
+
+	return bot.IsMemberAbove(c.GS, aState, bState), nil
+}
+
 func (c *Context) tmplGetMemberVoiceState(target interface{}) (*discordgo.VoiceState, error) {
 	if c.IncreaseCheckGenericAPICall() {
 		return nil, ErrTooManyAPICalls


### PR DESCRIPTION
Add a `memberAbove` function for use in custom commands. Currently,
users have to write a fair bit of code to perform hierarchy checks. This
convenience function condenses it down to a single line.
It reports whether member a is above member b.

Usage:

```
{{ $isAbove := memberAbove <a> <b> }}
```

Both `a` and `b` must be a member object.

See https://discord.com/channels/166207328570441728/356486960417734666/1469137169242128415

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
