### PR TITLE
templates: default to short TextInput style

### DIFF
--- a/common/templates/components.go
+++ b/common/templates/components.go
@@ -55,7 +55,7 @@ func CreateComponent(expectedType discordgo.ComponentType, values ...any) (disco
 		err = json.Unmarshal(encoded, &comp)
 		component = comp
 	case discordgo.TextInputComponent:
-		var comp discordgo.TextInput
+		comp := discordgo.NewShortTextInput()
 		err = json.Unmarshal(encoded, &comp)
 		component = comp
 	case discordgo.UserSelectMenuComponent:
@@ -460,7 +460,7 @@ func CreateTextInput(values ...any) (*discordgo.TextInput, error) {
 		}
 		messageSdict = dict
 	}
-	var textInput discordgo.TextInput
+
 	convertedTextInput := make(map[string]any)
 	for k, v := range messageSdict {
 		switch strings.ToLower(k) {
@@ -476,6 +476,8 @@ func CreateTextInput(values ...any) (*discordgo.TextInput, error) {
 	}
 
 	t, err := CreateComponent(discordgo.TextInputComponent, convertedTextInput)
+
+	var textInput discordgo.TextInput
 	if err == nil {
 		textInput = t.(discordgo.TextInput)
 	}

--- a/lib/discordgo/components.go
+++ b/lib/discordgo/components.go
@@ -381,6 +381,12 @@ type TextInput struct {
 	MaxLength   int            `json:"max_length,omitempty"`
 }
 
+func NewShortTextInput() TextInput {
+	return TextInput{
+		Style: TextInputShort,
+	}
+}
+
 // Type is a method to get the type of a component.
 func (TextInput) Type() ComponentType {
 	return TextInputComponent


### PR DESCRIPTION
The default style for `ctextInput` used to be set to short, but since
the introduction of v2, it is now set to 0. This means that users are
required to provide a style field, which is unnecesary.

See https://discord.com/channels/166207328570441728/356486960417734666/1529998357773160470
