### PR TITLE
discordgo: add message attachment flags

### DIFF
--- a/lib/discordgo/message.go
+++ b/lib/discordgo/message.go
@@ -414,14 +414,25 @@ func (m *MessageEdit) SetEmbeds(embeds []*MessageEmbed) *MessageEdit {
 
 // A MessageAttachment stores data for message attachments.
 type MessageAttachment struct {
-	ID       string `json:"id"`
-	URL      string `json:"url"`
-	ProxyURL string `json:"proxy_url"`
-	Filename string `json:"filename"`
-	Width    int    `json:"width"`
-	Height   int    `json:"height"`
-	Size     int    `json:"size"`
+	ID       string                 `json:"id"`
+	URL      string                 `json:"url"`
+	ProxyURL string                 `json:"proxy_url"`
+	Filename string                 `json:"filename"`
+	Width    int                    `json:"width"`
+	Height   int                    `json:"height"`
+	Size     int                    `json:"size"`
+	Flags    MessageAttachmentFlags `json:"flags"`
 }
+
+type MessageAttachmentFlags int
+
+const (
+	MessageAttachmentFlagIsClip = 1 << iota
+	MessageAttachmentFlagIsThumbnail
+	MessageAttachmentFlagIsRemix
+	MessageAttachmentFlagIsSpoiler
+	MessageAttachmentFlagIsAnimated
+)
 
 // MessageEmbedFooter is a part of a MessageEmbed struct.
 type MessageEmbedFooter struct {


### PR DESCRIPTION
Add the newly introduced message attachment flags[0]. Without this
change, users will only be able to detect a spoilered file when it is
using the legacy `SPOILER_` prefix, which not every spoilered file will
have. In custom command terms, it would look something like this:

```yag
{{ $ma := index .Message.Attachments 0 }}
{{/* a spoilered file has the third bit set: 1 << 3 */}}
{{ $mask := bitwiseLeftShift 1 3 }} 
{{/* The flag is set when: ($ma.Flags & $mask) != 0 */}}
{{ $is_spoiler := ne (bitwiseAnd $a.Flags $mask) 0 }}
```

[0]: https://docs.discord.com/developers/resources/message#attachment-object-attachment-flags

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
