### PR TITLE
Added 'Colors' as both a struct and an element of 'Role'

### DIFF
--- a/lib/discordgo/structs.go
+++ b/lib/discordgo/structs.go
@@ -694,6 +694,13 @@ type GuildParams struct {
 	Splash                      string             `json:"splash,omitempty"`
 }
 
+// A Colors holds information about a Discord guild role's colors
+type Colors struct {
+  PrimaryColor int32 `json:"primary_color"`
+  SecondaryColor int32 `json:"secondary_color"`
+  TertiaryColor int32 `json:"tertiary_color"`
+}
+
 // A Role stores information about Discord guild member roles.
 type Role struct {
 	// The ID of the role.
@@ -712,8 +719,11 @@ type Role struct {
 	// Whether this role is hoisted (shows up separately in member list).
 	Hoist bool `json:"hoist"`
 
-	// The hex color of this role.
+	// The hex color of this role (deprecated).
 	Color int `json:"color"`
+
+	// The colors for this role
+	Colors *Colors `json:"colors"`
 
 	// The position of this role in the guild's role hierarchy.
 	Position int `json:"position"`

--- a/lib/discordgo/structs.go
+++ b/lib/discordgo/structs.go
@@ -719,7 +719,7 @@ type Role struct {
 	// Whether this role is hoisted (shows up separately in member list).
 	Hoist bool `json:"hoist"`
 
-	// The hex color of this role (deprecated).
+	// Deprecated: The hex color of this role.
 	Color int `json:"color"`
 
 	// The colors for this role


### PR DESCRIPTION
As per Discord's documentation, the 'Color' element that is provided by the Role struct is now considered deprecated. The new way to access the primary color of a role is through the element 'Colors'. Colors is itself a struct that contains the primary, secondary and tertiary colors of the role. Even if a role does not have all colors, all elements will be present in the struct. If a role doesn't have a particular color, it will simply return 'null'.

Additionally, 'Color' has been properly labeled as deprecated in the comment directly above the element.