### PR TITLE
Fix issues with delayed interaction CCs and editing deferred responses. 

### DIFF
--- a/commands/util.go
+++ b/commands/util.go
@@ -334,10 +334,6 @@ func (e *EphemeralOrNone) Send(data *dcmd.Data) ([]*discordgo.Message, error) {
 			params.Embeds = []*discordgo.MessageEmbed{e.Embed}
 		}
 
-		// _, err := data.Session.EditOriginalInteractionResponse(common.BotApplication.ID, data.SlashCommandTriggerData.Interaction.Token, &discordgo.EditWebhookMessageRequest{
-		// 	Content: "Failed running the command.",
-		// })
-
 		if yc, ok := data.Cmd.Command.(*YAGCommand); ok {
 			settings, err := yc.GetSettings(data.ContainerChain, data.GuildData.CS, data.GuildData.GS)
 			if err != nil {
@@ -354,19 +350,10 @@ func (e *EphemeralOrNone) Send(data *dcmd.Data) ([]*discordgo.Message, error) {
 		}
 
 		m, err := data.Session.CreateFollowupMessage(common.BotApplication.ID, data.SlashCommandTriggerData.Interaction.Token, params)
-		// m, err := data.Session.EditOriginalInteractionResponse(common.BotApplication.ID, data.SlashCommandTriggerData.Interaction.Token, params)
-		// err = data.Session.CreateInteractionResponse(data.SlashCommandTriggerData.Interaction.ID, data.SlashCommandTriggerData.Interaction.Token, &discordgo.InteractionResponse{
-		// 	Kind: discordgo.InteractionResponseTypeChannelMessageWithSource,
-		// 	Data: &discordgo.InteractionApplicationCommandCallbackData{
-		// 		Content: &e.Content,
-		// 		Flags:   64,
-		// 	},
-		// })
 		if err != nil {
 			return nil, err
 		}
 
-		// return []*discordgo.Message{}, nil
 		return []*discordgo.Message{m}, nil
 	default:
 		return nil, nil

--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -261,32 +261,51 @@ type Context struct {
 }
 
 type ContextFrame struct {
-	CS *dstate.ChannelState
+	CS *dstate.ChannelState `json:"cs"`
 
-	MentionEveryone bool
-	MentionHere     bool
-	MentionRoles    []int64
+	MentionEveryone bool    `json:"mention_everyone"`
+	MentionHere     bool    `json:"mention_here"`
+	MentionRoles    []int64 `json:"mention_roles"`
 
-	DelResponse       bool
-	PublishResponse   bool
-	EphemeralResponse bool
+	DelResponse       bool `json:"del_response"`
+	PublishResponse   bool `json:"publish_response"`
+	EphemeralResponse bool `json:"ephemeral_response"`
 
-	DelResponseDelay         int
-	EmbedsToSend             []*discordgo.MessageEmbed
-	ComponentsToSend         []discordgo.TopLevelComponent
-	AddResponseReactionNames []string
+	DelResponseDelay         int                           `json:"del_response_delay"`
+	EmbedsToSend             []*discordgo.MessageEmbed     `json:"embeds_to_send"`
+	ComponentsToSend         []discordgo.TopLevelComponent `json:"components_to_send"`
+	AddResponseReactionNames []string                      `json:"add_response_reaction_names"`
 
-	isNestedTemplate bool
+	IsNestedTemplate bool `json:"is_nested_template"`
 	parsedTemplate   *template.Template
-	SendResponseInDM bool
+	SendResponseInDM bool `json:"send_response_in_dm"`
 
-	Interaction *CustomCommandInteraction
+	Interaction *CustomCommandInteraction `json:"interaction"`
 }
 
 type CustomCommandInteraction struct {
-	*discordgo.Interaction
-	RespondedTo bool
-	Deferred    bool
+	*discordgo.Interaction `json:"interaction"`
+	RespondedTo            bool `json:"responded_to"`
+	Deferred               bool `json:"deferred"`
+}
+
+func (c *CustomCommandInteraction) UnmarshalJSON(data []byte) error {
+	var aux struct {
+		Interaction *discordgo.Interaction `json:"interaction"`
+		RespondedTo bool                   `json:"responded_to"`
+		Deferred    bool                   `json:"deferred"`
+	}
+
+	err := json.Unmarshal(data, &aux)
+	if err != nil {
+		return err
+	}
+
+	c.Interaction = aux.Interaction
+	c.RespondedTo = aux.RespondedTo
+	c.Deferred = aux.Deferred
+
+	return nil
 }
 
 func NewContext(gs *dstate.GuildSet, cs *dstate.ChannelState, ms *dstate.MemberState) *Context {
@@ -502,7 +521,7 @@ func (c *Context) newContextFrame(cs *dstate.ChannelState) *ContextFrame {
 	old := c.CurrentFrame
 	c.CurrentFrame = &ContextFrame{
 		CS:               cs,
-		isNestedTemplate: true,
+		IsNestedTemplate: true,
 	}
 
 	return old
@@ -553,7 +572,7 @@ func (c *Context) SendResponse(content string) (m *discordgo.Message, err error)
 	if c.CurrentFrame.Interaction != nil {
 		if c.CurrentFrame.Interaction.RespondedTo {
 			sendType = sendMessageInteractionFollowup
-			if c.CurrentFrame.Interaction.Deferred {
+			if c.CurrentFrame.EphemeralResponse {
 				sendType = sendMessageInteractionDeferred
 			}
 		} else {

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -212,7 +212,7 @@ func (c *Context) sendNestedTemplate(channel interface{}, dm bool, name string, 
 	if name == "" {
 		return "", errors.New("no template name passed")
 	}
-	if c.CurrentFrame.isNestedTemplate {
+	if c.CurrentFrame.IsNestedTemplate {
 		return "", errors.New("can't call this in a nested template")
 	}
 

--- a/common/templates/context_interactions.go
+++ b/common/templates/context_interactions.go
@@ -171,6 +171,10 @@ func (c *Context) tmplDeleteInteractionResponse(interactionToken, msgID interfac
 
 func (c *Context) tmplEditInteractionResponse(filterSpecialMentions bool) func(interactionToken, msgID, msg interface{}) (interface{}, error) {
 	return func(interactionToken, msgID, msg interface{}) (interface{}, error) {
+		if c.CurrentFrame.Interaction == nil {
+			return "", errors.New("no interaction data in context")
+		}
+
 		if c.IncreaseCheckGenericAPICall() {
 			return "", ErrTooManyAPICalls
 		}
@@ -202,8 +206,13 @@ func (c *Context) tmplEditInteractionResponse(filterSpecialMentions bool) func(i
 		}
 
 		if editOriginal {
-			_, err = common.BotSession.EditOriginalInteractionResponse(common.BotApplication.ID, token, msgEditResponse)
-			if err == nil && token == c.CurrentFrame.Interaction.Token {
+			if c.CurrentFrame.EphemeralResponse {
+				_, err = common.BotSession.EditOriginalInteractionResponse(common.BotApplication.ID, token, msgEditResponse)
+			} else {
+				_, err = common.BotSession.CreateFollowupMessage(common.BotApplication.ID, token, msgEditResponse)
+			}
+
+			if err == nil && c.CurrentFrame.Interaction != nil && token == c.CurrentFrame.Interaction.Token {
 				c.CurrentFrame.Interaction.RespondedTo = true
 				c.CurrentFrame.Interaction.Deferred = false
 			}
@@ -422,9 +431,16 @@ func (c *Context) tokenArg(interactionToken interface{}) (sendType sendMessageTy
 			return
 		}
 	} else {
+		sToken = strings.TrimSpace(sToken)
 		//rudimentary check for valid token because people don't read docs and will send anything.
-		decoded, _ := base64.URLEncoding.DecodeString(sToken)
-		parts := strings.Split(string(decoded), ":")
+		decoded, err := base64.RawURLEncoding.DecodeString(sToken)
+		if err != nil {
+			decoded, err = base64.URLEncoding.DecodeString(sToken)
+		}
+		if err != nil {
+			return
+		}
+		parts := strings.SplitN(string(decoded), ":", 3)
 		if len(parts) < 3 {
 			return
 		}

--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -538,9 +538,10 @@ func parseAllowedMentions(Data interface{}) (*discordgo.AllowedMentions, error) 
 					return nil, errors.New(`Allowed Mentions Parsing: invalid slice element in "Parse", accepts "roles", "users", and "everyone"`)
 				}
 				parseMentions = append(parseMentions, discordgo.AllowedMentionType(elem_conv))
-				if elem_conv == "users" {
+				switch elem_conv {
+				case "users":
 					parsingUsers = true
-				} else if elem_conv == "roles" {
+				case "roles":
 					parsingRoles = true
 				}
 			}

--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -84,7 +84,8 @@ type DelayedRunCCData struct {
 	Message *discordgo.Message
 	Member  *dstate.MemberState
 
-	UserKey interface{} `json:"user_key"`
+	UserKey      interface{}             `json:"user_key"`
+	CurrentFrame *templates.ContextFrame `json:"current_frame,omitempty"`
 
 	ExecutedFrom templates.ExecutedFromType `json:"executed_from"`
 }

--- a/customcommands/handle_timed.go
+++ b/customcommands/handle_timed.go
@@ -106,6 +106,14 @@ func handleDelayedRunCC(evt *schEventsModels.ScheduledEvent, data interface{}) (
 	}
 
 	tmplCtx.ExecutedFrom = dataCast.ExecutedFrom
+	if dataCast.CurrentFrame != nil {
+		tmplCtx.CurrentFrame = dataCast.CurrentFrame
+		tmplCtx.CurrentFrame.CS = cs
+	}
+
+	if tmplCtx.CurrentFrame.Interaction != nil {
+		tmplCtx.Data["Interaction"] = tmplCtx.CurrentFrame.Interaction.Interaction
+	}
 
 	// decode userdata
 	if len(dataCast.UserData) > 0 {

--- a/customcommands/tmplextensions.go
+++ b/customcommands/tmplextensions.go
@@ -253,8 +253,9 @@ func tmplRunCC(ctx *templates.Context) interface{} {
 			ChannelID: channelID,
 			CmdID:     cmd.LocalID,
 
-			Member:  ctx.MS,
-			Message: ctx.Msg,
+			Member:       ctx.MS,
+			Message:      ctx.Msg,
+			CurrentFrame: ctx.CurrentFrame,
 
 			ExecutedFrom: ctx.ExecutedFrom,
 		}
@@ -337,9 +338,10 @@ func tmplScheduleUniqueCC(ctx *templates.Context) interface{} {
 			ChannelID: channelID,
 			CmdID:     cmd.LocalID,
 
-			Member:  ctx.MS,
-			Message: ctx.Msg,
-			UserKey: stringedKey,
+			Member:       ctx.MS,
+			Message:      ctx.Msg,
+			UserKey:      stringedKey,
+			CurrentFrame: ctx.CurrentFrame,
 
 			ExecutedFrom: ctx.ExecutedFrom,
 		}

--- a/lib/discordgo/structs.go
+++ b/lib/discordgo/structs.go
@@ -1471,7 +1471,7 @@ type WebhookParams struct {
 	AvatarURL       string              `json:"avatar_url,omitempty"`
 	TTS             bool                `json:"tts,omitempty"`
 	File            *File               `json:"-,omitempty"`
-	Components      []TopLevelComponent `json:"components"`
+	Components      []TopLevelComponent `json:"components,omitempty"`
 	Embeds          []*MessageEmbed     `json:"embeds,omitempty"`
 	Flags           MessageFlags        `json:"flags,omitempty"`
 	AllowedMentions *AllowedMentions    `json:"allowed_mentions,omitempty"`


### PR DESCRIPTION
This fixes issues with delayed interaction CCs via execCC and scheduleUniqueCC and uses createFollowupResponse instead of editOriginalInteractionResponse for non-ephemeral deferreed messages

<!-- Please describe the changes this PR makes -->

<!-- 
If this Pull Request requires documentation changes, consider raising a PR
to our documentation at https://github.com/botlabs-gg/yagpdb-docs-v2 as well.
Please cross-link the PR below this comment if you do so.
Alternatively, you can also just create an issue over there.
-->
