### PR TITLE
fix all caps trigger never firing on regular messages

### DIFF
--- a/automod/triggers.go
+++ b/automod/triggers.go
@@ -492,17 +492,17 @@ func (caps *AllCapsTrigger) UserSettings() []*SettingDef {
 func (caps *AllCapsTrigger) CheckMessage(triggerCtx *TriggerContext, cs *dstate.ChannelState, m *discordgo.Message) (bool, error) {
 	dataCast := triggerCtx.Data.(*AllCapsTriggerData)
 
-	if len(m.GetMessageContents()) < dataCast.MinLength {
+	messageContent := strings.Join(m.GetMessageContents(), " ")
+	if len(messageContent) < dataCast.MinLength {
 		return false, nil
+	}
+
+	if dataCast.SanitizeText {
+		messageContent = confusables.SanitizeText(messageContent)
 	}
 
 	totalCapitalisableChars := 0
 	numCaps := 0
-
-	messageContent := strings.Join(m.GetMessageContents(), "")
-	if dataCast.SanitizeText {
-		messageContent = confusables.SanitizeText(messageContent)
-	}
 
 	// count the number of upper case characters, note that this dosen't include other characters such as punctuation
 	for _, r := range messageContent {


### PR DESCRIPTION
Support for message forwards swapped len(m.Content) for len(m.GetMessageContents()), which is the number of content pieces (message plus one per forwarded snapshot) rather than the length of the text. At the default MinLength of 3 a plain message has len 1, so the trigger bailed out before counting any caps and only fired on messages carrying two or more forwards.

Join the contents first and length-check the actual text, keeping the gate on the raw text as it was before sanitization.

<!-- Please describe the changes this PR makes -->

<!-- 
If this Pull Request requires documentation changes, consider raising a PR
to our documentation at https://github.com/botlabs-gg/yagpdb-docs-v2 as well.
Please cross-link the PR below this comment if you do so.
Alternatively, you can also just create an issue over there.
-->
