### PR TITLE
Fix ffmpeg stats parsing errors and bot status state duplication

### DIFF
--- a/lib/dca/encode.go
+++ b/lib/dca/encode.go
@@ -478,7 +478,9 @@ func (e *EncodeSession) handleStderrLine(line string) {
 
 	_, err := fmt.Sscanf(line, "size=%dkB time=%d:%d:%f bitrate=%fkbits/s speed=%fx", &size, &timeH, &timeM, &timeS, &bitrate, &speed)
 	if err != nil {
-		logln("Error parsing ffmpeg stats:", err)
+		// Silently skip malformed stats lines (e.g., when ffmpeg outputs "N/A" for unavailable values)
+		// This commonly happens with short audio files or during early transcoding stages
+		return
 	}
 
 	dur := time.Duration(timeH) * time.Hour

--- a/lib/discordgo/gateway.go
+++ b/lib/discordgo/gateway.go
@@ -835,7 +835,7 @@ func newUpdateStatusData(activityType ActivityType, statusType Status, statusTex
 	if statusText != "" {
 		usd.Activity = &Activity{
 			Name:  statusText,
-			State: statusText,
+			// State: statusText,
 			Type:  activityType,
 			URL:   streamingUrl,
 		}


### PR DESCRIPTION
This PR addresses two issues:

## 1. DCA Library: FFmpeg Stats Parsing Error

**Problem:** When transcoding audio files (especially short files), ffmpeg outputs `N/A` or `N` for unavailable statistics like bitrate or speed during early processing stages. The parser attempted to parse these as numbers, resulting in error logs:
```
ERRO Error parsing ffmpeg stats: strconv.ParseFloat: parsing "N": invalid syntax
```

**Fix:** Modified `lib/dca/encode.go` to gracefully handle malformed stats lines by returning early instead of logging errors. These occurrences are expected behavior and don't affect transcoding functionality.

## 2. DiscordGo: Redundant Status State Field

**Problem:** In `lib/discordgo/gateway.go`, the `State` field in status updates was being set to the same value as `Name`, causing duplication in bot status displays.

**Fix:** Commented out the redundant `State` field assignment in the `newUpdateStatusData` function.

Both changes improve the user experience by reducing log noise and fixing display issues without affecting core functionality.