### PR TITLE
Added support for SubCommands in custom slash commands. 

### DIFF
--- a/customcommands/assets/customcommands-editcmd.html
+++ b/customcommands/assets/customcommands-editcmd.html
@@ -1,3 +1,83 @@
+{{/* Reusable slash option row. Expects a dict with: Prefix (form field name prefix, e.g. "slash_options.0"), ReqID (unique id for the required toggle), Opt (a SlashOptionView). */}}
+{{define "slashOptionRow"}}
+                                            <div class="slash-option-row mb-3">
+                                                <div class="form-row align-items-end">
+                                                    <div class="col-12 col-md-3 mb-2 mb-md-0">
+                                                        <label class="small mb-1">Name</label>
+                                                        <input type="text" class="form-control" data-slash-field="name" name="{{.Prefix}}.name" maxlength="32" placeholder="name" value="{{.Opt.Name}}">
+                                                    </div>
+                                                    <div class="col-12 col-md-2 mb-2 mb-md-0">
+                                                        <label class="small mb-1">Type</label>
+                                                        <select class="form-control slash-option-type-select" data-slash-field="type" name="{{.Prefix}}.type" onchange="slashOptTypeChanged(this)">
+                                                            <option value="string" {{if eq .Opt.TypeKey "string"}}selected{{end}}>Text</option>
+                                                            <option value="string_menu" {{if eq .Opt.TypeKey "string_menu"}}selected{{end}}>Text menu</option>
+                                                            <option value="integer" {{if eq .Opt.TypeKey "integer"}}selected{{end}}>Integer</option>
+                                                            <option value="integer_menu" {{if eq .Opt.TypeKey "integer_menu"}}selected{{end}}>Integer menu</option>
+                                                            <option value="number" {{if eq .Opt.TypeKey "number"}}selected{{end}}>Number</option>
+                                                            <option value="number_menu" {{if eq .Opt.TypeKey "number_menu"}}selected{{end}}>Number menu</option>
+                                                            <option value="boolean" {{if eq .Opt.TypeKey "boolean"}}selected{{end}}>True/False</option>
+                                                            <option value="user" {{if eq .Opt.TypeKey "user"}}selected{{end}}>User</option>
+                                                            <option value="channel" {{if eq .Opt.TypeKey "channel"}}selected{{end}}>Channel</option>
+                                                            <option value="role" {{if eq .Opt.TypeKey "role"}}selected{{end}}>Role</option>
+                                                            <option value="mentionable" {{if eq .Opt.TypeKey "mentionable"}}selected{{end}}>Mentionable</option>
+                                                        </select>
+                                                    </div>
+                                                    <div class="col-12 col-md-4 mb-2 mb-md-0">
+                                                        <label class="small mb-1">Description</label>
+                                                        <input type="text" class="form-control" data-slash-field="description" name="{{.Prefix}}.description" maxlength="100" placeholder="description" value="{{.Opt.Description}}">
+                                                    </div>
+                                                    <div class="col-6 col-md-2 mb-2 mb-md-0">
+                                                        {{checkbox (printf "%s.required" .Prefix) .ReqID "Required" .Opt.Required "data-slash-field=required"}}
+                                                    </div>
+                                                    <div class="col-6 col-md-1 text-right">
+                                                        <button type="button" class="btn btn-danger btn-sm slash-option-remove" title="Remove argument"><i class="fas fa-minus"></i></button>
+                                                    </div>
+                                                </div>
+                                                <div class="form-row slash-opt-extra-choices mt-2 {{if and (ne .Opt.TypeKey "string_menu") (ne .Opt.TypeKey "integer_menu") (ne .Opt.TypeKey "number_menu")}}hidden{{end}}">
+                                                    <div class="col-12">
+                                                        <label class="small mb-1">Choices - one per line (turns this into a dropdown / select menu). For Integer/Number arguments each line must be a number.</label>
+                                                        <textarea class="form-control" data-slash-field="choices" name="{{.Prefix}}.choices" rows="3" placeholder="Leave empty for free input">{{range .Opt.Choices}}{{.}}
+{{end}}</textarea>
+                                                    </div>
+                                                </div>
+                                                <div class="form-row slash-opt-extra-text mt-2 {{if ne .Opt.TypeKey "string"}}hidden{{end}}">
+                                                    <div class="col-6 col-md-3 mb-2 mb-md-0">
+                                                        <label class="small mb-1">Min length</label>
+                                                        <input type="number" min="0" class="form-control" data-slash-field="min_length" name="{{.Prefix}}.min_length" {{if .Opt.MinLength}}value="{{.Opt.MinLength}}"{{end}}>
+                                                    </div>
+                                                    <div class="col-6 col-md-3 mb-2 mb-md-0">
+                                                        <label class="small mb-1">Max length</label>
+                                                        <input type="number" min="0" class="form-control" data-slash-field="max_length" name="{{.Prefix}}.max_length" {{if .Opt.MaxLength}}value="{{.Opt.MaxLength}}"{{end}}>
+                                                    </div>
+                                                </div>
+                                                <div class="form-row slash-opt-extra-number mt-2 {{if and (ne .Opt.TypeKey "integer") (ne .Opt.TypeKey "number")}}hidden{{end}}">
+                                                    <div class="col-6 col-md-3 mb-2 mb-md-0">
+                                                        <label class="small mb-1">Min value</label>
+                                                        <input type="number" step="any" class="form-control" data-slash-field="min_value" name="{{.Prefix}}.min_value" {{if .Opt.MinValue}}value="{{.Opt.MinValue}}"{{end}}>
+                                                    </div>
+                                                    <div class="col-6 col-md-3 mb-2 mb-md-0">
+                                                        <label class="small mb-1">Max value</label>
+                                                        <input type="number" step="any" class="form-control" data-slash-field="max_value" name="{{.Prefix}}.max_value" {{if .Opt.MaxValue}}value="{{.Opt.MaxValue}}"{{end}}>
+                                                    </div>
+                                                </div>
+                                                <div class="form-row slash-opt-extra-channel mt-2 {{if ne .Opt.TypeKey "channel"}}hidden{{end}}">
+                                                    <div class="col-12">
+                                                        <label class="small mb-1 d-block">Allowed channel types (leave empty to allow any)</label>
+                                                        <select class="multiselect form-control" multiple="multiple" data-plugin-multiselect data-slash-field="channel_types" name="{{.Prefix}}.channel_types">
+                                                            <option value="0" {{if in .Opt.ChannelTypes 0}}selected{{end}}>Text</option>
+                                                            <option value="2" {{if in .Opt.ChannelTypes 2}}selected{{end}}>Voice</option>
+                                                            <option value="4" {{if in .Opt.ChannelTypes 4}}selected{{end}}>Category</option>
+                                                            <option value="5" {{if in .Opt.ChannelTypes 5}}selected{{end}}>Announcement</option>
+                                                            <option value="13" {{if in .Opt.ChannelTypes 13}}selected{{end}}>Stage</option>
+                                                            <option value="15" {{if in .Opt.ChannelTypes 15}}selected{{end}}>Forum</option>
+                                                            <option value="11" {{if in .Opt.ChannelTypes 11}}selected{{end}}>Public Thread</option>
+                                                            <option value="12" {{if in .Opt.ChannelTypes 12}}selected{{end}}>Private Thread</option>
+                                                            <option value="10" {{if in .Opt.ChannelTypes 10}}selected{{end}}>Announcement Thread</option>
+                                                        </select>
+                                                    </div>
+                                                </div>
+                                            </div>
+{{end}}
 {{define "cp_custom_commands_edit_cmd"}}
 {{template "cp_head" .}}
 <header class="page-header">
@@ -338,6 +418,17 @@
                                 <hr>
                                 <div class="row mt-2">
                                     <div class="col-lg-12">
+                                        <div class="form-group d-flex align-items-center mb-1">
+                                            <input type="checkbox" class="tgl tgl-flat" id="slash_use_subcommands" name="slash_use_subcommands" {{if call .GetCCSlashUseSubcommands .CC}}checked{{end}}>
+                                            <label class="tgl-btn mb-0" for="slash_use_subcommands"></label>
+                                            <span class="ml-2">Use subcommands</span>
+                                        </div>
+                                        <small class="form-text text-muted">Split this command into subcommands (e.g. <code>/cmd add</code>, <code>/cmd remove</code>). Branch your response on <code>.SubCommand</code>, which holds the invoked subcommand name.</small>
+                                    </div>
+                                </div>
+                                <hr>
+                                <div id="slash-flat-options-section" class="row mt-2">
+                                    <div class="col-lg-12">
                                         <button type="button" class="btn btn-primary btn-sm btn-block d-flex align-items-center justify-content-between slash-options-toggle" data-toggle="collapse" data-target="#slash-options-collapse" aria-expanded="true">
                                             <span>Options (<span id="slash-options-count">0</span>)</span>
                                             <i class="fas fa-chevron-down slash-options-chevron"></i>
@@ -346,91 +437,82 @@
                                         <div class="collapse show mt-2" id="slash-options-collapse">
                                         <div id="slash-options-list">
                                             {{range $i, $opt := call .GetCCSlashOptions .CC}}
-                                            <div class="slash-option-row mb-3">
-                                                <div class="form-row align-items-end">
-                                                    <div class="col-12 col-md-3 mb-2 mb-md-0">
-                                                        <label class="small mb-1">Name</label>
-                                                        <input type="text" class="form-control" data-slash-field="name" name="slash_options.{{$i}}.name" maxlength="32" placeholder="name" value="{{$opt.Name}}">
-                                                    </div>
-                                                    <div class="col-12 col-md-2 mb-2 mb-md-0">
-                                                        <label class="small mb-1">Type</label>
-                                                        <select class="form-control slash-option-type-select" data-slash-field="type" name="slash_options.{{$i}}.type" onchange="slashOptTypeChanged(this)">
-                                                            <option value="string" {{if eq $opt.TypeKey "string"}}selected{{end}}>Text</option>
-                                                            <option value="string_menu" {{if eq $opt.TypeKey "string_menu"}}selected{{end}}>Text menu</option>
-                                                            <option value="integer" {{if eq $opt.TypeKey "integer"}}selected{{end}}>Integer</option>
-                                                            <option value="integer_menu" {{if eq $opt.TypeKey "integer_menu"}}selected{{end}}>Integer menu</option>
-                                                            <option value="number" {{if eq $opt.TypeKey "number"}}selected{{end}}>Number</option>
-                                                            <option value="number_menu" {{if eq $opt.TypeKey "number_menu"}}selected{{end}}>Number menu</option>
-                                                            <option value="boolean" {{if eq $opt.TypeKey "boolean"}}selected{{end}}>True/False</option>
-                                                            <option value="user" {{if eq $opt.TypeKey "user"}}selected{{end}}>User</option>
-                                                            <option value="channel" {{if eq $opt.TypeKey "channel"}}selected{{end}}>Channel</option>
-                                                            <option value="role" {{if eq $opt.TypeKey "role"}}selected{{end}}>Role</option>
-                                                            <option value="mentionable" {{if eq $opt.TypeKey "mentionable"}}selected{{end}}>Mentionable</option>
-                                                        </select>
-                                                    </div>
-                                                    <div class="col-12 col-md-4 mb-2 mb-md-0">
-                                                        <label class="small mb-1">Description</label>
-                                                        <input type="text" class="form-control" data-slash-field="description" name="slash_options.{{$i}}.description" maxlength="100" placeholder="description" value="{{$opt.Description}}">
-                                                    </div>
-                                                    <div class="col-6 col-md-2 mb-2 mb-md-0">
-                                                        {{checkbox (printf "slash_options.%d.required" $i) (printf "slash-opt-req-%d" $i) "Required" $opt.Required "data-slash-field=required"}}
-                                                    </div>
-                                                    <div class="col-6 col-md-1 text-right">
-                                                        <button type="button" class="btn btn-danger btn-sm slash-option-remove" title="Remove argument"><i class="fas fa-minus"></i></button>
-                                                    </div>
-                                                </div>
-                                                <div class="form-row slash-opt-extra-choices mt-2 {{if and (ne $opt.TypeKey "string_menu") (ne $opt.TypeKey "integer_menu") (ne $opt.TypeKey "number_menu")}}hidden{{end}}">
-                                                    <div class="col-12">
-                                                        <label class="small mb-1">Choices - one per line (turns this into a dropdown / select menu). For Integer/Number arguments each line must be a number.</label>
-                                                        <textarea class="form-control" data-slash-field="choices" name="slash_options.{{$i}}.choices" rows="3" placeholder="Leave empty for free input">{{range $opt.Choices}}{{.}}
-{{end}}</textarea>
-                                                    </div>
-                                                </div>
-                                                <div class="form-row slash-opt-extra-text mt-2 {{if ne $opt.TypeKey "string"}}hidden{{end}}">
-                                                    <div class="col-6 col-md-3 mb-2 mb-md-0">
-                                                        <label class="small mb-1">Min length</label>
-                                                        <input type="number" min="0" class="form-control" data-slash-field="min_length" name="slash_options.{{$i}}.min_length" {{if $opt.MinLength}}value="{{$opt.MinLength}}"{{end}}>
-                                                    </div>
-                                                    <div class="col-6 col-md-3 mb-2 mb-md-0">
-                                                        <label class="small mb-1">Max length</label>
-                                                        <input type="number" min="0" class="form-control" data-slash-field="max_length" name="slash_options.{{$i}}.max_length" {{if $opt.MaxLength}}value="{{$opt.MaxLength}}"{{end}}>
-                                                    </div>
-                                                </div>
-                                                <div class="form-row slash-opt-extra-number mt-2 {{if and (ne $opt.TypeKey "integer") (ne $opt.TypeKey "number")}}hidden{{end}}">
-                                                    <div class="col-6 col-md-3 mb-2 mb-md-0">
-                                                        <label class="small mb-1">Min value</label>
-                                                        <input type="number" step="any" class="form-control" data-slash-field="min_value" name="slash_options.{{$i}}.min_value" {{if $opt.MinValue}}value="{{$opt.MinValue}}"{{end}}>
-                                                    </div>
-                                                    <div class="col-6 col-md-3 mb-2 mb-md-0">
-                                                        <label class="small mb-1">Max value</label>
-                                                        <input type="number" step="any" class="form-control" data-slash-field="max_value" name="slash_options.{{$i}}.max_value" {{if $opt.MaxValue}}value="{{$opt.MaxValue}}"{{end}}>
-                                                    </div>
-                                                </div>
-                                                <div class="form-row slash-opt-extra-channel mt-2 {{if ne $opt.TypeKey "channel"}}hidden{{end}}">
-                                                    <div class="col-12">
-                                                        <label class="small mb-1 d-block">Allowed channel types (leave empty to allow any)</label>
-                                                        <select class="multiselect form-control" multiple="multiple" data-plugin-multiselect data-slash-field="channel_types" name="slash_options.{{$i}}.channel_types">
-                                                            <option value="0" {{if in $opt.ChannelTypes 0}}selected{{end}}>Text</option>
-                                                            <option value="2" {{if in $opt.ChannelTypes 2}}selected{{end}}>Voice</option>
-                                                            <option value="4" {{if in $opt.ChannelTypes 4}}selected{{end}}>Category</option>
-                                                            <option value="5" {{if in $opt.ChannelTypes 5}}selected{{end}}>Announcement</option>
-                                                            <option value="13" {{if in $opt.ChannelTypes 13}}selected{{end}}>Stage</option>
-                                                            <option value="15" {{if in $opt.ChannelTypes 15}}selected{{end}}>Forum</option>
-                                                            <option value="11" {{if in $opt.ChannelTypes 11}}selected{{end}}>Public Thread</option>
-                                                            <option value="12" {{if in $opt.ChannelTypes 12}}selected{{end}}>Private Thread</option>
-                                                            <option value="10" {{if in $opt.ChannelTypes 10}}selected{{end}}>Announcement Thread</option>
-                                                        </select>
-                                                    </div>
-                                                </div>
-                                            </div>
+                                            {{template "slashOptionRow" (dict "Prefix" (printf "slash_options.%d" $i) "ReqID" (printf "slash-opt-req-%d" $i) "Opt" $opt)}}
                                             {{end}}
                                         </div>
                                         <button type="button" id="slash-option-add" class="btn btn-success btn-sm mt-1"><i class="fas fa-plus"></i> Add Option</button>
                                         <small class="form-text text-muted">Up to 25 Options. Required Options are automatically ordered before optional ones by discord</small>
                                         </div>
+                                    </div>
+                                </div>
+                                <div id="slash-subcommands-section" class="row mt-2 hidden">
+                                    <div class="col-lg-12">
+                                        <label class="mb-1">Subcommands (<span id="slash-subcommands-count">0</span>)</label>
+                                        <div id="slash-subcommands-list" class="mb-2">
+                                            {{range $si, $sub := call .GetCCSlashSubcommands .CC}}
+                                            <div class="slash-subcommand-card card mb-2">
+                                                <div class="card-header p-2 d-flex align-items-center justify-content-between slash-subcommand-toggle" data-toggle="collapse" data-target="#slash-sub-body-{{$si}}" style="cursor:pointer;">
+                                                    <span class="slash-subcommand-title font-weight-bold">{{if $sub.Name}}{{$sub.Name}}{{else}}Subcommand {{add $si 1}}{{end}}</span>
+                                                    <button type="button" class="btn btn-danger btn-sm slash-subcommand-remove" title="Remove subcommand"><i class="fas fa-minus"></i></button>
+                                                </div>
+                                                <div class="collapse slash-subcommand-body" id="slash-sub-body-{{$si}}" data-parent="#slash-subcommands-list">
+                                                    <div class="card-body">
+                                                        <div class="form-row">
+                                                            <div class="col-12 col-md-4 mb-2">
+                                                                <label class="small mb-1">Name</label>
+                                                                <input type="text" class="form-control" data-slash-sub-field="name" name="slash_subcommands.{{$si}}.name" maxlength="32" placeholder="name" value="{{$sub.Name}}">
+                                                            </div>
+                                                            <div class="col-12 col-md-8 mb-2">
+                                                                <label class="small mb-1">Description</label>
+                                                                <input type="text" class="form-control" data-slash-sub-field="description" name="slash_subcommands.{{$si}}.description" maxlength="100" placeholder="description" value="{{$sub.Description}}">
+                                                            </div>
+                                                        </div>
+                                                        <label class="small mb-1">Options (<span class="slash-subcommand-optcount">0</span>)</label>
+                                                        <div class="slash-subcommand-options">
+                                                            {{range $oi, $opt := $sub.Options}}
+                                                            {{template "slashOptionRow" (dict "Prefix" (printf "slash_subcommands.%d.options.%d" $si $oi) "ReqID" (printf "slash-sub-%d-opt-req-%d" $si $oi) "Opt" $opt)}}
+                                                            {{end}}
+                                                        </div>
+                                                        <button type="button" class="btn btn-success btn-sm mt-1 slash-subcommand-option-add"><i class="fas fa-plus"></i> Add Option</button>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            {{end}}
+                                        </div>
+                                        <button type="button" id="slash-subcommand-add" class="btn btn-success btn-sm mt-1"><i class="fas fa-plus"></i> Add Subcommand</button>
+                                        <small class="form-text text-muted">Up to <span id="slash-subcommand-limit">{{if .IsGuildPremium}}10{{else}}3{{end}}</span> subcommands, each with up to 25 options. Only one subcommand can be expanded at a time.</small>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <div class="col-lg-12">
                                         <div id="slash-validation-errors" class="alert alert-danger py-2 mt-2 mb-0 hidden"></div>
                                     </div>
                                 </div>
+                                <template id="slash-subcommand-template">
+                                    <div class="slash-subcommand-card card mb-2">
+                                        <div class="card-header p-2 d-flex align-items-center justify-content-between slash-subcommand-toggle" data-toggle="collapse" style="cursor:pointer;">
+                                            <span class="slash-subcommand-title font-weight-bold">Subcommand</span>
+                                            <button type="button" class="btn btn-danger btn-sm slash-subcommand-remove" title="Remove subcommand"><i class="fas fa-minus"></i></button>
+                                        </div>
+                                        <div class="collapse show slash-subcommand-body" data-parent="#slash-subcommands-list">
+                                            <div class="card-body">
+                                                <div class="form-row">
+                                                    <div class="col-12 col-md-4 mb-2">
+                                                        <label class="small mb-1">Name</label>
+                                                        <input type="text" class="form-control" data-slash-sub-field="name" maxlength="32" placeholder="name">
+                                                    </div>
+                                                    <div class="col-12 col-md-8 mb-2">
+                                                        <label class="small mb-1">Description</label>
+                                                        <input type="text" class="form-control" data-slash-sub-field="description" maxlength="100" placeholder="description">
+                                                    </div>
+                                                </div>
+                                                <label class="small mb-1">Options (<span class="slash-subcommand-optcount">0</span>)</label>
+                                                <div class="slash-subcommand-options"></div>
+                                                <button type="button" class="btn btn-success btn-sm mt-1 slash-subcommand-option-add"><i class="fas fa-plus"></i> Add Option</button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </template>
                                 <template id="slash-option-template">
                                     <div class="slash-option-row mb-3">
                                         <div class="form-row align-items-end">
@@ -1179,6 +1261,146 @@
     // Ensure field names/ids are consistent on initial load too.
     renumberSlashOptions();
 
+    // ===== Subcommands =====
+    // Initializes a freshly-cloned option row: multiselect widget + per-type field visibility.
+    function slashInitOptionRow(row) {
+        if (!row) return;
+        if ($.isFunction($.fn['multiselect'])) {
+            $(row).find('[data-plugin-multiselect]').each(function () {
+                $(this).themePluginMultiSelect($(this).data('plugin-options') || {});
+            });
+        }
+        const typeSel = row.querySelector('[data-slash-field="type"]');
+        if (typeSel) slashOptTypeChanged(typeSel);
+    }
+
+    function slashSubcommandLimit() {
+        const el = document.getElementById('slash-subcommand-limit');
+        const n = el ? parseInt(el.textContent, 10) : 3;
+        return isNaN(n) ? 3 : n;
+    }
+
+    // Reassigns field names for every subcommand and its option rows as a 2-level indexed
+    // slice (slash_subcommands.S.name/.description and slash_subcommands.S.options.O.<field>),
+    // keeps the accordion collapse ids/targets unique after add/remove, and refreshes
+    // header titles and option counts.
+    function slashRenumberSubcommands() {
+        const cards = document.querySelectorAll('#slash-subcommands-list .slash-subcommand-card');
+        cards.forEach((card, s) => {
+            card.querySelectorAll('[data-slash-sub-field]').forEach((el) => {
+                el.name = 'slash_subcommands.' + s + '.' + el.getAttribute('data-slash-sub-field');
+            });
+
+            const body = card.querySelector('.slash-subcommand-body');
+            const toggle = card.querySelector('.slash-subcommand-toggle');
+            const bodyId = 'slash-sub-body-' + s;
+            if (body) {
+                body.id = bodyId;
+                body.setAttribute('data-parent', '#slash-subcommands-list');
+            }
+            if (toggle) toggle.setAttribute('data-target', '#' + bodyId);
+
+            const nameInput = card.querySelector('[data-slash-sub-field="name"]');
+            const title = card.querySelector('.slash-subcommand-title');
+            if (title) {
+                const nm = nameInput ? nameInput.value.trim() : '';
+                title.textContent = nm !== '' ? nm : ('Subcommand ' + (s + 1));
+            }
+
+            const rows = card.querySelectorAll('.slash-subcommand-options .slash-option-row');
+            rows.forEach((row, o) => {
+                row.querySelectorAll('[data-slash-field]').forEach((el) => {
+                    el.name = 'slash_subcommands.' + s + '.options.' + o + '.' + el.getAttribute('data-slash-field');
+                });
+                const cb = row.querySelector('[data-slash-field="required"]');
+                const lbl = row.querySelector('.tgl-btn');
+                if (cb && lbl) {
+                    const id = 'slash-sub-' + s + '-opt-req-' + o;
+                    cb.id = id;
+                    lbl.htmlFor = id;
+                }
+            });
+            const optCount = card.querySelector('.slash-subcommand-optcount');
+            if (optCount) optCount.textContent = rows.length;
+        });
+        const count = document.getElementById('slash-subcommands-count');
+        if (count) count.textContent = cards.length;
+    }
+
+    // Show the flat-options editor or the subcommands editor depending on the toggle.
+    function slashUpdateSubcommandMode() {
+        const cb = document.getElementById('slash_use_subcommands');
+        if (!cb) return;
+        const on = cb.checked;
+        const flat = document.getElementById('slash-flat-options-section');
+        const subs = document.getElementById('slash-subcommands-section');
+        if (flat) flat.classList.toggle('hidden', on);
+        if (subs) subs.classList.toggle('hidden', !on);
+    }
+
+    $('#slash_use_subcommands').on('change', function () {
+        slashUpdateSubcommandMode();
+        validateSlashUI();
+    });
+
+    $('#slash-subcommand-add').on('click', function (e) {
+        e.preventDefault();
+        const list = document.getElementById('slash-subcommands-list');
+        if (list.querySelectorAll('.slash-subcommand-card').length >= slashSubcommandLimit()) {
+            return;
+        }
+        // keep only one subcommand expanded at a time: collapse existing before adding
+        // the new (expanded) one.
+        list.querySelectorAll('.slash-subcommand-body.show').forEach((b) => b.classList.remove('show'));
+        const frag = document.getElementById('slash-subcommand-template').content.cloneNode(true);
+        list.appendChild(frag);
+        slashRenumberSubcommands();
+        validateSlashUI();
+    });
+
+    $('#slash-subcommands-list').on('click', '.slash-subcommand-remove', function (e) {
+        e.preventDefault();
+        e.stopPropagation(); // don't also toggle the collapse header
+        $(this).closest('.slash-subcommand-card').remove();
+        slashRenumberSubcommands();
+        validateSlashUI();
+    });
+
+    // Add an option row to a specific subcommand (capped at 25 per subcommand).
+    $('#slash-subcommands-list').on('click', '.slash-subcommand-option-add', function (e) {
+        e.preventDefault();
+        const optList = $(this).closest('.card-body').find('.slash-subcommand-options')[0];
+        if (!optList || optList.querySelectorAll('.slash-option-row').length >= 25) {
+            return;
+        }
+        const frag = document.getElementById('slash-option-template').content.cloneNode(true);
+        optList.appendChild(frag);
+        const newRow = optList.lastElementChild;
+        slashRenumberSubcommands();
+        slashInitOptionRow(newRow);
+    });
+
+    $('#slash-subcommands-list').on('click', '.slash-option-remove', function (e) {
+        e.preventDefault();
+        $(this).closest('.slash-option-row').remove();
+        slashRenumberSubcommands();
+        validateSlashUI();
+    });
+
+    // Keep a subcommand's collapsed-header title in sync as its name is typed.
+    $('#slash-subcommands-list').on('input', '[data-slash-sub-field="name"]', function () {
+        const card = $(this).closest('.slash-subcommand-card')[0];
+        const title = card.querySelector('.slash-subcommand-title');
+        if (title) {
+            const nm = this.value.trim();
+            const cards = Array.prototype.slice.call(document.querySelectorAll('#slash-subcommands-list .slash-subcommand-card'));
+            title.textContent = nm !== '' ? nm : ('Subcommand ' + (cards.indexOf(card) + 1));
+        }
+    });
+
+    slashRenumberSubcommands();
+    slashUpdateSubcommandMode();
+
     // Client-side validation mirroring the server rules in validateSlashCommandData.
     // Discord's name pattern (lowercased). \p{L}\p{N} need the unicode flag.
     const SLASH_NAME_RE = /^[-_\p{L}\p{N}]{1,32}$/u;
@@ -1191,6 +1413,92 @@
 
     function slashMark(el, invalid) {
         if (el) el.classList.toggle('is-invalid', !!invalid);
+    }
+
+    // Validates a single option row, pushing messages into errors and marking offending
+    // inputs. seen tracks duplicate names within the row's scope (command or subcommand).
+    // labelPrefix prefixes messages so subcommand errors are distinguishable.
+    function slashValidateOptionRow(row, seen, errors, labelPrefix) {
+        const nIn = row.querySelector('[data-slash-field="name"]');
+        const dIn = row.querySelector('[data-slash-field="description"]');
+        const tSel = row.querySelector('[data-slash-field="type"]');
+        const oname = (nIn ? nIn.value : '').trim();
+        if (oname === '') return; // blank rows are dropped server-side
+        const label = labelPrefix + 'argument "' + oname + '"';
+
+        if (!SLASH_NAME_RE.test(oname)) {
+            errors.push(labelPrefix + 'argument name "' + oname + '" must be 1-32 characters: letters, numbers, dashes and underscores.');
+            slashMark(nIn, true);
+        } else if (oname !== oname.toLowerCase()) {
+            errors.push(labelPrefix + 'argument name "' + oname + '" must be lowercase.');
+            slashMark(nIn, true);
+        }
+        if (seen[oname]) {
+            errors.push(labelPrefix + 'duplicate argument name "' + oname + '".');
+            slashMark(nIn, true);
+        }
+        seen[oname] = true;
+
+        const odesc = (dIn ? dIn.value : '').trim();
+        if (odesc.length < 1 || odesc.length > 100) {
+            errors.push('Description for ' + label + ' must be between 1 and 100 characters.');
+            slashMark(dIn, true);
+        }
+
+        const t = tSel ? tSel.value : '';
+        const isMenu = t === 'string_menu' || t === 'integer_menu' || t === 'number_menu';
+        if (isMenu) {
+            const choicesEl = row.querySelector('[data-slash-field="choices"]');
+            const lines = (choicesEl ? choicesEl.value : '').split('\n').map((s) => s.trim()).filter((s) => s !== '');
+            if (lines.length === 0) {
+                errors.push(label + ' is a menu but has no choices.');
+                slashMark(choicesEl, true);
+            }
+            if (lines.length > 25) {
+                errors.push(label + ' can have at most 25 choices.');
+                slashMark(choicesEl, true);
+            }
+            if (lines.some((l) => l.length > 100)) {
+                errors.push('Each choice on ' + label + ' must be at most 100 characters.');
+                slashMark(choicesEl, true);
+            }
+            if (t === 'integer_menu' && lines.some((l) => !/^-?\d+$/.test(l))) {
+                errors.push('Each choice on ' + label + ' must be a whole number.');
+                slashMark(choicesEl, true);
+            }
+            if (t === 'number_menu' && lines.some((l) => isNaN(Number(l)))) {
+                errors.push('Each choice on ' + label + ' must be a number.');
+                slashMark(choicesEl, true);
+            }
+        } else if (t === 'string') {
+            const minL = row.querySelector('[data-slash-field="min_length"]');
+            const maxL = row.querySelector('[data-slash-field="max_length"]');
+            const minv = minL && minL.value.trim() !== '' ? parseInt(minL.value, 10) : null;
+            const maxv = maxL && maxL.value.trim() !== '' ? parseInt(maxL.value, 10) : null;
+            if (minv !== null && minv < 0) {
+                errors.push('Min length for ' + label + ' cannot be negative.');
+                slashMark(minL, true);
+            }
+            if (maxv !== null && maxv > 6000) {
+                errors.push('Max length for ' + label + ' cannot exceed 6000.');
+                slashMark(maxL, true);
+            }
+            if (minv !== null && maxv !== null && minv > maxv) {
+                errors.push('Min length cannot exceed max length for ' + label + '.');
+                slashMark(minL, true);
+                slashMark(maxL, true);
+            }
+        } else if (t === 'integer' || t === 'number') {
+            const minV = row.querySelector('[data-slash-field="min_value"]');
+            const maxV = row.querySelector('[data-slash-field="max_value"]');
+            const minn = minV && minV.value.trim() !== '' ? parseFloat(minV.value) : null;
+            const maxn = maxV && maxV.value.trim() !== '' ? parseFloat(maxV.value) : null;
+            if (minn !== null && maxn !== null && minn > maxn) {
+                errors.push('Min value cannot exceed max value for ' + label + '.');
+                slashMark(minV, true);
+                slashMark(maxV, true);
+            }
+        }
     }
 
     // Validates the slash command fields, marks offending inputs and renders an error
@@ -1229,89 +1537,51 @@
             slashMark(descEl, true);
         }
 
-        const seen = {};
-        section.querySelectorAll('.slash-option-row').forEach((row) => {
-            const nIn = row.querySelector('[data-slash-field="name"]');
-            const dIn = row.querySelector('[data-slash-field="description"]');
-            const tSel = row.querySelector('[data-slash-field="type"]');
-            const oname = (nIn ? nIn.value : '').trim();
-            if (oname === '') return; // blank rows are dropped server-side
-            const label = 'argument "' + oname + '"';
+        const useSubs = document.getElementById('slash_use_subcommands').checked;
+        if (!useSubs) {
+            const seen = {};
+            document.querySelectorAll('#slash-options-list .slash-option-row').forEach((row) => {
+                slashValidateOptionRow(row, seen, errors, '');
+            });
+        } else {
+            const cards = document.querySelectorAll('#slash-subcommands-list .slash-subcommand-card');
+            if (cards.length === 0) {
+                errors.push('Enable subcommands requires at least one subcommand (or turn the toggle off).');
+            }
+            if (cards.length > slashSubcommandLimit()) {
+                errors.push('At most ' + slashSubcommandLimit() + ' subcommands are allowed.');
+            }
+            const seenSubs = {};
+            cards.forEach((card, idx) => {
+                const nIn = card.querySelector('[data-slash-sub-field="name"]');
+                const dIn = card.querySelector('[data-slash-sub-field="description"]');
+                const sname = (nIn ? nIn.value : '').trim();
+                const slabel = sname !== '' ? 'subcommand "' + sname + '"' : 'subcommand ' + (idx + 1);
 
-            if (!SLASH_NAME_RE.test(oname)) {
-                errors.push('Argument name "' + oname + '" must be 1-32 characters: letters, numbers, dashes and underscores.');
-                slashMark(nIn, true);
-            } else if (oname !== oname.toLowerCase()) {
-                errors.push('Argument name "' + oname + '" must be lowercase.');
-                slashMark(nIn, true);
-            }
-            if (seen[oname]) {
-                errors.push('Duplicate argument name "' + oname + '".');
-                slashMark(nIn, true);
-            }
-            seen[oname] = true;
+                if (!SLASH_NAME_RE.test(sname)) {
+                    errors.push('Subcommand name "' + sname + '" must be 1-32 characters: letters, numbers, dashes and underscores.');
+                    slashMark(nIn, true);
+                } else if (sname !== sname.toLowerCase()) {
+                    errors.push('Subcommand name "' + sname + '" must be lowercase.');
+                    slashMark(nIn, true);
+                } else if (seenSubs[sname]) {
+                    errors.push('Duplicate subcommand name "' + sname + '".');
+                    slashMark(nIn, true);
+                }
+                if (sname !== '') seenSubs[sname] = true;
 
-            const odesc = (dIn ? dIn.value : '').trim();
-            if (odesc.length < 1 || odesc.length > 100) {
-                errors.push('Description for ' + label + ' must be between 1 and 100 characters.');
-                slashMark(dIn, true);
-            }
+                const sdesc = (dIn ? dIn.value : '').trim();
+                if (sdesc.length < 1 || sdesc.length > 100) {
+                    errors.push('Description for ' + slabel + ' must be between 1 and 100 characters.');
+                    slashMark(dIn, true);
+                }
 
-            const t = tSel ? tSel.value : '';
-            const isMenu = t === 'string_menu' || t === 'integer_menu' || t === 'number_menu';
-            if (isMenu) {
-                const choicesEl = row.querySelector('[data-slash-field="choices"]');
-                const lines = (choicesEl ? choicesEl.value : '').split('\n').map((s) => s.trim()).filter((s) => s !== '');
-                if (lines.length === 0) {
-                    errors.push(label + ' is a menu but has no choices.');
-                    slashMark(choicesEl, true);
-                }
-                if (lines.length > 25) {
-                    errors.push(label + ' can have at most 25 choices.');
-                    slashMark(choicesEl, true);
-                }
-                if (lines.some((l) => l.length > 100)) {
-                    errors.push('Each choice on ' + label + ' must be at most 100 characters.');
-                    slashMark(choicesEl, true);
-                }
-                if (t === 'integer_menu' && lines.some((l) => !/^-?\d+$/.test(l))) {
-                    errors.push('Each choice on ' + label + ' must be a whole number.');
-                    slashMark(choicesEl, true);
-                }
-                if (t === 'number_menu' && lines.some((l) => isNaN(Number(l)))) {
-                    errors.push('Each choice on ' + label + ' must be a number.');
-                    slashMark(choicesEl, true);
-                }
-            } else if (t === 'string') {
-                const minL = row.querySelector('[data-slash-field="min_length"]');
-                const maxL = row.querySelector('[data-slash-field="max_length"]');
-                const minv = minL && minL.value.trim() !== '' ? parseInt(minL.value, 10) : null;
-                const maxv = maxL && maxL.value.trim() !== '' ? parseInt(maxL.value, 10) : null;
-                if (minv !== null && minv < 0) {
-                    errors.push('Min length for ' + label + ' cannot be negative.');
-                    slashMark(minL, true);
-                }
-                if (maxv !== null && maxv > 6000) {
-                    errors.push('Max length for ' + label + ' cannot exceed 6000.');
-                    slashMark(maxL, true);
-                }
-                if (minv !== null && maxv !== null && minv > maxv) {
-                    errors.push('Min length cannot exceed max length for ' + label + '.');
-                    slashMark(minL, true);
-                    slashMark(maxL, true);
-                }
-            } else if (t === 'integer' || t === 'number') {
-                const minV = row.querySelector('[data-slash-field="min_value"]');
-                const maxV = row.querySelector('[data-slash-field="max_value"]');
-                const minn = minV && minV.value.trim() !== '' ? parseFloat(minV.value) : null;
-                const maxn = maxV && maxV.value.trim() !== '' ? parseFloat(maxV.value) : null;
-                if (minn !== null && maxn !== null && minn > maxn) {
-                    errors.push('Min value cannot exceed max value for ' + label + '.');
-                    slashMark(minV, true);
-                    slashMark(maxV, true);
-                }
-            }
-        });
+                const seen = {};
+                card.querySelectorAll('.slash-subcommand-options .slash-option-row').forEach((row) => {
+                    slashValidateOptionRow(row, seen, errors, slabel + ' ');
+                });
+            });
+        }
 
         if (errors.length) {
             box.innerHTML = '<ul class="mb-0 pl-3">' + errors.map((e) => '<li>' + slashEscapeHtml(e) + '</li>').join('') + '</ul>';
@@ -1338,8 +1608,11 @@
         if ($('#trigger-type-dropdown').val() === 'slash_command' && !validateSlashUI()) {
             e.preventDefault();
             e.stopImmediatePropagation();
-            // Expand the arguments section so the offending (marked) fields are visible.
-            $('#slash-options-collapse').collapse('show');
+            // Expand the flat arguments section so the offending (marked) fields are visible
+            // (only relevant when not using subcommands).
+            if (!document.getElementById('slash_use_subcommands').checked) {
+                $('#slash-options-collapse').collapse('show');
+            }
             const box = document.getElementById('slash-validation-errors');
             if (box) box.scrollIntoView({ behavior: 'smooth', block: 'center' });
         }

--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -576,6 +576,16 @@ func (p *Plugin) OnRemovedPremiumGuild(GuildID int64) error {
 			return errors.WrapIf(err, "Failed disabling slash command custom commands on premium removal")
 		}
 	}
+
+	_, err = models.CustomCommands(
+		qm.Where("guild_id = ? AND disabled = false AND trigger_type = ?", GuildID, CommandTriggerSlash),
+		qm.Where("jsonb_typeof(slash_command_options->'subcommands') = 'array'"),
+		qm.Where("jsonb_array_length(slash_command_options->'subcommands') > ?", MaxSlashCommandCCs),
+	).UpdateAllG(context.Background(), models.M{"disabled": true})
+	if err != nil {
+		return errors.WrapIf(err, "failed disabling slash command custom commands exceeding the free subcommand limit on premium removal")
+	}
+
 	pubsub.PublishLogErr(SlashCommandResyncEvent, GuildID, nil)
 
 	return nil

--- a/customcommands/customcommands.go
+++ b/customcommands/customcommands.go
@@ -159,6 +159,15 @@ type SlashCommandOption struct {
 	ChannelTypes []int `json:"channel_types,omitempty"`
 }
 
+// SlashCommandSubcommand is one subcommand of a slash command custom command. When a
+// command has subcommands it has no top-level options and is invoked as
+// "/<command> <subcommand>"; the invoked name is exposed to the template as .SubCommand.
+type SlashCommandSubcommand struct {
+	Name        string               `json:"name"`
+	Description string               `json:"description"`
+	Options     []SlashCommandOption `json:"options,omitempty"`
+}
+
 // slashCommandNameRegex matches Discord's allowed application command/option name
 // pattern (lowercased). See https://discord.com/developers/docs/interactions/application-commands#application-command-object
 var slashCommandNameRegex = regexp.MustCompile(`^[-_\p{L}\p{N}]{1,32}$`)
@@ -212,6 +221,28 @@ type CustomCommand struct {
 
 	SlashCommandDescription string                   `schema:"slash_command_description" valid:",0,100"`
 	SlashOptions            []SlashCommandOptionForm `schema:"slash_options"`
+	// When SlashUseSubcommands is set the command has subcommands (slash_subcommands)
+	// instead of top-level options; the two are mutually exclusive on Discord.
+	SlashUseSubcommands bool                         `schema:"slash_use_subcommands"`
+	SlashSubcommands    []SlashCommandSubcommandForm `schema:"slash_subcommands"`
+}
+
+type SlashCommandSubcommandForm struct {
+	Name        string                   `schema:"name"`
+	Description string                   `schema:"description"`
+	Options     []SlashCommandOptionForm `schema:"options"`
+}
+
+func (sf SlashCommandSubcommandForm) isEmpty() bool {
+	if strings.TrimSpace(sf.Name) != "" || strings.TrimSpace(sf.Description) != "" {
+		return false
+	}
+	for _, o := range sf.Options {
+		if !o.isEmpty() {
+			return false
+		}
+	}
+	return true
 }
 
 type SlashCommandOptionForm struct {
@@ -306,8 +337,15 @@ func (f SlashCommandOptionForm) isEmpty() bool {
 }
 
 func (cc *CustomCommand) SlashCommandOptions() []SlashCommandOption {
-	opts := make([]SlashCommandOption, 0, len(cc.SlashOptions))
-	for _, f := range cc.SlashOptions {
+	return parseSlashOptionForms(cc.SlashOptions)
+}
+
+// parseSlashOptionForms converts a list of option form rows into resolved options,
+// dropping empty rows and sorting required-first. Shared by the top-level options and
+// per-subcommand options.
+func parseSlashOptionForms(forms []SlashCommandOptionForm) []SlashCommandOption {
+	opts := make([]SlashCommandOption, 0, len(forms))
+	for _, f := range forms {
 		if f.isEmpty() {
 			continue
 		}
@@ -316,7 +354,7 @@ func (cc *CustomCommand) SlashCommandOptions() []SlashCommandOption {
 		dType, isMenu, _ := slashFormType(f.Type)
 
 		opt := SlashCommandOption{
-			Name:        strings.ToLower(strings.TrimSpace(f.Name)),
+			Name:        strings.TrimSpace(f.Name),
 			Type:        dType,
 			Description: f.Description,
 			Required:    f.Required,
@@ -349,6 +387,23 @@ func (cc *CustomCommand) SlashCommandOptions() []SlashCommandOption {
 	})
 
 	return opts
+}
+
+// SlashCommandSubcommands converts the subcommand form rows into resolved subcommands,
+// dropping fully-empty rows.
+func (cc *CustomCommand) SlashCommandSubcommands() []SlashCommandSubcommand {
+	subs := make([]SlashCommandSubcommand, 0, len(cc.SlashSubcommands))
+	for _, sf := range cc.SlashSubcommands {
+		if sf.isEmpty() {
+			continue
+		}
+		subs = append(subs, SlashCommandSubcommand{
+			Name:        strings.TrimSpace(sf.Name),
+			Description: sf.Description,
+			Options:     parseSlashOptionForms(sf.Options),
+		})
+	}
+	return subs
 }
 
 func parseChoiceLines(raw string) []string {
@@ -499,7 +554,14 @@ func (cc *CustomCommand) validateSlashCommand(tmpl web.TemplateData, guildID int
 		return false
 	}
 
-	if ok, msg := validateSlashCommandData(guildID, cc.Trigger, cc.SlashCommandDescription, cc.SlashCommandOptions(), cc.ID, cc.IsEnabled); !ok {
+	data := slashCommandData{Description: cc.SlashCommandDescription}
+	if cc.SlashUseSubcommands {
+		data.Subcommands = cc.SlashCommandSubcommands()
+	} else {
+		data.Options = cc.SlashCommandOptions()
+	}
+
+	if ok, msg := validateSlashCommandData(guildID, cc.Trigger, data, cc.ID, cc.IsEnabled); !ok {
 		tmpl.AddAlerts(web.ErrorAlert(msg))
 		return false
 	}
@@ -512,13 +574,13 @@ func (cc *CustomCommand) validateSlashCommand(tmpl web.TemplateData, guildID int
 // path so both reject invalid/duplicate commands. currentLocalID is the local_id of
 // the command being saved (0 for new commands) and is excluded from the duplicate
 // and limit checks.
-func validateSlashCommandData(guildID int64, name, description string, options []SlashCommandOption, currentLocalID int64, isEnabled bool) (ok bool, errMsg string) {
+func validateSlashCommandData(guildID int64, name string, data slashCommandData, currentLocalID int64, isEnabled bool) (ok bool, errMsg string) {
 	name = strings.ToLower(strings.TrimSpace(name))
 	if !slashCommandNameRegex.MatchString(name) {
 		return false, "Slash command name must be 1-32 characters and contain only letters, numbers, dashes and underscores"
 	}
 
-	if l := utf8.RuneCountInString(description); l < 1 || l > MaxSlashCommandDescription {
+	if l := utf8.RuneCountInString(data.Description); l < 1 || l > MaxSlashCommandDescription {
 		return false, fmt.Sprintf("Slash command description must be between 1 and %d characters", MaxSlashCommandDescription)
 	}
 
@@ -526,8 +588,67 @@ func validateSlashCommandData(guildID int64, name, description string, options [
 		return false, "A built-in command with that name already exists, please choose a different name"
 	}
 
+	if len(data.Subcommands) > 0 {
+		// A command with subcommands is invoked as "/<command> <subcommand>" and has no
+		// top-level options; subcommands reuse the same 3-free / 10-premium limit.
+		maxSubs := MaxSlashCommandForContext(guildID)
+		if len(data.Subcommands) > maxSubs {
+			return false, fmt.Sprintf("You can have at most %d subcommands per command (%d on premium servers)", maxSubs, MaxSlashCommandCCsPremium)
+		}
+
+		seenSubs := make(map[string]bool, len(data.Subcommands))
+		for _, sub := range data.Subcommands {
+			sname := strings.TrimSpace(sub.Name)
+			if !slashCommandNameRegex.MatchString(sname) {
+				return false, fmt.Sprintf("Subcommand name %q must be 1-32 characters (letters, numbers, dashes, underscores)", sub.Name)
+			}
+			if sname != strings.ToLower(sname) {
+				return false, fmt.Sprintf("Subcommand name %q must be lowercase", sub.Name)
+			}
+			if seenSubs[sname] {
+				return false, fmt.Sprintf("Duplicate subcommand name %q", sname)
+			}
+			seenSubs[sname] = true
+			if l := utf8.RuneCountInString(sub.Description); l < 1 || l > MaxSlashCommandDescription {
+				return false, fmt.Sprintf("Description for subcommand %q must be between 1 and %d characters", sname, MaxSlashCommandDescription)
+			}
+			if ok, msg := validateSlashOptionList(sub.Options); !ok {
+				return false, fmt.Sprintf("Subcommand %q: %s", sname, msg)
+			}
+		}
+	} else if ok, msg := validateSlashOptionList(data.Options); !ok {
+		return false, msg
+	}
+
+	existing, err := models.CustomCommands(qm.Where("guild_id = ? AND trigger_type = ? AND local_id != ?", guildID, int(CommandTriggerSlash), currentLocalID)).AllG(context.Background())
+	if err != nil {
+		logger.WithError(err).WithField("guild", guildID).Error("failed fetching existing slash command ccs for validation")
+		return false, "Failed validating slash command, please try again"
+	}
+
+	enabledCount := 0
+	for _, e := range existing {
+		if strings.EqualFold(e.TextTrigger, name) {
+			return false, "Another slash command in this server already uses that name"
+		}
+		if !e.Disabled {
+			enabledCount++
+		}
+	}
+
+	maxSlash := MaxSlashCommandForContext(guildID)
+	if isEnabled && enabledCount >= maxSlash {
+		return false, fmt.Sprintf("You can have at most %d enabled slash commands per server (%d on premium servers)", maxSlash, MaxSlashCommandCCsPremium)
+	}
+
+	return true, ""
+}
+
+// validateSlashOptionList validates a single option list (the command's top-level
+// options, or one subcommand's options). Error messages reference the option name.
+func validateSlashOptionList(options []SlashCommandOption) (ok bool, errMsg string) {
 	if len(options) > MaxSlashCommandOptions {
-		return false, fmt.Sprintf("A slash command can have at most %d options", MaxSlashCommandOptions)
+		return false, fmt.Sprintf("can have at most %d options", MaxSlashCommandOptions)
 	}
 
 	seenOptions := make(map[string]bool, len(options))
@@ -583,27 +704,6 @@ func validateSlashCommandData(guildID int64, name, description string, options [
 		if (opt.MinLength != nil && *opt.MinLength < 0) || (opt.MaxLength != nil && *opt.MaxLength > MaxSlashCommandStringLength) {
 			return false, fmt.Sprintf("Length constraints for option %q must be between 0 and %d", oname, MaxSlashCommandStringLength)
 		}
-	}
-
-	existing, err := models.CustomCommands(qm.Where("guild_id = ? AND trigger_type = ? AND local_id != ?", guildID, int(CommandTriggerSlash), currentLocalID)).AllG(context.Background())
-	if err != nil {
-		logger.WithError(err).WithField("guild", guildID).Error("failed fetching existing slash command ccs for validation")
-		return false, "Failed validating slash command, please try again"
-	}
-
-	enabledCount := 0
-	for _, e := range existing {
-		if strings.EqualFold(e.TextTrigger, name) {
-			return false, "Another slash command in this server already uses that name"
-		}
-		if !e.Disabled {
-			enabledCount++
-		}
-	}
-
-	maxSlash := MaxSlashCommandForContext(guildID)
-	if isEnabled && enabledCount >= maxSlash {
-		return false, fmt.Sprintf("You can have at most %d enabled slash commands per server (%d on premium servers)", maxSlash, MaxSlashCommandCCsPremium)
 	}
 
 	return true, ""
@@ -665,10 +765,12 @@ func (cc *CustomCommand) ToDBModel() *models.CustomCommand {
 	if cc.TriggerTypeForm == "slash_command" {
 		pqCommand.TextTrigger = strings.ToLower(cc.Trigger)
 
-		opts := cc.SlashCommandOptions()
-		payload := slashCommandData{
-			Description: cc.SlashCommandDescription,
-			Options:     opts,
+		payload := slashCommandData{Description: cc.SlashCommandDescription}
+		// subcommands and top-level options are mutually exclusive on Discord.
+		if cc.SlashUseSubcommands {
+			payload.Subcommands = cc.SlashCommandSubcommands()
+		} else {
+			payload.Options = cc.SlashCommandOptions()
 		}
 		if b, err := json.Marshal(payload); err == nil {
 			pqCommand.SlashCommandOptions = null.JSONFrom(b)
@@ -681,10 +783,12 @@ func (cc *CustomCommand) ToDBModel() *models.CustomCommand {
 }
 
 // slashCommandData is the structure stored in the slash_command_options jsonb
-// column for slash command custom commands.
+// column for slash command custom commands. Options and Subcommands are mutually
+// exclusive: a command with subcommands has no top-level options.
 type slashCommandData struct {
-	Description string               `json:"description"`
-	Options     []SlashCommandOption `json:"options"`
+	Description string                   `json:"description"`
+	Options     []SlashCommandOption     `json:"options,omitempty"`
+	Subcommands []SlashCommandSubcommand `json:"subcommands,omitempty"`
 }
 
 // parseSlashCommandData decodes the slash_command_options jsonb column of a stored

--- a/customcommands/customcommands.go
+++ b/customcommands/customcommands.go
@@ -557,6 +557,10 @@ func (cc *CustomCommand) validateSlashCommand(tmpl web.TemplateData, guildID int
 	data := slashCommandData{Description: cc.SlashCommandDescription}
 	if cc.SlashUseSubcommands {
 		data.Subcommands = cc.SlashCommandSubcommands()
+		if len(data.Subcommands) == 0 {
+			tmpl.AddAlerts(web.ErrorAlert("Add at least one subcommand (with a name and description) or turn off the \"Use subcommands\" toggle"))
+			return false
+		}
 	} else {
 		data.Options = cc.SlashCommandOptions()
 	}

--- a/customcommands/handle_slashcommand.go
+++ b/customcommands/handle_slashcommand.go
@@ -114,15 +114,33 @@ func ExecuteCustomCommandFromSlash(cc *models.CustomCommand, gs *dstate.GuildSet
 
 	stored := parseSlashCommandData(cc)
 
-	provided := make(map[string]*discordgo.ApplicationCommandInteractionDataOption, len(data.Options))
-	for _, o := range data.Options {
+	// For a command with subcommands the chosen subcommand is the first interaction
+	// option (type SUB_COMMAND); descend into it for the leaf options and expose its
+	// name as .SubCommand. Otherwise use the top-level options directly.
+	defs := stored.Options
+	leafOptions := data.Options
+	subName := ""
+	if len(stored.Subcommands) > 0 && len(data.Options) > 0 && data.Options[0].Type == discordgo.ApplicationCommandOptionSubCommand {
+		subName = data.Options[0].Name
+		leafOptions = data.Options[0].Options
+		for _, s := range stored.Subcommands {
+			if strings.EqualFold(s.Name, subName) {
+				defs = s.Options
+				break
+			}
+		}
+	}
+	tmplCtx.Data["SubCommand"] = subName
+
+	provided := make(map[string]*discordgo.ApplicationCommandInteractionDataOption, len(leafOptions))
+	for _, o := range leafOptions {
 		provided[strings.ToLower(o.Name)] = o
 	}
 
 	options := templates.SDict{}
-	args := make([]interface{}, 0, len(stored.Options)+1)
+	args := make([]interface{}, 0, len(defs)+1)
 	args = append(args, data.Name)
-	for _, def := range stored.Options {
+	for _, def := range defs {
 		o, ok := provided[strings.ToLower(def.Name)]
 		if !ok {
 			// optional option not provided by the user
@@ -214,11 +232,11 @@ func resolveSlashUser(data *discordgo.ApplicationCommandInteractionData, id int6
 
 // buildSlashCommandRequest converts a stored slash command custom command into the
 // discordgo request used to (re)register it with Discord.
-func buildSlashCommandRequest(cc *models.CustomCommand) *discordgo.CreateApplicationCommandRequest {
-	stored := parseSlashCommandData(cc)
-
-	opts := make([]*discordgo.ApplicationCommandOption, 0, len(stored.Options))
-	for _, o := range stored.Options {
+// buildOptionList converts stored leaf options into discordgo options, sorted
+// required-first (Discord rejects a required option after an optional one).
+func buildOptionList(options []SlashCommandOption) []*discordgo.ApplicationCommandOption {
+	opts := make([]*discordgo.ApplicationCommandOption, 0, len(options))
+	for _, o := range options {
 		ao := &discordgo.ApplicationCommandOption{
 			Type:        discordgo.ApplicationCommandOptionType(o.Type),
 			Name:        strings.ToLower(o.Name),
@@ -256,6 +274,32 @@ func buildSlashCommandRequest(cc *models.CustomCommand) *discordgo.CreateApplica
 	sort.SliceStable(opts, func(i, j int) bool {
 		return opts[i].Required && !opts[j].Required
 	})
+	return opts
+}
+
+func buildSlashCommandRequest(cc *models.CustomCommand) *discordgo.CreateApplicationCommandRequest {
+	stored := parseSlashCommandData(cc)
+
+	var opts []*discordgo.ApplicationCommandOption
+	if len(stored.Subcommands) > 0 {
+		// A command that owns subcommands carries one SUB_COMMAND option per
+		// subcommand and is not directly invocable. Subcommand ordering is stable;
+		// SUB_COMMAND options have no required/optional ordering constraint.
+		for _, sub := range stored.Subcommands {
+			desc := sub.Description
+			if strings.TrimSpace(desc) == "" {
+				desc = "Subcommand"
+			}
+			opts = append(opts, &discordgo.ApplicationCommandOption{
+				Type:        discordgo.ApplicationCommandOptionSubCommand,
+				Name:        strings.ToLower(sub.Name),
+				Description: common.CutStringShort(desc, MaxSlashCommandDescription),
+				Options:     buildOptionList(sub.Options),
+			})
+		}
+	} else {
+		opts = buildOptionList(stored.Options)
+	}
 
 	description := stored.Description
 	if strings.TrimSpace(description) == "" {

--- a/customcommands/web.go
+++ b/customcommands/web.go
@@ -358,6 +358,8 @@ func serveGroupSelected(r *http.Request, templateData web.TemplateData, groupID 
 	templateData["GetCCInterval"] = tmplGetCCInterval
 	templateData["GetCCSlashOptions"] = tmplGetCCSlashOptions
 	templateData["GetCCSlashDescription"] = tmplGetCCSlashDescription
+	templateData["GetCCSlashUseSubcommands"] = tmplGetCCSlashUseSubcommands
+	templateData["GetCCSlashSubcommands"] = tmplGetCCSlashSubcommands
 
 	// Whether the guild has already reached the free-tier slash command limit, used
 	// to decide when to surface the premium nudge in the slash command editor.
@@ -491,7 +493,7 @@ func handleNewCommand(w http.ResponseWriter, r *http.Request) (web.TemplateData,
 		dbModel.SlashCommandOptions = importCC.SlashCommandOptions
 		if importCC.TriggerType == int(CommandTriggerSlash) {
 			data := parseSlashCommandData(dbModel)
-			if ok, _ := validateSlashCommandData(activeGuild.ID, dbModel.TextTrigger, data.Description, data.Options, dbModel.LocalID, !dbModel.Disabled); !ok {
+			if ok, _ := validateSlashCommandData(activeGuild.ID, dbModel.TextTrigger, data, dbModel.LocalID, !dbModel.Disabled); !ok {
 				http.Redirect(w, r, fmt.Sprintf("/manage/%d/customcommands?import_failed=true", activeGuild.ID), http.StatusSeeOther)
 				return templateData, nil
 			}
@@ -993,6 +995,35 @@ func tmplGetCCSlashOptions(cc *models.CustomCommand) []SlashOptionView {
 // custom command for rendering in the edit form.
 func tmplGetCCSlashDescription(cc *models.CustomCommand) string {
 	return parseSlashCommandData(cc).Description
+}
+
+// SlashSubcommandView is a stored subcommand plus its options tagged with editor
+// type keys, for rendering in the edit form.
+type SlashSubcommandView struct {
+	Name        string
+	Description string
+	Options     []SlashOptionView
+}
+
+// tmplGetCCSlashUseSubcommands reports whether a slash command custom command is
+// configured with subcommands (vs flat top-level options).
+func tmplGetCCSlashUseSubcommands(cc *models.CustomCommand) bool {
+	return len(parseSlashCommandData(cc).Subcommands) > 0
+}
+
+// tmplGetCCSlashSubcommands returns the configured subcommands of a slash command
+// custom command for rendering in the edit form.
+func tmplGetCCSlashSubcommands(cc *models.CustomCommand) []SlashSubcommandView {
+	stored := parseSlashCommandData(cc).Subcommands
+	views := make([]SlashSubcommandView, 0, len(stored))
+	for _, s := range stored {
+		opts := make([]SlashOptionView, 0, len(s.Options))
+		for _, o := range s.Options {
+			opts = append(opts, SlashOptionView{SlashCommandOption: o, TypeKey: slashFormTypeKey(o)})
+		}
+		views = append(views, SlashSubcommandView{Name: s.Name, Description: s.Description, Options: opts})
+	}
+	return views
 }
 
 var _ web.PluginWithServerHomeWidget = (*Plugin)(nil)


### PR DESCRIPTION
This PR adds supports for SubCommands to Slash type custom commands. 

To keep it simple SubCommands just add an extra layer of hierachy to Options. 

Example Hierarchy
```
parent  
   - subcommand1
          - [options] 
   - subcommand2
          - [options] 
   - subcommand3
          - [options] 
   - subcommand4
          - [options] 
   - subcommand5
          - [options] 
```


And inside the custom command you can write an If else Ladder to handle each individual subcommand as below 
```

{{if eq .SubCommand "subcommand1"}}

{{else if eq SubCommand "subcommand2"}}

{{else if eq SubCommand "subcommand3"}}

{{else if eq SubCommand "subcommand4"}}

{{else if eq SubCommand "subcommand5"}}

{{end}}

```

Or whatever is your  preferred form of conditional branching depending on the name of the subcommand. 

Limits are as below. 

Each Slash command can have 
- 3 subcommands for free, and 10 with premium. 
- upto 25 options per subcommand ( irrespective of premium) 