### PR TITLE
fix interval CC run now rendering the edit page into the list page

### DIFF
--- a/customcommands/assets/customcommands.html
+++ b/customcommands/assets/customcommands.html
@@ -163,7 +163,8 @@
                 <div class="pull-right">
                     {{if and (eq .TriggerType 5) (not .Disabled) }}
                         <button type="submit" class="btn btn-secondary" title="This will trigger this custom command immediately"
-                        formaction="/manage/{{$guild}}/customcommands/commands/{{.LocalID}}/run_now" style="margin: 5px 5px 5px 0px!important">Run now</button>
+                        formaction="/manage/{{$guild}}/customcommands/commands/{{.LocalID}}/run_now"
+                        data-async-form-alertsonly style="margin: 5px 5px 5px 0px!important">Run now</button>
                     {{end}}
                     <button type="button" title="#{{.LocalID}} - {{.TextTrigger}}" class="btn btn-success" onclick="window.location.href = '/manage/{{$guild}}/customcommands/commands/{{.LocalID}}/';" style="margin: 5px 5px 5px 0px!important">Edit</button>
                     <button type="submit" title="#{{.LocalID}} - {{.TextTrigger}}" class="btn btn-danger" formaction="/manage/{{$guild}}/customcommands/commands/{{.LocalID}}/delete" style="margin: 5px 5px 5px 0px!important">Delete</button>

--- a/customcommands/web.go
+++ b/customcommands/web.go
@@ -140,7 +140,7 @@ func (p *Plugin) InitWeb() {
 	subMux.Handle(pat.Post("/commands/new"), newCommandHandler)
 	subMux.Handle(pat.Post("/commands/:cmd/update"), web.ControllerPostHandler(handleUpdateCommand, getCmdHandler, CustomCommand{}))
 	subMux.Handle(pat.Post("/commands/:cmd/delete"), web.ControllerPostHandler(handleDeleteCommand, getHandler, nil))
-	subMux.Handle(pat.Post("/commands/:cmd/run_now"), web.ControllerPostHandler(handleRunCommandNow, getCmdHandler, nil))
+	subMux.Handle(pat.Post("/commands/:cmd/run_now"), web.ControllerPostHandler(handleRunCommandNow, getHandler, nil))
 	subMux.Handle(pat.Post("/commands/:cmd/update_and_run"), web.ControllerPostHandler(handleUpdateAndRunNow, getCmdHandler, CustomCommand{}))
 	subMux.Handle(pat.Post("/commands/import/:cmd"), PublicCommandMW(newCommandHandler))
 


### PR DESCRIPTION
c44e5f1a gave the edit page's Run now (update_and_run) the data-async-form-alertsonly attribute but not the commands list page's (run_now), so that one still took the full partial-render path: the POST went out without alertsonly=1, ControllerPostHandler's extra handler rendered the edit command page, and navigate() dropped that into #main-content of the list or group page. The URL stayed on the group page while the body read "Editing Custom Command #123", with the injected page's init JS never having run, so every trigger description showed at once and the response length counter stayed uninitialized.

Also point the run_now route's extra handler at the commands list rather than the edit page, so a rendered response lands on the page the request came from if it is ever reached without JS.

<!-- Please describe the changes this PR makes -->

<!-- 
If this Pull Request requires documentation changes, consider raising a PR
to our documentation at https://github.com/botlabs-gg/yagpdb-docs-v2 as well.
Please cross-link the PR below this comment if you do so.
Alternatively, you can also just create an issue over there.
-->
