### PR TITLE
Fix guild specific application commands being seen as global commands

### DIFF
--- a/commands/slashcommands.go
+++ b/commands/slashcommands.go
@@ -392,6 +392,11 @@ func handleInteractionCreate(evt *eventsystem.EventData) {
 		return
 	}
 
+	//if guildID is present then this is a guild custom slash cmmand
+	if interaction.DataCommand.GuildID != 0 {
+		return
+	}
+
 	// serialized, _ := json.MarshalIndent(interaction.Interaction, "", "  ")
 	// logger.Infof("Got interaction %#v", interaction.Interaction)
 	// fmt.Println(string(serialized))

--- a/customcommands/handle_slashcommand.go
+++ b/customcommands/handle_slashcommand.go
@@ -53,7 +53,7 @@ func BotCachedGetCommandsWithSlashTrigger(guildID int64, ctx context.Context) ([
 // handleInteractionCreate for InteractionApplicationCommand interactions.
 func handleSlashCommandInteraction(evt *eventsystem.EventData, cs *dstate.ChannelState, interaction *templates.CustomCommandInteraction) {
 	data := interaction.DataCommand
-	if data == nil || interaction.Member == nil {
+	if data == nil || data.GuildID == 0 || interaction.Member == nil {
 		return
 	}
 

--- a/lib/discordgo/interactions.go
+++ b/lib/discordgo/interactions.go
@@ -305,6 +305,11 @@ type ApplicationCommandInteractionData struct {
 	CommandType ApplicationCommandType                     `json:"type"`
 	Resolved    *ApplicationCommandInteractionDataResolved `json:"resolved"`
 
+	// GuildID is the id of the guild the invoked command is registered to. It is only
+	// set for guild-scoped commands and omitted (0) for global commands, so it can be
+	// used to tell whether the interaction is for a guild command or a global one.
+	GuildID int64 `json:"guild_id,string"`
+
 	// Slash command options
 	Options []*ApplicationCommandInteractionDataOption `json:"options"`
 	// Target (user/message) id on which context menu command was called.


### PR DESCRIPTION
… with an assumption that guild scoped application commands will always be custom commands

<!-- Please describe the changes this PR makes -->

<!-- 
If this Pull Request requires documentation changes, consider raising a PR
to our documentation at https://github.com/botlabs-gg/yagpdb-docs-v2 as well.
Please cross-link the PR below this comment if you do so.
Alternatively, you can also just create an issue over there.
-->
