### PR TITLE
feat(moderation): add disconnect command for voice members

### DIFF
--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -576,7 +576,7 @@ var ModerationCommands = []*commands.YAGCommand{
 		CustomEnabled: true,
 		CmdCategory:   commands.CategoryModeration,
 		Name:          "Disconnect",
-		Aliases:       []string{"voicekick" "disconnect"},
+		Aliases:       []string{"voicekick", "disconnect"},
 		Description:   "Disconnects a member from their voice channel",
 		RequiredArgs:  1,
 		Arguments: []*dcmd.ArgDef{

--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -520,7 +520,8 @@ var ModerationCommands = []*commands.YAGCommand{
 
 			return GenericCmdResp(MATimeoutAdded, target, d, true, false), nil
 		},
-	}, {
+	},
+	{
 		CustomEnabled: true,
 		CmdCategory:   commands.CategoryModeration,
 		Name:          "RemoveTimeout",
@@ -569,6 +570,69 @@ var ModerationCommands = []*commands.YAGCommand{
 			}
 
 			return GenericCmdResp(MATimeoutRemoved, target, 0, false, true), nil
+		},
+	},
+	{
+		CustomEnabled: true,
+		CmdCategory:   commands.CategoryModeration,
+		Name:          "Disconnect",
+		Aliases:       []string{"voicekick" "disconnect"},
+		Description:   "Disconnects a member from their voice channel",
+		RequiredArgs:  1,
+		Arguments: []*dcmd.ArgDef{
+			{Name: "User", Type: dcmd.UserID},
+			{Name: "Reason", Type: dcmd.String},
+		},
+		RequiredDiscordPermsHelp: "MoveMembers or ManageGuild",
+		RequireBotPerms: [][]int64{
+			{discordgo.PermissionAdministrator},
+			{discordgo.PermissionVoiceMoveMembers},
+		},
+		SlashCommandEnabled: true,
+		DefaultEnabled:      false,
+		IsResponseEphemeral: false,
+		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
+			config, target, err := MBaseCmd(parsed, parsed.Args[0].Int64())
+			if err != nil {
+				return nil, err
+			}
+
+			reason := SafeArgString(parsed, 1)
+			reason, err = MBaseCmdSecond(parsed, reason, true,
+				discordgo.PermissionVoiceMoveMembers,
+				config.KickCmdRoles,
+				config.KickEnabled, true)
+			if err != nil {
+				return nil, err
+			}
+
+			member, err := bot.GetMember(parsed.GuildData.GS.ID, target.ID)
+			if err != nil || member == nil {
+				return "Member not found", err
+			}
+
+			vs := parsed.GuildData.GS.GetVoiceState(target.ID)
+			if vs == nil {
+				return "Member is not in a voice channel", nil
+			}
+
+			err = checkHierarchy(parsed, target.ID)
+			if err != nil {
+				return nil, err
+			}
+
+			err = common.BotSession.GuildMemberMove(
+				parsed.GuildData.GS.ID, target.ID, 0)
+			if err != nil {
+				return nil, err
+			}
+
+			if config.ActionChannel != 0 {
+				CreateModlogEmbed(config, parsed.Author,
+					MADisconnect, target, reason, "")
+			}
+
+			return GenericCmdResp(MADisconnect, target, 0, true, true), nil
 		},
 	},
 	{

--- a/moderation/modlog.go
+++ b/moderation/modlog.go
@@ -30,6 +30,7 @@ var (
 	MAMute           = ModlogAction{Prefix: "Muted", Emoji: "🔇", Color: 0x57728e}
 	MAUnmute         = ModlogAction{Prefix: "Unmuted", Emoji: "🔊", Color: 0x62c65f}
 	MAKick           = ModlogAction{Prefix: "Kicked", Emoji: "👢", Color: 0xf2a013}
+	MADisconnect     = ModlogAction{Prefix: "Disconnected", Emoji: "🔌", Color: 0xe67e22}
 	MABanned         = ModlogAction{Prefix: "Banned", Emoji: "🔨", Color: 0xd64848}
 	MAUnbanned       = ModlogAction{Prefix: "Unbanned", Emoji: "🔓", Color: 0x62c65f}
 	MAWarned         = ModlogAction{Prefix: "Warned", Emoji: "⚠", Color: 0xfca253}


### PR DESCRIPTION
## Summary

This PR adds a new moderation command, disconnect, which disconnects a member from their current voice channel.

The command is also available through execAdmin, enabling custom command use cases such as automatically disconnecting users from voice channels.

## Features
New moderation command: disconnect
Alias: voicekick
Slash command support
Modlog integration
Custom command support via execAdmin
Requires the Discord Move Members permission

## Implementation

The command disconnects users by moving them to channel ID 0 using Discord's existing voice API:

``common.BotSession.GuildMemberMove(guildID, userID, 0)``

This capability is already used internally by the moderation plugin when muting members, but was not previously exposed as a standalone moderation action.

To keep the change small and avoid database or UI modifications, the command currently reuses the existing Kick command configuration and permission model (KickEnabled and KickCmdRoles).

## Example Usage

Regular command:
```
-disconnect @user
-voicekick @user
```
Custom command:

``{{execAdmin "voicekick" .User.ID}}``

## Motivation

Disconnecting users from voice channels is a common moderation action supported by Discord through the Move Members permission. This PR exposes that functionality through YAGPDB's moderation system in a way that is consistent with existing moderation commands such as kick, mute, and timeout.


### Please note I'm not familiar with Go and I wasn't able to test this locally. The code was written by following existing patterns in the moderation module, but it may need adjustments based on project conventions or build requirements.