### PR TITLE
evalcc: use templates.ctx.MessageSend for response

### DIFF
--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -101,7 +101,7 @@ var cmdEvalCommand = &commands.YAGCommand{
 	},
 	SlashCommandEnabled: false,
 	DefaultEnabled:      true,
-	RunFunc: func(data *dcmd.Data) (interface{}, error) {
+	RunFunc: func(data *dcmd.Data) (any, error) {
 		hasCoreWriteRole := false
 
 		writeRoles := common.GetCoreServerConfCached(data.GuildData.GS.ID).AllowedWriteRoles
@@ -147,7 +147,9 @@ var cmdEvalCommand = &commands.YAGCommand{
 			return formatCustomCommandRunErr(code, err), err
 		}
 
-		return out, nil
+		msg := ctx.MessageSend(out)
+
+		return msg, nil
 	},
 }
 


### PR DESCRIPTION
This enables `evalcc` to be even closer to custom commands -- this time,
we're respecting the effects of `mentionRole` and friends who set
ctx.CurrentFrame.MentionRoles, which is then used by ctx.MessageSend to
populate fields like `allowed_mentions`.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
