### PR TITLE
confusables: fix erroneous collapse of '+' in command output

### DIFF
--- a/common/invites.go
+++ b/common/invites.go
@@ -28,9 +28,9 @@ var ThirdpartyDiscordSites = []*InviteSource{
 var AllInviteSources = append([]*InviteSource{DiscordInviteSource}, ThirdpartyDiscordSites...)
 
 func ReplaceServerInvites(msg string, guildID int64, replacement string) string {
+	msg = confusables.NormalizeQueryEncodedText(msg)
 
 	for _, s := range AllInviteSources {
-		msg = confusables.NormalizeQueryEncodedText(msg)
 		msg = s.Regex.ReplaceAllString(msg, replacement)
 	}
 

--- a/lib/confusables/confusables.go
+++ b/lib/confusables/confusables.go
@@ -29,7 +29,7 @@ func SanitizeText(content string) string {
 // Normalizes QueryEscaped content in a string.
 // Example: "Hello%20World%20%"" will be normalized to "Hello World "
 func NormalizeQueryEncodedText(content string) string {
-	decoded, err := url.QueryUnescape(content)
+	decoded, err := url.PathUnescape(content)
 	if err != nil {
 		decoded = content
 	}


### PR DESCRIPTION
The confusables.NormalizeQueryEncodedText erroneously calls
url.QueryUnescape, when it should be calling url.PathUnescape. These
effectively do the same thing, but PathUnescape is a little more
conservative, as it doesn't collapse `+` to a single space ` `.

Without this fix, this minimal reproducer is broken:

`-evalcc "+ ---- + ---- +"`
    => `   ----  ----   ` (with spaces trimmed as discord does)

Additionally, some command output itself might break; see e.g.
https://discord.com/channels/166207328570441728/1510505142666006568/1530982688532598814

While we're here, call NormalizeQueryEncodedText only once instead of
for every invite source. We only need to normalise once.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
