### PR TITLE
Added support for context menu CCs

### DIFF
--- a/customcommands/assets/customcommands-editcmd.html
+++ b/customcommands/assets/customcommands-editcmd.html
@@ -203,6 +203,8 @@
                                                     Crontab </option>
                                                 <option value="role_trigger" {{ if eq .CC.TriggerType 11}}selected{{end}}> Role Change</option>
                                                 <option value="slash_command" {{ if eq .CC.TriggerType 12}}selected{{end}}> Slash Command</option>
+                                                <option value="user_context_menu" {{ if eq .CC.TriggerType 13}}selected{{end}}> User Context Menu</option>
+                                                <option value="message_context_menu" {{ if eq .CC.TriggerType 14}}selected{{end}}> Message Context Menu</option>
                                             </select>
                                         </div>
                                     </div>
@@ -252,9 +254,17 @@
                                         <small id="trigger-desc-role_trigger">
                                             The command will run when a role is assigned to or removed from a member,
                                             <b>has a cooldown of 5 minutes per user-role combination, reduced to 1 minute for premium servers</b>
+                                            The user who got the role available as <code>.TargetUser</code> and <code>.TargetMember</code>, and the user who gave the role is available as <code>.Author</code>
+                                            The role given is availabe in <code>.Role</code>
                                         </small>
                                         <small id="trigger-desc-slash_command">
                                             Creates a Slash command, trigger name must not be same as an inbuilt slash command.
+                                        </small>
+                                        <small id="trigger-desc-user_context_menu">
+                                            Adds a command to the right-click menu on users. The clicked user is available as <code>.TargetUser</code> and <code>.TargetMember</code>; the user who ran the command is <code>.Author</code>.
+                                        </small>
+                                        <small id="trigger-desc-message_context_menu">
+                                            Adds a command to the right-click (Apps) menu on messages. The clicked message is available as <code>.Message</code>, its author as <code>.TargetUser</code> and <code>.TargetMember</code>, and the user who ran the command as <code>.Author</code>.
                                         </small>
                                     </div>
                                 </div>
@@ -267,12 +277,23 @@
                                             <label id="cc-customid-trigger-label">Component Custom ID Regex (<span id="trigger-length">{{len .CC.TextTrigger}}</span>/1000)</label>
                                             <label id="cc-cron-trigger-label">Crontab (<span id="trigger-length">{{len .CC.TextTrigger}}</span>/1000)</label>
                                             <label id="cc-slash-trigger-label">Command Trigger (<span id="trigger-length">{{len .CC.TextTrigger}}</span>/32) <i class="fas fa-info-circle text-primary" data-toggle="tooltip" data-placement="top" title="The /name members type in Discord. Lowercase letters, numbers, dashes and underscores only."></i></label>
+                                            <label id="cc-contextmenu-trigger-label">Command Name (<span id="trigger-length">{{len .CC.TextTrigger}}</span>/32) <i class="fas fa-info-circle text-primary" data-toggle="tooltip" data-placement="top" title="The label shown in Discord's right-click menu. Letters, numbers and spaces allowed."></i></label>
                                             <div class="input-group mb-2">
                                                 <div id="command-trigger-prepended-prefix" class="input-group-prepend">
                                                     <div class="input-group-text">{{.CommandPrefix}}</div>
                                                 </div>
                                                 <input id="trigger" type="text" class="form-control" name="trigger" placeholder="{{if eq .CC.TriggerType 9}}45 23 * * 6{{else}}fun{{end}}"
                                                     value="{{.CC.TextTrigger}}">
+                                            </div>
+                                            <div id="contextmenu-user-nudge" class="hidden">
+                                                {{if and (not .IsGuildPremium) .UserContextMenuLimitReached}}
+                                                {{template "cp_premium_nudge" (dict "IsGuildPremium" .IsGuildPremium "Title" "You've reached the free limit of 1 user context menu command. Premium servers can have up to 5.")}}
+                                                {{end}}
+                                            </div>
+                                            <div id="contextmenu-message-nudge" class="hidden">
+                                                {{if and (not .IsGuildPremium) .MessageContextMenuLimitReached}}
+                                                {{template "cp_premium_nudge" (dict "IsGuildPremium" .IsGuildPremium "Title" "You've reached the free limit of 1 message context menu command. Premium servers can have up to 5.")}}
+                                                {{end}}
                                             </div>
                                             <div class="row">
                                               <div id="cc-text-trigger-case-sensitivity-toggle" class="col-lg-6"> {{checkbox "case_sensitive" "case_sensitive" "Case Sensitive?" .CC.TextTriggerCaseSensitive}}</div>
@@ -996,6 +1017,8 @@
         cron: ['#cc-text-trigger-details', '#cc-cron-trigger-label', '#cc-time-trigger-details', '#trigger-desc-cron'],
         role_trigger: ['#cc-role-trigger-details', '#cc-role-settings','#trigger-desc-role_trigger'],
         slash_command: ['#cc-text-trigger-details', '#cc-slash-trigger-label', '#cc-interaction-trigger-details', '#cc-role-settings', '#cc-channel-settings', '#cc-slash-trigger-details', '#trigger-desc-slash_command'],
+        user_context_menu: ['#cc-text-trigger-details', '#cc-contextmenu-trigger-label', '#cc-interaction-trigger-details', '#cc-role-settings', '#cc-channel-settings', '#contextmenu-user-nudge', '#trigger-desc-user_context_menu'],
+        message_context_menu: ['#cc-text-trigger-details', '#cc-contextmenu-trigger-label', '#cc-interaction-trigger-details', '#cc-role-settings', '#cc-channel-settings', '#contextmenu-message-nudge', '#trigger-desc-message_context_menu'],
         none: ['#trigger-desc-none'],
     };
 
@@ -1022,7 +1045,7 @@
         // is no prior message to update), so hide that option for them and fall back
         // to "None" if it happened to be selected.
         const updateOption = $('#interaction-defer-update-option');
-        if (curTriggerType === 'slash_command') {
+        if (curTriggerType === 'slash_command' || curTriggerType === 'user_context_menu' || curTriggerType === 'message_context_menu') {
             updateOption.addClass('hidden');
             const updateRadio = updateOption.find('input[type="radio"]');
             if (updateRadio.prop('checked')) {
@@ -1137,8 +1160,9 @@
         const trigger = $('#trigger');
         if (!trigger.length) return;
         const len = trigger.val().length;
-        // slash command triggers are limited to 32 chars, other triggers to 1000.
-        const max = $('#trigger-type-dropdown').val() === 'slash_command' ? 32 : 1000;
+        // slash and context menu command names are limited to 32 chars, other triggers to 1000.
+        const triggerType = $('#trigger-type-dropdown').val();
+        const max = (triggerType === 'slash_command' || triggerType === 'user_context_menu' || triggerType === 'message_context_menu') ? 32 : 1000;
         // there are several #trigger-length spans (one per trigger-type label); update them all.
         $('[id="trigger-length"]').text(len).toggleClass('text-danger', len > max);
     }

--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -586,6 +586,19 @@ func (p *Plugin) OnRemovedPremiumGuild(GuildID int64) error {
 		return errors.WrapIf(err, "failed disabling slash command custom commands exceeding the free subcommand limit on premium removal")
 	}
 
+	for _, t := range []CommandTriggerType{CommandTriggerUserContextMenu, CommandTriggerMessageContextMenu} {
+		contextMenuCommands, err := models.CustomCommands(qm.Where("guild_id = ? AND disabled = false AND trigger_type = ?", GuildID, t), qm.OrderBy("local_id ASC"), qm.Offset(MaxContextMenuCCs)).AllG(context.Background())
+		if err != nil {
+			return errors.WrapIf(err, "failed fetching context menu custom commands on premium removal")
+		}
+		if len(contextMenuCommands) > 0 {
+			_, err = contextMenuCommands.UpdateAllG(context.Background(), models.M{"disabled": true})
+			if err != nil {
+				return errors.WrapIf(err, "failed disabling context menu custom commands on premium removal")
+			}
+		}
+	}
+
 	pubsub.PublishLogErr(SlashCommandResyncEvent, GuildID, nil)
 
 	return nil

--- a/customcommands/contextmenu_test.go
+++ b/customcommands/contextmenu_test.go
@@ -1,0 +1,72 @@
+package customcommands
+
+import (
+	"testing"
+
+	"github.com/botlabs-gg/yagpdb/v2/customcommands/models"
+	"github.com/botlabs-gg/yagpdb/v2/lib/discordgo"
+)
+
+func TestContextMenuNameRegex(t *testing.T) {
+	valid := []string{"Report", "Report Message", "flag-user", "abc 123", "ünïcode name"}
+	invalid := []string{"", "bad.name", "way too long name that exceeds the limit!!", "no_emoji_😀"}
+
+	for _, v := range valid {
+		if !contextMenuNameRegex.MatchString(v) {
+			t.Errorf("expected %q to be valid", v)
+		}
+	}
+	for _, v := range invalid {
+		if contextMenuNameRegex.MatchString(v) {
+			t.Errorf("expected %q to be invalid", v)
+		}
+	}
+}
+
+func TestToDBModelContextMenu(t *testing.T) {
+	cc := &CustomCommand{
+		TriggerTypeForm: "user_context_menu",
+		TriggerType:     CommandTriggerUserContextMenu,
+		Trigger:         "  Report User  ", // case + spaces preserved, surrounding space trimmed
+		Responses:       []string{"hi"},
+	}
+
+	db := cc.ToDBModel()
+	if db.TriggerType != int(CommandTriggerUserContextMenu) {
+		t.Errorf("unexpected trigger type %d", db.TriggerType)
+	}
+	if db.TextTrigger != "Report User" {
+		t.Errorf("expected trimmed, case-preserved name %q, got %q", "Report User", db.TextTrigger)
+	}
+	if db.SlashCommandOptions.Valid {
+		t.Error("context menu commands should not store slash command options")
+	}
+}
+
+func TestBuildContextMenuCommandRequest(t *testing.T) {
+	user := &models.CustomCommand{TextTrigger: "Report User", TriggerType: int(CommandTriggerUserContextMenu)}
+	req := buildContextMenuCommandRequest(user)
+	if req.Name != "Report User" {
+		t.Errorf("unexpected name %q", req.Name)
+	}
+	if req.Type != discordgo.UserApplicationCommand {
+		t.Errorf("expected USER command type, got %v", req.Type)
+	}
+	if req.Description != "" || len(req.Options) != 0 {
+		t.Errorf("context menu commands must have no description/options: %+v", req)
+	}
+
+	msg := &models.CustomCommand{TextTrigger: "Report Message", TriggerType: int(CommandTriggerMessageContextMenu)}
+	if got := buildContextMenuCommandRequest(msg); got.Type != discordgo.MessageApplicationCommand {
+		t.Errorf("expected MESSAGE command type, got %v", got.Type)
+	}
+}
+
+func TestIsContextMenuTrigger(t *testing.T) {
+	if !IsContextMenuTrigger(CommandTriggerUserContextMenu) || !IsContextMenuTrigger(CommandTriggerMessageContextMenu) {
+		t.Error("expected both context menu types to report true")
+	}
+	if IsContextMenuTrigger(CommandTriggerSlash) || IsContextMenuTrigger(CommandTriggerCommand) {
+		t.Error("non context menu types must report false")
+	}
+}

--- a/customcommands/customcommands.go
+++ b/customcommands/customcommands.go
@@ -71,18 +71,20 @@ const (
 
 	CommandTriggerNone CommandTriggerType = 10
 
-	CommandTriggerCommand    CommandTriggerType = 0
-	CommandTriggerStartsWith CommandTriggerType = 1
-	CommandTriggerContains   CommandTriggerType = 2
-	CommandTriggerRegex      CommandTriggerType = 3
-	CommandTriggerExact      CommandTriggerType = 4
-	CommandTriggerInterval   CommandTriggerType = 5
-	CommandTriggerReaction   CommandTriggerType = 6
-	CommandTriggerComponent  CommandTriggerType = 7
-	CommandTriggerModal      CommandTriggerType = 8
-	CommandTriggerCron       CommandTriggerType = 9
-	CommandTriggerRole       CommandTriggerType = 11
-	CommandTriggerSlash      CommandTriggerType = 12
+	CommandTriggerCommand            CommandTriggerType = 0
+	CommandTriggerStartsWith         CommandTriggerType = 1
+	CommandTriggerContains           CommandTriggerType = 2
+	CommandTriggerRegex              CommandTriggerType = 3
+	CommandTriggerExact              CommandTriggerType = 4
+	CommandTriggerInterval           CommandTriggerType = 5
+	CommandTriggerReaction           CommandTriggerType = 6
+	CommandTriggerComponent          CommandTriggerType = 7
+	CommandTriggerModal              CommandTriggerType = 8
+	CommandTriggerCron               CommandTriggerType = 9
+	CommandTriggerRole               CommandTriggerType = 11
+	CommandTriggerSlash              CommandTriggerType = 12
+	CommandTriggerUserContextMenu    CommandTriggerType = 13
+	CommandTriggerMessageContextMenu CommandTriggerType = 14
 )
 
 var (
@@ -100,22 +102,26 @@ var (
 		CommandTriggerCron,
 		CommandTriggerRole,
 		CommandTriggerSlash,
+		CommandTriggerUserContextMenu,
+		CommandTriggerMessageContextMenu,
 	}
 
 	triggerStrings = map[CommandTriggerType]string{
-		CommandTriggerCommand:    "Command",
-		CommandTriggerStartsWith: "StartsWith",
-		CommandTriggerContains:   "Contains",
-		CommandTriggerRegex:      "Regex",
-		CommandTriggerExact:      "Exact",
-		CommandTriggerInterval:   "Interval",
-		CommandTriggerReaction:   "Reaction",
-		CommandTriggerNone:       "None",
-		CommandTriggerComponent:  "Component",
-		CommandTriggerModal:      "Modal",
-		CommandTriggerCron:       "Crontab",
-		CommandTriggerRole:       "Role",
-		CommandTriggerSlash:      "Slash Command",
+		CommandTriggerCommand:            "Command",
+		CommandTriggerStartsWith:         "StartsWith",
+		CommandTriggerContains:           "Contains",
+		CommandTriggerRegex:              "Regex",
+		CommandTriggerExact:              "Exact",
+		CommandTriggerInterval:           "Interval",
+		CommandTriggerReaction:           "Reaction",
+		CommandTriggerNone:               "None",
+		CommandTriggerComponent:          "Component",
+		CommandTriggerModal:              "Modal",
+		CommandTriggerCron:               "Crontab",
+		CommandTriggerRole:               "Role",
+		CommandTriggerSlash:              "Slash Command",
+		CommandTriggerUserContextMenu:    "User Context Menu",
+		CommandTriggerMessageContextMenu: "Message Context Menu",
 	}
 )
 
@@ -171,6 +177,11 @@ type SlashCommandSubcommand struct {
 // slashCommandNameRegex matches Discord's allowed application command/option name
 // pattern (lowercased). See https://discord.com/developers/docs/interactions/application-commands#application-command-object
 var slashCommandNameRegex = regexp.MustCompile(`^[-_\p{L}\p{N}]{1,32}$`)
+
+// contextMenuNameRegex matches Discord's allowed USER/MESSAGE command name pattern.
+// Unlike slash commands, context menu command names may contain spaces and uppercase
+// letters. See https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-naming
+var contextMenuNameRegex = regexp.MustCompile(`^[-_\p{L}\p{N} ]{1,32}$`)
 
 const (
 	MaxSlashCommandOptions      = 25
@@ -514,8 +525,58 @@ func (cc *CustomCommand) Validate(tmpl web.TemplateData, guild_id int64) (ok boo
 		}
 	}
 
+	if cc.TriggerTypeForm == "user_context_menu" || cc.TriggerTypeForm == "message_context_menu" {
+		if !cc.validateContextMenuCommand(tmpl, guild_id) {
+			return false
+		}
+	}
+
 	return true
 
+}
+
+func (cc *CustomCommand) validateContextMenuCommand(tmpl web.TemplateData, guildID int64) bool {
+	if cc.InteractionDeferMode == InteractionDeferModeUpdate {
+		tmpl.AddAlerts(web.ErrorAlert("\"Update message\" defer mode is not valid for context menu commands"))
+		return false
+	}
+
+	if ok, msg := validateContextMenuData(guildID, cc.Trigger, cc.TriggerType, cc.ID, cc.IsEnabled); !ok {
+		tmpl.AddAlerts(web.ErrorAlert(msg))
+		return false
+	}
+
+	return true
+}
+
+func validateContextMenuData(guildID int64, name string, triggerType CommandTriggerType, currentLocalID int64, isEnabled bool) (ok bool, errMsg string) {
+	name = strings.TrimSpace(name)
+	if !contextMenuNameRegex.MatchString(name) {
+		return false, "Context menu command name must be 1-32 characters and contain only letters, numbers, spaces, dashes and underscores"
+	}
+
+	existing, err := models.CustomCommands(qm.Where("guild_id = ? AND trigger_type = ? AND local_id != ?", guildID, int(triggerType), currentLocalID)).AllG(context.Background())
+	if err != nil {
+		logger.WithError(err).WithField("guild", guildID).Error("failed fetching existing context menu ccs for validation")
+		return false, "Failed validating context menu command, please try again"
+	}
+
+	enabledCount := 0
+	for _, e := range existing {
+		if strings.EqualFold(strings.TrimSpace(e.TextTrigger), name) {
+			return false, "Another context menu command of this type in this server already uses that name"
+		}
+		if !e.Disabled {
+			enabledCount++
+		}
+	}
+
+	max := MaxContextMenuForContext(guildID)
+	if isEnabled && enabledCount >= max {
+		return false, fmt.Sprintf("You can have at most %d enabled context menu commands of this type per server (%d on premium servers)", max, MaxContextMenuCCsPremium)
+	}
+
+	return true, ""
 }
 
 var validSlashOptionTypes = map[int]bool{
@@ -783,6 +844,10 @@ func (cc *CustomCommand) ToDBModel() *models.CustomCommand {
 		}
 	}
 
+	if cc.TriggerTypeForm == "user_context_menu" || cc.TriggerTypeForm == "message_context_menu" {
+		pqCommand.TextTrigger = strings.TrimSpace(cc.Trigger)
+	}
+
 	return pqCommand
 }
 
@@ -892,6 +957,8 @@ const (
 	MaxGroups                     = 50
 	MaxSlashCommandCCs            = 3
 	MaxSlashCommandCCsPremium     = 10
+	MaxContextMenuCCs             = 1
+	MaxContextMenuCCsPremium      = 5
 )
 
 // MaxSlashCommandForContext returns how many enabled slash command custom commands
@@ -901,6 +968,21 @@ func MaxSlashCommandForContext(guildID int64) int {
 		return MaxSlashCommandCCsPremium
 	}
 	return MaxSlashCommandCCs
+}
+
+// MaxContextMenuForContext returns how many enabled context menu custom commands of
+// a single type (user or message) a guild may have, depending on premium status.
+func MaxContextMenuForContext(guildID int64) int {
+	if isPremium, _ := premium.IsGuildPremium(guildID); isPremium {
+		return MaxContextMenuCCsPremium
+	}
+	return MaxContextMenuCCs
+}
+
+// IsContextMenuTrigger reports whether the trigger type is one of the context menu
+// command types (user or message).
+func IsContextMenuTrigger(t CommandTriggerType) bool {
+	return t == CommandTriggerUserContextMenu || t == CommandTriggerMessageContextMenu
 }
 
 func MaxCommandsForContext(ctx context.Context) int {

--- a/customcommands/handle_contextmenu.go
+++ b/customcommands/handle_contextmenu.go
@@ -1,0 +1,223 @@
+package customcommands
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/botlabs-gg/yagpdb/v2/bot"
+	"github.com/botlabs-gg/yagpdb/v2/bot/eventsystem"
+	"github.com/botlabs-gg/yagpdb/v2/common"
+	"github.com/botlabs-gg/yagpdb/v2/common/templates"
+	"github.com/botlabs-gg/yagpdb/v2/customcommands/models"
+	"github.com/botlabs-gg/yagpdb/v2/lib/discordgo"
+	"github.com/botlabs-gg/yagpdb/v2/lib/dstate"
+	"github.com/sirupsen/logrus"
+	"github.com/volatiletech/sqlboiler/v4/queries/qm"
+)
+
+var cachedCommandsContextMenuTrigger = common.CacheSet.RegisterSlot("custom_commands_context_menu_trigger", nil, int64(0))
+
+// BotCachedGetCommandsWithContextMenuTrigger returns the (cached) context menu custom
+// commands (both user and message type) for a guild.
+func BotCachedGetCommandsWithContextMenuTrigger(guildID int64, ctx context.Context) ([]*models.CustomCommand, error) {
+	v, err := cachedCommandsContextMenuTrigger.GetCustomFetch(guildID, func(key interface{}) (interface{}, error) {
+		var cmds []*models.CustomCommand
+		var err error
+		common.LogLongCallTime(time.Second, true, "Took longer than a second to fetch custom commands from db", logrus.Fields{"guild": guildID}, func() {
+			cmds, err = models.CustomCommands(
+				qm.Where("guild_id = ? AND trigger_type IN (?, ?)", guildID, int(CommandTriggerUserContextMenu), int(CommandTriggerMessageContextMenu)),
+				qm.OrderBy("local_id asc"),
+				qm.Load("Group"),
+			).AllG(ctx)
+		})
+		return cmds, err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return v.([]*models.CustomCommand), nil
+}
+
+// contextMenuTriggerForCommandType maps a Discord application command type to the
+// matching context menu custom command trigger type.
+func contextMenuTriggerForCommandType(t discordgo.ApplicationCommandType) (CommandTriggerType, bool) {
+	switch t {
+	case discordgo.UserApplicationCommand:
+		return CommandTriggerUserContextMenu, true
+	case discordgo.MessageApplicationCommand:
+		return CommandTriggerMessageContextMenu, true
+	default:
+		return 0, false
+	}
+}
+
+// handleContextMenuInteraction matches an incoming USER/MESSAGE application command
+// interaction to a context menu custom command and executes it.
+func handleContextMenuInteraction(evt *eventsystem.EventData, cs *dstate.ChannelState, interaction *templates.CustomCommandInteraction) {
+	data := interaction.DataCommand
+	if data == nil || interaction.Member == nil {
+		return
+	}
+
+	wantTrigger, ok := contextMenuTriggerForCommandType(data.CommandType)
+	if !ok {
+		return
+	}
+
+	cmds, err := BotCachedGetCommandsWithContextMenuTrigger(cs.GuildID, evt.Context())
+	if err != nil {
+		logger.WithField("guild", cs.GuildID).WithError(err).Error("failed fetching context menu ccs")
+		return
+	}
+
+	var matched *models.CustomCommand
+	for _, cmd := range cmds {
+		if cmd.TriggerType != int(wantTrigger) {
+			continue
+		}
+		if cmd.Disabled || (cmd.R != nil && cmd.R.Group != nil && cmd.R.Group.Disabled) {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(cmd.TextTrigger), strings.TrimSpace(data.Name)) {
+			matched = cmd
+			break
+		}
+	}
+
+	if matched == nil {
+		return
+	}
+
+	ms := dstate.MemberStateFromMember(interaction.Member)
+	if ms == nil || ms.User.Bot {
+		return
+	}
+
+	if !CmdRunsInChannel(matched, common.ChannelOrThreadParentID(cs)) || !CmdRunsForUser(matched, ms) {
+		respondRestrictedInteraction(interaction)
+		return
+	}
+
+	deferResponseToCCs(interaction, []*TriggeredCC{{CC: matched}})
+	if err := ExecuteCustomCommandFromContextMenu(matched, evt.GS, cs, interaction); err != nil {
+		logger.WithField("guild", cs.GuildID).WithField("cc_id", matched.LocalID).WithError(err).Error("Error executing context menu custom command")
+	}
+}
+
+// ExecuteCustomCommandFromContextMenu builds the template context for a context menu
+// custom command and executes it. The right-clicked target is exposed as .TargetUser
+// (+ .TargetMember) for user commands and .TargetMessage for message commands, with
+// .CommandType set to "user" or "message".
+func ExecuteCustomCommandFromContextMenu(cc *models.CustomCommand, gs *dstate.GuildSet, cs *dstate.ChannelState, interaction *templates.CustomCommandInteraction) error {
+	ms := dstate.MemberStateFromMember(interaction.Member)
+	tmplCtx := templates.NewContext(gs, cs, ms)
+	tmplCtx.CurrentFrame.Interaction = interaction
+
+	data := interaction.DataCommand
+
+	tmplCtx.Data["Interaction"] = interaction
+	tmplCtx.Data["InteractionData"] = data
+	tmplCtx.Data["IsContextMenuCommand"] = true
+	tmplCtx.Data["CommandName"] = data.Name
+	tmplCtx.Data["Cmd"] = data.Name
+	tmplCtx.Data["Author"] = &ms.User
+
+	msg := &discordgo.Message{
+		GuildID:   gs.ID,
+		ChannelID: cs.ID,
+		Member:    ms.DgoMember(),
+	}
+	msg.Author = msg.Member.User
+
+	switch data.CommandType {
+	case discordgo.UserApplicationCommand:
+		tmplCtx.Data["CommandType"] = "user"
+		user := resolveSlashUser(data, data.TargetID)
+		tmplCtx.Data["TargetUser"] = user
+		if data.Resolved != nil {
+			if m, ok := data.Resolved.Members[data.TargetID]; ok && m != nil {
+				if m.User == nil {
+					m.User = user
+				}
+				m.GuildID = gs.ID
+				tmplCtx.Data["TargetMember"] = m
+			}
+		}
+	case discordgo.MessageApplicationCommand:
+		tmplCtx.Data["CommandType"] = "message"
+		if data.Resolved != nil {
+			if target, ok := data.Resolved.Messages[data.TargetID]; ok && target != nil {
+				target.GuildID = gs.ID
+				msg = target
+				tmplCtx.Data["TargetUser"] = target.Author
+				authorID := int64(0)
+				if target.Author != nil {
+					authorID = target.Author.ID
+				}
+				if m, _ := bot.GetMember(gs.ID, authorID); m != nil {
+					tmplCtx.Data["TargetMember"] = m
+				} else {
+					tmplCtx.Data["TargetMember"] = msg.Member
+				}
+			}
+		}
+	}
+
+	tmplCtx.Msg = msg
+	tmplCtx.Data["Message"] = msg
+
+	return ExecuteCustomCommand(cc, tmplCtx)
+}
+
+// buildContextMenuCommandRequest converts a stored context menu custom command into the
+// discordgo request used to (re)register it with Discord. Context menu commands carry
+// no description or options.
+func buildContextMenuCommandRequest(cc *models.CustomCommand) *discordgo.CreateApplicationCommandRequest {
+	cmdType := discordgo.UserApplicationCommand
+	if cc.TriggerType == int(CommandTriggerMessageContextMenu) {
+		cmdType = discordgo.MessageApplicationCommand
+	}
+
+	defaultPermission := true
+	return &discordgo.CreateApplicationCommandRequest{
+		Name:              strings.TrimSpace(cc.TextTrigger),
+		Type:              cmdType,
+		DefaultPermission: &defaultPermission,
+	}
+}
+
+// buildGuildContextMenuRequests fetches a guild's enabled context menu custom commands
+// and builds their registration requests, capping each type at its per-guild limit.
+func buildGuildContextMenuRequests(guildID int64) []*discordgo.CreateApplicationCommandRequest {
+	cmds, err := models.CustomCommands(
+		qm.Where("guild_id = ? AND disabled = false AND trigger_type IN (?, ?)", guildID, int(CommandTriggerUserContextMenu), int(CommandTriggerMessageContextMenu)),
+		qm.OrderBy("local_id asc"),
+	).AllG(context.Background())
+	if err != nil {
+		logger.WithField("guild", guildID).WithError(err).Error("failed fetching context menu ccs for resync")
+		return nil
+	}
+
+	max := MaxContextMenuForContext(guildID)
+	var userCount, msgCount int
+	set := make([]*discordgo.CreateApplicationCommandRequest, 0, len(cmds))
+	for _, cc := range cmds {
+		switch cc.TriggerType {
+		case int(CommandTriggerUserContextMenu):
+			if userCount >= max {
+				continue
+			}
+			userCount++
+		case int(CommandTriggerMessageContextMenu):
+			if msgCount >= max {
+				continue
+			}
+			msgCount++
+		default:
+			continue
+		}
+		set = append(set, buildContextMenuCommandRequest(cc))
+	}
+	return set
+}

--- a/customcommands/handle_slashcommand.go
+++ b/customcommands/handle_slashcommand.go
@@ -57,6 +57,13 @@ func handleSlashCommandInteraction(evt *eventsystem.EventData, cs *dstate.Channe
 		return
 	}
 
+	// USER (2) and MESSAGE (3) application commands are context menu commands and are
+	// handled separately; everything else is a slash (CHAT_INPUT) command.
+	if data.CommandType == discordgo.UserApplicationCommand || data.CommandType == discordgo.MessageApplicationCommand {
+		handleContextMenuInteraction(evt, cs, interaction)
+		return
+	}
+
 	cmds, err := BotCachedGetCommandsWithSlashTrigger(cs.GuildID, evt.Context())
 	if err != nil {
 		logger.WithField("guild", cs.GuildID).WithError(err).Error("failed fetching slash command ccs")
@@ -346,6 +353,11 @@ func resyncGuildSlashCommands(guildID int64) {
 	for _, cc := range cmds {
 		set = append(set, buildSlashCommandRequest(cc))
 	}
+
+	// Context menu (USER/MESSAGE) commands are also guild application commands and must
+	// be part of the same bulk overwrite, otherwise they'd clobber the slash commands
+	// (and vice-versa). They use a separate per-type limit.
+	set = append(set, buildGuildContextMenuRequests(guildID)...)
 
 	// Skip the (rate-limited) overwrite if the resulting command set is unchanged.
 	serialized, _ := json.Marshal(set)

--- a/customcommands/web.go
+++ b/customcommands/web.go
@@ -369,6 +369,19 @@ func serveGroupSelected(r *http.Request, templateData web.TemplateData, groupID 
 	}
 	templateData["SlashCommandLimitReached"] = slashCount >= MaxSlashCommandCCs
 
+	// Same, for the free-tier per-type context menu command limits.
+	userContextMenuCount, err := models.CustomCommands(qm.Where("guild_id = ? AND trigger_type = ? AND disabled = false", guildID, int(CommandTriggerUserContextMenu))).CountG(r.Context())
+	if err != nil {
+		return templateData, err
+	}
+	templateData["UserContextMenuLimitReached"] = userContextMenuCount >= MaxContextMenuCCs
+
+	messageContextMenuCount, err := models.CustomCommands(qm.Where("guild_id = ? AND trigger_type = ? AND disabled = false", guildID, int(CommandTriggerMessageContextMenu))).CountG(r.Context())
+	if err != nil {
+		return templateData, err
+	}
+	templateData["MessageContextMenuLimitReached"] = messageContextMenuCount >= MaxContextMenuCCs
+
 	// Same, for the free-tier role-change command limit.
 	roleTriggerCount, err := models.CustomCommands(qm.Where("guild_id = ? AND trigger_type = ? AND disabled = false", guildID, int(CommandTriggerRole))).CountG(r.Context())
 	if err != nil {
@@ -494,6 +507,12 @@ func handleNewCommand(w http.ResponseWriter, r *http.Request) (web.TemplateData,
 		if importCC.TriggerType == int(CommandTriggerSlash) {
 			data := parseSlashCommandData(dbModel)
 			if ok, _ := validateSlashCommandData(activeGuild.ID, dbModel.TextTrigger, data, dbModel.LocalID, !dbModel.Disabled); !ok {
+				http.Redirect(w, r, fmt.Sprintf("/manage/%d/customcommands?import_failed=true", activeGuild.ID), http.StatusSeeOther)
+				return templateData, nil
+			}
+		}
+		if IsContextMenuTrigger(CommandTriggerType(importCC.TriggerType)) {
+			if ok, _ := validateContextMenuData(activeGuild.ID, dbModel.TextTrigger, CommandTriggerType(importCC.TriggerType), dbModel.LocalID, !dbModel.Disabled); !ok {
 				http.Redirect(w, r, fmt.Sprintf("/manage/%d/customcommands?import_failed=true", activeGuild.ID), http.StatusSeeOther)
 				return templateData, nil
 			}
@@ -936,6 +955,10 @@ func triggerTypeFromForm(str string) CommandTriggerType {
 		return CommandTriggerRole
 	case "slash_command":
 		return CommandTriggerSlash
+	case "user_context_menu":
+		return CommandTriggerUserContextMenu
+	case "message_context_menu":
+		return CommandTriggerMessageContextMenu
 	default:
 		return CommandTriggerCommand
 
@@ -1107,6 +1130,7 @@ func EvictCustomCommandCache(guildID int64) {
 	pubsub.EvictCacheSet(cachedCommandsReactionTrigger, guildID)
 	pubsub.EvictCacheSet(cachedCommandsRoleTrigger, guildID)
 	pubsub.EvictCacheSet(cachedCommandsSlashTrigger, guildID)
+	pubsub.EvictCacheSet(cachedCommandsContextMenuTrigger, guildID)
 
 	// Rebuild the guild's registered slash commands on the owning bot node. This is
 	// a no-op (deduped via a redis hash) when the slash command set is unchanged, so

--- a/lib/discordgo/interactions.go
+++ b/lib/discordgo/interactions.go
@@ -300,9 +300,10 @@ type InteractionData interface {
 
 // ApplicationCommandInteractionData contains the data of application command interaction.
 type ApplicationCommandInteractionData struct {
-	ID       int64                                      `json:"id,string"`
-	Name     string                                     `json:"name"`
-	Resolved *ApplicationCommandInteractionDataResolved `json:"resolved"`
+	ID          int64                                      `json:"id,string"`
+	Name        string                                     `json:"name"`
+	CommandType ApplicationCommandType                     `json:"type"`
+	Resolved    *ApplicationCommandInteractionDataResolved `json:"resolved"`
 
 	// Slash command options
 	Options []*ApplicationCommandInteractionDataOption `json:"options"`

--- a/lib/discordgo/structs.go
+++ b/lib/discordgo/structs.go
@@ -1600,8 +1600,9 @@ type InviteUser struct {
 
 type CreateApplicationCommandRequest struct {
 	Name              string                      `json:"name"`                         // 1-32 character name matching ^[\w-]{1,32}$
-	Description       string                      `json:"description"`                  // 1-100 character description
-	Options           []*ApplicationCommandOption `json:"options"`                      // the parameters for the command
+	Type              ApplicationCommandType      `json:"type,omitempty"`               // defaults to CHAT_INPUT (1); 2=USER, 3=MESSAGE context menu
+	Description       string                      `json:"description,omitempty"`        // 1-100 character description (must be empty for context menu commands)
+	Options           []*ApplicationCommandOption `json:"options,omitempty"`            // the parameters for the command
 	DefaultPermission *bool                       `json:"default_permission,omitempty"` // (default true)	whether the command is enabled by default when the app is added to a guild
 	NSFW              bool                        `json:"nsfw,omitempty"`               // marks a command as age-restricted
 }
@@ -1614,10 +1615,12 @@ func (a *ApplicationCommandInteractionDataResolved) UnmarshalJSON(b []byte) erro
 	}
 
 	*a = ApplicationCommandInteractionDataResolved{
-		Users:    make(map[int64]*User),
-		Members:  make(map[int64]*Member),
-		Roles:    make(map[int64]*Role),
-		Channels: make(map[int64]*Channel),
+		Users:       make(map[int64]*User),
+		Members:     make(map[int64]*Member),
+		Roles:       make(map[int64]*Role),
+		Channels:    make(map[int64]*Channel),
+		Messages:    make(map[int64]*Message),
+		Attachments: make(map[int64]*MessageAttachment),
 	}
 
 	for k, v := range temp.Channels {
@@ -1652,14 +1655,32 @@ func (a *ApplicationCommandInteractionDataResolved) UnmarshalJSON(b []byte) erro
 		a.Users[parsed] = v
 	}
 
+	for k, v := range temp.Messages {
+		parsed, err := strconv.ParseInt(k, 10, 64)
+		if err != nil {
+			return err
+		}
+		a.Messages[parsed] = v
+	}
+
+	for k, v := range temp.Attachments {
+		parsed, err := strconv.ParseInt(k, 10, 64)
+		if err != nil {
+			return err
+		}
+		a.Attachments[parsed] = v
+	}
+
 	return nil
 }
 
 type applicationCommandInteractionDataResolvedTemp struct {
-	Users    map[string]*User    `json:"users"`
-	Members  map[string]*Member  `json:"members"`
-	Roles    map[string]*Role    `json:"roles"`
-	Channels map[string]*Channel `json:"channels"`
+	Users       map[string]*User              `json:"users"`
+	Members     map[string]*Member            `json:"members"`
+	Roles       map[string]*Role              `json:"roles"`
+	Channels    map[string]*Channel           `json:"channels"`
+	Messages    map[string]*Message           `json:"messages"`
+	Attachments map[string]*MessageAttachment `json:"attachments"`
 }
 
 type applicationCommandInteractionDataOptionTemporary struct {


### PR DESCRIPTION
This adds support for User Context Menu and Message Context Menu CCS that will show up as Apps -> Yagpdb.xyz -> command_name on the right click context menu on user or message. 

Like role CCs 
.Author is the person executing the command. 
.TargetUser / .TargetMember is the message author / user on the context menu. 
.Message doesn't exist on user context menu. 
.Channel for user context menu is the channel which was open when the user was clicked. 