### PR TITLE
Add nick and globalname to LeaderboardEntry

### DIFF
--- a/reputation/reputation.go
+++ b/reputation/reputation.go
@@ -446,9 +446,11 @@ func GetConfig(ctx context.Context, guildID int64) (*models.ReputationConfig, er
 
 type LeaderboardEntry struct {
 	*RankEntry
-	Username string `json:"username"`
-	Bot      bool   `json:"bot"`
-	Avatar   string `json:"avatar"`
+	Username   string `json:"username"`
+	Nick       string `json:"nick"`
+	Globalname string `json:"globalname"`
+	Bot        bool   `json:"bot"`
+	Avatar     string `json:"avatar"`
 }
 
 func DetailedLeaderboardEntries(guildID int64, ranks []*RankEntry) ([]*LeaderboardEntry, error) {
@@ -490,6 +492,8 @@ func DetailedLeaderboardEntries(guildID int64, ranks []*RankEntry) ([]*Leaderboa
 		for _, m := range members {
 			if m.User.ID == userIDs[i] {
 				lEntry.Username = m.User.String()
+				lEntry.Nick = m.Nick
+				lEntry.Globalname = m.User.Globalname
 				lEntry.Avatar = m.User.AvatarURL("256")
 				lEntry.Bot = m.User.Bot
 				break


### PR DESCRIPTION
This PR adds - as the name says `Nick` (the server nickname) and `Globalname` (the global displayname) of the user/guild member to `LeaderboardEntry`, which displays it on the Control Panel and in the public API response.

This PR doesn't raise any docs changes.

Old PR with wrong base branch: #2073