### PR TITLE
Fix: Components V2 message builder not rendering fields

### DIFF
--- a/frontend/static/js/messagecreator.js
+++ b/frontend/static/js/messagecreator.js
@@ -428,7 +428,7 @@
         let j = idx + delta;
         if (j < 0 || j >= list.length) return;
         let tmp = list[idx]; list[idx] = list[j]; list[j] = tmp;
-        (onChange || rebuild)();
+        (onChange || rebuildEditor)();
     }
 
     function renderBuilder() {
@@ -466,7 +466,7 @@
     }
 
     function nodeHeader(title, list, idx, onChange) {
-        onChange = onChange || rebuild;
+        onChange = onChange || rebuildEditor;
         let tools = el("div", { class: "mc-node-tools" }, [
             btn('<i class="fas fa-arrow-up"></i>', "btn-sm btn-secondary", function () { move(list, idx, -1, onChange); }, { title: "Move up" }),
             btn('<i class="fas fa-arrow-down"></i>', "btn-sm btn-secondary", function () { move(list, idx, 1, onChange); }, { title: "Move down" }),


### PR DESCRIPTION
The components V2  message builder was failing to render the configuration components in the web UI when the user clicked to add each component. The root cause was a type/missed rename of `rebuild` -> `rebuildEditor`. This appears to be isolated to just these two lines of code and so the fix is quite simple. 
