### PR TITLE
 customcommands: new hasAnyPermissions functions

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -850,7 +850,9 @@ func baseContextFuncs(c *Context) {
 
 	// Permission functions
 	c.addContextFunc("hasPermissions", c.tmplHasPermissions)
+	c.addContextFunc("hasAnyPermissions", c.tmplHasAnyPermissions)
 	c.addContextFunc("targetHasPermissions", c.tmplTargetHasPermissions)
+	c.addContextFunc("targetHasAnyPermissions", c.tmplTargetHasAnyPermissions)
 	c.addContextFunc("getTargetPermissionsIn", c.tmplGetTargetPermissionsIn)
 
 	// Channel functions

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -773,22 +773,18 @@ func (c *Context) tmplHasPermissions(needed int64) (bool, error) {
 		return false, ErrTooManyAPICalls
 	}
 
-	if c.MS == nil {
-		return false, nil
-	}
-
-	if needed < 0 {
-		return false, nil
-	}
-
-	if needed == 0 {
-		return true, nil
-	}
-
-	return c.hasPerms(c.MS, c.CurrentFrame.CS.ID, needed)
+	return c.hasPerms(c.MS, c.CurrentFrame.CS.ID, needed, false)
 }
 
-func (c *Context) tmplTargetHasPermissions(target interface{}, needed int64) (bool, error) {
+func (c *Context) tmplHasAnyPermissions(needed int64) (bool, error) {
+	if c.IncreaseCheckGenericAPICall() {
+		return false, ErrTooManyAPICalls
+	}
+
+	return c.hasPerms(c.MS, c.CurrentFrame.CS.ID, needed, true)
+}
+
+func (c *Context) tmplTargetHasPermissions(target any, needed int64) (bool, error) {
 	if c.IncreaseCheckGenericAPICall() {
 		return false, ErrTooManyAPICalls
 	}
@@ -798,6 +794,37 @@ func (c *Context) tmplTargetHasPermissions(target interface{}, needed int64) (bo
 		return false, nil
 	}
 
+	ms, err := bot.GetMember(c.GS.ID, targetID)
+	if err != nil {
+		return false, err
+	}
+
+	return c.hasPerms(ms, c.CurrentFrame.CS.ID, needed, false)
+}
+
+func (c *Context) tmplTargetHasAnyPermissions(target any, needed int64) (bool, error) {
+	if c.IncreaseCheckGenericAPICall() {
+		return false, ErrTooManyAPICalls
+	}
+
+	targetID := TargetUserID(target)
+	if targetID == 0 {
+		return false, nil
+	}
+
+	ms, err := bot.GetMember(c.GS.ID, targetID)
+	if err != nil {
+		return false, err
+	}
+
+	return c.hasPerms(ms, c.CurrentFrame.CS.ID, needed, true)
+}
+
+func (c *Context) hasPerms(ms *dstate.MemberState, channelID int64, needed int64, requireAny bool) (bool, error) {
+	if ms == nil {
+		return false, nil
+	}
+
 	if needed < 0 {
 		return false, nil
 	}
@@ -806,12 +833,20 @@ func (c *Context) tmplTargetHasPermissions(target interface{}, needed int64) (bo
 		return true, nil
 	}
 
-	ms, err := bot.GetMember(c.GS.ID, targetID)
+	perms, err := c.GS.GetMemberPermissions(channelID, ms.User.ID, ms.Member.Roles)
 	if err != nil {
 		return false, err
 	}
 
-	return c.hasPerms(ms, c.CurrentFrame.CS.ID, needed)
+	if perms&discordgo.PermissionAdministrator != 0 {
+		return true, nil
+	}
+
+	if requireAny {
+		return perms&needed != 0, nil
+	}
+
+	return perms&needed == needed, nil
 }
 
 func (c *Context) tmplGetTargetPermissionsIn(target interface{}, channel interface{}) (int64, error) {
@@ -835,23 +870,6 @@ func (c *Context) tmplGetTargetPermissionsIn(target interface{}, channel interfa
 	}
 
 	return c.GS.GetMemberPermissions(channelID, ms.User.ID, ms.Member.Roles)
-}
-
-func (c *Context) hasPerms(ms *dstate.MemberState, channelID int64, needed int64) (bool, error) {
-	perms, err := c.GS.GetMemberPermissions(channelID, ms.User.ID, ms.Member.Roles)
-	if err != nil {
-		return false, err
-	}
-
-	if perms&needed == needed {
-		return true, nil
-	}
-
-	if perms&discordgo.PermissionAdministrator != 0 {
-		return true, nil
-	}
-
-	return false, nil
 }
 
 func (c *Context) tmplDelResponse(args ...interface{}) string {


### PR DESCRIPTION
As it is, the hasPermissions function checks whether *all* bits are
set. To test for any bit, users currently need to write their own logic,
which is quite unergonomic.

Add two new function, targetHasAnyPermissions and hasAnyPermissions that
checks whether at least one permission bit is set, allowing for more
ergonomic permission checking when only one of many permissions is
necessary to the user.

<!-- 
If this Pull Request requires documentation changes, consider raising a PR
to our documentation at https://github.com/botlabs-gg/yagpdb-docs-v2 as well.
Please cross-link the PR below this comment if you do so.
Alternatively, you can also just create an issue over there.
-->
