### PR TITLE
fix: correct occured to occurred typo in code comments and error messages

### DIFF
--- a/bot/eventsystem/eventsystem.go
+++ b/bot/eventsystem/eventsystem.go
@@ -192,7 +192,7 @@ func runEvents(h []*Handler, data *EventData) {
 					guildID = guildIDProvider.GetGuildID()
 				}
 				if err != nil {
-					logrus.WithField("guild", guildID).WithField("evt", data.Type.String()).Errorf("%s: An error occured in a discord event handler: %+v", v.Plugin.PluginInfo().SysName, err)
+					logrus.WithField("guild", guildID).WithField("evt", data.Type.String()).Errorf("%s: An error occurred in a discord event handler: %+v", v.Plugin.PluginInfo().SysName, err)
 				}
 
 				if retry {

--- a/bot/eventsystem/gen/events_gen.go
+++ b/bot/eventsystem/gen/events_gen.go
@@ -3,7 +3,7 @@
 
 // Generates the wrapper event handlers for discordgo events
 // The wrappers adds an extra parameter to the handlers which is a redis connection
-// And will also recover from panic that occured inside them
+// And will also recover from panic that occurred inside them
 package main
 
 import (

--- a/bot/util.go
+++ b/bot/util.go
@@ -470,7 +470,7 @@ func CheckDiscordErrRetry(err error) bool {
 		return false
 	}
 
-	// an unknown error unrelated to the discord api occured (503's for example) attempt a retry
+	// an unknown error unrelated to the discord api occurred (503's for example) attempt a retry
 	return true
 }
 

--- a/cmd/gen/events.go
+++ b/cmd/gen/events.go
@@ -1,6 +1,6 @@
 // Generates the wrapper event handlers for discordgo events
 // The wrappers adds an extra parameter to the handlers which is a redis connection
-// And will also recover from panic that occured inside them
+// And will also recover from panic that occurred inside them
 package main
 
 import (

--- a/commands/plugin_bot.go
+++ b/commands/plugin_bot.go
@@ -175,7 +175,7 @@ func YAGCommandMiddleware(inner dcmd.RunFunc) dcmd.RunFunc {
 		// Check if the user can execute the command
 		canExecute, resp, settings, err := yc.checkCanExecuteCommand(data)
 		if err != nil {
-			yc.Logger(data).WithError(err).Error("An error occured while checking if we could run command")
+			yc.Logger(data).WithError(err).Error("An error occurred while checking if we could run command")
 		}
 
 		if data.TriggerType == dcmd.TriggerTypeSlashCommands && data.SlashCommandTriggerData.Interaction.Type != discordgo.InteractionApplicationCommandAutocomplete {

--- a/commands/yagcommmand.go
+++ b/commands/yagcommmand.go
@@ -407,7 +407,7 @@ func (yc *YAGCommand) PostCommandExecuted(settings *CommandSettings, cmdData *dc
 type CanExecuteType int
 
 const (
-	// ReasonError                    = "An error occured"
+	// ReasonError                    = "An error occurred"
 	// ReasonCommandDisabaledSettings = "Command is disabled in the settings"
 	// ReasonMissingRole              = "Missing a required role for this command"
 	// ReasonIgnoredRole              = "Has a ignored role for this command"

--- a/common/internalapi/server.go
+++ b/common/internalapi/server.go
@@ -151,7 +151,7 @@ func ServeJson(w http.ResponseWriter, r *http.Request, data interface{}) {
 	}
 }
 
-// Returns true if an error occured
+// Returns true if an error occurred
 func ServerError(w http.ResponseWriter, r *http.Request, err error) bool {
 	if err == nil {
 		return false

--- a/common/pqkeydb/pqkeydb.go
+++ b/common/pqkeydb/pqkeydb.go
@@ -66,7 +66,7 @@ func (db *DB) Get(guildID int64, key string) (r *Result) {
 type Result struct {
 	Entry Entry
 
-	// Set if an error occured
+	// Set if an error occurred
 	Error error
 }
 
@@ -79,12 +79,12 @@ type Entry struct {
 	UpdatedAt time.Time
 }
 
-// Str returns the string value of the entry, or an error if an error occured
+// Str returns the string value of the entry, or an error if an error occurred
 func (r *Result) Str() (string, error) {
 	return r.Entry.Value, r.Error
 }
 
-// Int64 returns the value parsed as a int64, or an error if an error occured
+// Int64 returns the value parsed as a int64, or an error if an error occurred
 func (r *Result) Int64() (int64, error) {
 	if r.Error != nil {
 		return 0, r.Error

--- a/common/scheduledevents2/scheduledevents.go
+++ b/common/scheduledevents2/scheduledevents.go
@@ -433,6 +433,6 @@ func CheckDiscordErrRetry(err error) bool {
 		return false
 	}
 
-	// an unknown error unrelated to the discord api occured (503's for example) attempt a retry
+	// an unknown error unrelated to the discord api occurred (503's for example) attempt a retry
 	return true
 }

--- a/lib/dca/encode.go
+++ b/lib/dca/encode.go
@@ -634,7 +634,7 @@ func (e *EncodeSession) Cleanup() {
 }
 
 // Read implements io.Reader,
-// n == len(p) if err == nil, otherwise n contains the number bytes read before an error occured
+// n == len(p) if err == nil, otherwise n contains the number bytes read before an error occurred
 func (e *EncodeSession) Read(p []byte) (n int, err error) {
 	if e.buf.Len() >= len(p) {
 		return e.buf.Read(p)
@@ -656,7 +656,7 @@ func (e *EncodeSession) FrameDuration() time.Duration {
 	return time.Duration(e.options.FrameDuration) * time.Millisecond
 }
 
-// Error returns any error that occured during the encoding process
+// Error returns any error that occurred during the encoding process
 func (e *EncodeSession) Error() error {
 	e.Lock()
 	defer e.Unlock()

--- a/lib/dcmd/arg.go
+++ b/lib/dcmd/arg.go
@@ -429,7 +429,7 @@ type ArgType interface {
 	// CheckCompatibility reports the degree to which the input matches the type.
 	CheckCompatibility(def *ArgDef, part string) CompatibilityResult
 
-	// Attempt to parse it, returning any error if one occured.
+	// Attempt to parse it, returning any error if one occurred.
 	ParseFromMessage(def *ArgDef, part string, data *Data) (val interface{}, err error)
 	ParseFromInteraction(def *ArgDef, data *Data, options *SlashCommandsParseOptions) (val interface{}, err error)
 

--- a/lib/dcmd/cmd.go
+++ b/lib/dcmd/cmd.go
@@ -34,7 +34,7 @@ type Cmd interface {
 	// Run the command with the provided data,
 	// response is either string, error, embed or custom that implements CmdResponse
 	// if response is nil, and an error is returned that is not PublicError,
-	// the string "An error occured. Contact bot owner" becomes the response
+	// the string "An error occurred. Contact bot owner" becomes the response
 	Run(data *Data) (interface{}, error)
 }
 

--- a/lib/dcmd/system.go
+++ b/lib/dcmd/system.go
@@ -32,7 +32,7 @@ func NewStandardSystem(staticPrefix string) (system *System) {
 	return sys
 }
 
-// You can add this as a handler directly to discordgo, it will recover from any panics that occured in commands
+// You can add this as a handler directly to discordgo, it will recover from any panics that occurred in commands
 // and log errors using the standard logger
 func (sys *System) HandleMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 	// Set up handler to recover from panics

--- a/lib/dshardorchestrator/cmd/dso-sample-bot/node-implementation.go
+++ b/lib/dshardorchestrator/cmd/dso-sample-bot/node-implementation.go
@@ -55,7 +55,7 @@ func (b *Bot) StartShard(shard int, sessionID string, sequence int64, resumeGate
 
 	newSession, err := discordgo.New(b.token)
 	if err != nil {
-		log.Println("an error occured when creating shard session: ", err)
+		log.Println("an error occurred when creating shard session: ", err)
 		return
 	}
 
@@ -80,7 +80,7 @@ func (b *Bot) StartShard(shard int, sessionID string, sequence int64, resumeGate
 
 	err = newSession.Open()
 	if err != nil {
-		log.Println("an error occured when starting shard session: ", err)
+		log.Println("an error occurred when starting shard session: ", err)
 		return
 	}
 

--- a/lib/dshardorchestrator/conn.go
+++ b/lib/dshardorchestrator/conn.go
@@ -49,7 +49,7 @@ func (c *Conn) Listen() {
 	var err error
 	defer func() {
 		if err != nil {
-			c.Log(LogError, err, "an error occured while handling a connection")
+			c.Log(LogError, err, "an error occurred while handling a connection")
 		}
 
 		c.netConn.Close()

--- a/lib/dshardorchestrator/events_test.go
+++ b/lib/dshardorchestrator/events_test.go
@@ -9,7 +9,7 @@ func TestEncodeMessage(t *testing.T) {
 	data := "hello"
 	encoded, err := EncodeMessage(EvtStartShards, data)
 	if err != nil {
-		t.Fatal("an error occured encoding the mssage: ", err)
+		t.Fatal("an error occurred encoding the mssage: ", err)
 	}
 
 	expectedOutput := []byte{

--- a/lib/jdshardmanager/dshardmanager.go
+++ b/lib/jdshardmanager/dshardmanager.go
@@ -189,7 +189,7 @@ func (m *Manager) Start() error {
 	return nil
 }
 
-// StopAll stops all the shard sessions and returns the last error that occured
+// StopAll stops all the shard sessions and returns the last error that occurred
 func (m *Manager) StopAll() (err error) {
 	m.Lock()
 	for _, v := range m.Sessions {
@@ -509,7 +509,7 @@ type Event struct {
 
 	Msg string
 
-	// When this event occured
+	// When this event occurred
 	Time time.Time
 }
 

--- a/notifications/plugin_bot.go
+++ b/notifications/plugin_bot.go
@@ -156,7 +156,7 @@ func HandleGuildMemberRemove(evt *eventsystem.EventData) (retry bool, err error)
 	return false, nil
 }
 
-// sendTemplate parses and executes the provided template, returns wether an error occured that we can retry from (temporary network failures and the like)
+// sendTemplate parses and executes the provided template, returns wether an error occurred that we can retry from (temporary network failures and the like)
 func sendTemplate(gs *dstate.GuildSet, cs *dstate.ChannelState, tmpl string, ms *dstate.MemberState, name string, censorInvites bool, executedFrom templates.ExecutedFromType) bool {
 	ctx := templates.NewContext(gs, cs, ms)
 	ctx.CurrentFrame.SendResponseInDM = cs.Type == discordgo.ChannelTypeDM

--- a/tickets/tickets_bot.go
+++ b/tickets/tickets_bot.go
@@ -345,7 +345,7 @@ func handleButton(evt *eventsystem.EventData, ic *discordgo.InteractionCreate, m
 			return nil, err
 		}
 		if activeTicket == nil {
-			response.Data.Content = "A problem occured, failed to close the ticket."
+			response.Data.Content = "A problem occurred, failed to close the ticket."
 			return response, err
 		}
 
@@ -417,7 +417,7 @@ func handleModal(evt *eventsystem.EventData, ic *discordgo.InteractionCreate, me
 			return nil, err
 		}
 		if activeTicket == nil {
-			response.Data.Content = "A problem occured, failed to close the ticket."
+			response.Data.Content = "A problem occurred, failed to close the ticket."
 			return response, err
 		}
 

--- a/tickets/tmplextensions.go
+++ b/tickets/tmplextensions.go
@@ -95,7 +95,7 @@ func tmplCreateTicket(ctx *templates.Context) interface{} {
 				return nil, err
 			}
 
-			return nil, errors.New("an unknown error occured")
+			return nil, errors.New("an unknown error occurred")
 		}
 		return &TemplateTicket{
 			GuildID:               ticket.GuildID,

--- a/verification/verification_bot.go
+++ b/verification/verification_bot.go
@@ -94,7 +94,7 @@ func (p *Plugin) handleVerificationAfterScreening(member *discordgo.Member) {
 		if err != sql.ErrNoRows {
 			logger.WithError(err).WithField("guild", member.GuildID).WithField("user", member.User.ID).Error("unable to retrieve config")
 		}
-		// either no config or an error occured
+		// either no config or an error occurred
 		return
 	}
 	if !conf.Enabled {
@@ -190,7 +190,7 @@ func (p *Plugin) createVerificationSession(userID, guildID int64) (string, error
 			continue
 		}
 
-		// otherwise an unknown error occured
+		// otherwise an unknown error occurred
 		return token, err
 	}
 }

--- a/web/util.go
+++ b/web/util.go
@@ -164,7 +164,7 @@ func GetBaseCPContextData(ctx context.Context) (*dstate.GuildSet, TemplateData) 
 }
 
 // Checks and error and logs it aswell as adding it to the alerts
-// returns true if an error occured
+// returns true if an error occurred
 func CheckErr(t TemplateData, err error, errMsg string, logger func(...interface{})) bool {
 	if err == nil {
 		return false
@@ -177,7 +177,7 @@ func CheckErr(t TemplateData, err error, errMsg string, logger func(...interface
 	t.AddAlerts(ErrorAlert("An error occurred: ", errMsg))
 
 	if logger != nil {
-		logger("An error occured:", err)
+		logger("An error occurred:", err)
 	}
 
 	return true

--- a/youtube/web.go
+++ b/youtube/web.go
@@ -178,7 +178,7 @@ func (p *Plugin) HandleNew(w http.ResponseWriter, r *http.Request) (web.Template
 
 	id, err := p.parseYtUrl(parsedUrl)
 	if err != nil {
-		logger.WithError(err).Errorf("error occured parsing channel from url %q", channelUrl)
+		logger.WithError(err).Errorf("error occurred parsing channel from url %q", channelUrl)
 		return templateData.AddAlerts(web.ErrorAlert(err)), err
 	}
 


### PR DESCRIPTION
Fix spelling error `occured` -> `occurred` in 23 files across the codebase.

Changes include:
- Error messages displayed to users
- Log messages for debugging
- Code comments

Example fix in `bot/eventsystem/eventsystem.go`:
```go
// Before:
logger.Errorf("%s: An error occured in a discord event handler", ...)
// After:
logger.Errorf("%s: An error occurred in a discord event handler", ...)
```

Total: 23 files changed, 31 occurrences corrected.