### PR TITLE
Fixes for global ratelimit handler and refresh mute overrides on guild create events 

### DIFF
--- a/common/mqueue/discordprocessor.go
+++ b/common/mqueue/discordprocessor.go
@@ -168,6 +168,12 @@ func trySendWebhook(l *logrus.Entry, elem *QueuedElement) (err error) {
 			AllowedMentions: &elem.MessageSend.AllowedMentions,
 		}
 		_, err = webhookSession.WebhookExecuteComplex(wh.ID, wh.Token, true, params)
+		if code, _ := common.DiscordError(err); code == discordgo.ErrCodeUnknownWebhook {
+			webhookCache.Delete(elem.ChannelID)
+			if delErr := deleteWebhookRow(elem.ChannelID, elem.Source); delErr != nil {
+				l.WithError(delErr).Error("failed deleting stale mqueue_webhooks row")
+			}
+		}
 		if err != nil {
 			logrus.WithError(err).Error("Failed sending mqueue v2 message via webhook (WebhookExecuteComplex)")
 			return err
@@ -197,8 +203,11 @@ func trySendWebhook(l *logrus.Entry, elem *QueuedElement) (err error) {
 
 	err = webhookSession.WebhookExecute(wh.ID, wh.Token, true, webhookParams)
 	if code, _ := common.DiscordError(err); code == discordgo.ErrCodeUnknownWebhook {
-		// webhook got deleted, try again
+		// webhook got deleted, drop our stale records and try again with a fresh one
 		webhookCache.Delete(elem.ChannelID)
+		if delErr := deleteWebhookRow(elem.ChannelID, elem.Source); delErr != nil {
+			l.WithError(delErr).Error("failed deleting stale mqueue_webhooks row")
+		}
 		wh, _, err = getWebhook()
 		if err != nil {
 			return err

--- a/common/mqueue/models.go
+++ b/common/mqueue/models.go
@@ -75,6 +75,12 @@ WHERE guild_id=$1 AND channel_id=$2 AND plugin=$3;
 	return &hook, nil
 }
 
+func deleteWebhookRow(channelID int64, plugin string) error {
+	const query = `DELETE FROM mqueue_webhooks WHERE channel_id=$1 AND plugin=$2;`
+	_, err := common.PQ.Exec(query, channelID, plugin)
+	return err
+}
+
 func createWebhook(guildID int64, channelID int64, plugin string, avatar string) (*webhook, error) {
 	discordHook, err := common.BotSession.WebhookCreate(channelID, plugin, avatar)
 	if err != nil {

--- a/common/pubsub/buildin_events.go
+++ b/common/pubsub/buildin_events.go
@@ -2,6 +2,7 @@ package pubsub
 
 import (
 	"encoding/json"
+	"os"
 	"reflect"
 	"time"
 
@@ -10,14 +11,25 @@ import (
 	"github.com/botlabs-gg/yagpdb/v2/lib/discordgo"
 )
 
+var hostname string
+
+func init() {
+	h, err := os.Hostname()
+	if err != nil {
+		return
+	}
+	hostname = h
+}
+
 // PublishRatelimit publishes a new global ratelimit hit on discord
 func PublishRatelimit(rl *discordgo.RateLimit) {
 	logger.Printf("Got 429: %s, %s", rl.Bucket, rl.RetryAfterDur())
 
 	reset := time.Now().Add(rl.RetryAfterDur())
 	err := Publish("global_ratelimit", -1, &globalRatelimitTriggeredEventData{
-		Bucket: rl.Bucket,
-		Reset:  reset,
+		Bucket:     rl.Bucket,
+		Reset:      reset,
+		SourceHost: hostname,
 	})
 	if err != nil {
 		logger.WithError(err).Error("failed publishing global ratelimit")
@@ -25,12 +37,16 @@ func PublishRatelimit(rl *discordgo.RateLimit) {
 }
 
 type globalRatelimitTriggeredEventData struct {
-	Reset  time.Time `json:"reset"`
-	Bucket string    `json:"bucket"`
+	Reset      time.Time `json:"reset"`
+	Bucket     string    `json:"bucket"`
+	SourceHost string    `json:"source_host"`
 }
 
 func handleGlobalRatelimtPusub(evt *Event) {
 	data := evt.Data.(*globalRatelimitTriggeredEventData)
+	if data.SourceHost == "" || hostname == "" || data.SourceHost != hostname {
+		return
+	}
 	common.BotSession.Ratelimiter.SetGlobalTriggered(data.Reset)
 }
 

--- a/moderation/plugin_bot.go
+++ b/moderation/plugin_bot.go
@@ -3,6 +3,7 @@ package moderation
 import (
 	"database/sql"
 	"math/rand"
+	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -22,6 +23,8 @@ import (
 	"github.com/botlabs-gg/yagpdb/v2/lib/dstate"
 	"github.com/botlabs-gg/yagpdb/v2/moderation/models"
 	"github.com/karlseguin/ccache"
+	"github.com/mediocregopher/radix/v3"
+	"golang.org/x/time/rate"
 )
 
 var (
@@ -55,12 +58,15 @@ func (p *Plugin) BotInit() {
 
 	eventsystem.AddHandlerAsyncLast(p, HandleGuildAuditLogEntryCreate, eventsystem.EventGuildAuditLogEntryCreate)
 
-	eventsystem.AddHandlerAsyncLastLegacy(p, bot.ConcurrentEventHandler(HandleGuildCreate), eventsystem.EventGuildCreate)
+	eventsystem.AddHandlerAsyncLastLegacy(p, HandleGuildCreate, eventsystem.EventGuildCreate)
 	eventsystem.AddHandlerAsyncLast(p, HandleChannelCreateUpdate, eventsystem.EventChannelCreate, eventsystem.EventChannelUpdate)
 
 	pubsub.AddHandler("invalidate_moderation_config_cache", handleInvalidateConfigCache, nil)
 	pubsub.AddHandler("mod_refresh_mute_override", HandleRefreshMuteOverrides, nil)
 	pubsub.AddHandler("mod_refresh_mute_override_create_role", HandleRefreshMuteOverridesCreateRole, nil)
+
+	initMuteRefreshQueueKey()
+	go muteRefreshWorker()
 }
 
 func BotCachedGetConfigIfNotSet(guildID int64, config *Config) (*Config, error) {
@@ -128,22 +134,71 @@ func HandleRefreshMuteOverridesCreateRole(evt *pubsub.Event) {
 	RefreshMuteOverrides(evt.TargetGuildInt, true)
 }
 
-var started = time.Now()
+const muteRefreshQueueKeyPrefix = "moderation:mute_refresh:host:"
+
+var (
+	muteRefreshLocalQueueKey string
+	muteRefreshLimiter       = rate.NewLimiter(rate.Every(2*time.Second), 1)
+)
+
+func initMuteRefreshQueueKey() {
+	host := common.NodeID
+	if host == "" {
+		if h, err := os.Hostname(); err == nil {
+			host = h
+		}
+	}
+	if host == "" {
+		host = "unknown"
+	}
+	muteRefreshLocalQueueKey = muteRefreshQueueKeyPrefix + host
+}
+
+func enqueueMuteRefresh(gid int64) {
+	score := strconv.FormatInt(time.Now().UnixNano(), 10)
+	err := common.RedisPool.Do(radix.Cmd(nil, "ZADD", muteRefreshLocalQueueKey, "NX", score, strconv.FormatInt(gid, 10)))
+	if err != nil {
+		logger.WithError(err).WithField("guild", gid).Error("failed enqueueing mute refresh")
+	}
+}
+
+func popMuteRefresh() (int64, bool) {
+	var resp []string
+	err := common.RedisPool.Do(radix.Cmd(&resp, "ZPOPMIN", muteRefreshLocalQueueKey, "1"))
+	if err != nil {
+		logger.WithError(err).Error("failed popping mute refresh")
+		return 0, false
+	}
+	if len(resp) < 1 {
+		return 0, false
+	}
+	gid, err := strconv.ParseInt(resp[0], 10, 64)
+	if err != nil {
+		logger.WithError(err).WithField("v", resp[0]).Error("invalid mute refresh queue entry")
+		return 0, false
+	}
+	return gid, true
+}
+
+func muteRefreshWorker() {
+	for {
+		gid, ok := popMuteRefresh()
+		if !ok {
+			time.Sleep(time.Second)
+			continue
+		}
+		if delay := muteRefreshLimiter.Reserve().Delay(); delay > 0 {
+			time.Sleep(delay)
+		}
+		RefreshMuteOverrides(gid, false)
+	}
+}
 
 func HandleGuildCreate(evt *eventsystem.EventData) {
 	if !evt.HasFeatureFlag(featureFlagMuteRoleManaged) {
-		return // nothing to do
+		return
 	}
-
-	gc := evt.GuildCreate()
-
-	// relieve startup preasure, sleep for up to 10 minutes
-	if time.Since(started) < time.Minute*10 {
-		sleep := time.Second * time.Duration(100+rand.Intn(60*180))
-		time.Sleep(sleep)
-	}
-
-	RefreshMuteOverrides(gc.ID, false)
+	enqueueMuteRefresh(evt.GuildCreate().ID)
 }
 
 // Refreshes the mute override on the channel, currently it only adds it.


### PR DESCRIPTION
changed global ratelimit lockdown to host level ratelimit lockdown to prevent the entire bot from shutting down in scenarios when a specific host gets ratelimited, modified the muterole override refresh to be queued instead of being executed per guild, add logic to delete webhook after failed mqueue requests that give unknown webhook error

<!-- Please describe the changes this PR makes -->

<!-- 
If this Pull Request requires documentation changes, consider raising a PR
to our documentation at https://github.com/botlabs-gg/yagpdb-docs-v2 as well.
Please cross-link the PR below this comment if you do so.
Alternatively, you can also just create an issue over there.
-->
