### PR TITLE
discordgo: self-reference Container for UnmarshalJSON

### DIFF
--- a/lib/discordgo/components.go
+++ b/lib/discordgo/components.go
@@ -788,15 +788,21 @@ func (s Container) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON is a helper function to unmarshal Container.
 func (c *Container) UnmarshalJSON(data []byte) error {
+	type container Container
 	var v struct {
+		container
 		RawComponents []unmarshalableMessageComponent `json:"components"`
 	}
+
 	err := json.Unmarshal(data, &v)
 	if err != nil {
 		return err
 	}
+
 	var ok bool
+	*c = Container(v.container)
 	c.Components = make([]TopLevelComponent, len(v.RawComponents))
+
 	for i, v := range v.RawComponents {
 		comp := v.MessageComponent
 		c.Components[i], ok = comp.(TopLevelComponent)


### PR DESCRIPTION
This lets users access the fields of a discordgo.Container for
components v2.

The current implementation unmarshals only into a container's
components, not the other fields; by adding a self-reference to the
struct we're unmarshalling into, we can ensure all fields are captured
properly. This is effectively the exact inverse of MarshalJSON.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
