### PR TITLE
fixed bulk role require ALL toggle and standardize its form parsing and improved message for Require ALL toggle. 

### DIFF
--- a/bulkrole/assets/bulkrole.html
+++ b/bulkrole/assets/bulkrole.html
@@ -80,7 +80,7 @@
                                                     </tr>
                                                     <tr>
                                                         <th scope="row" class="text-danger">Match Criteria</th>
-                                                        <td class="text-warning">{{if .CurrentOperation.FilterRequireAll}}Must match ALL{{else}}Must match ANY{{end}}</td>
+                                                        <td class="text-warning">{{.CurrentOperation.MatchCriteria}}</td>
                                                     </tr>
                                                 {{end}}
                                             {{end}}
@@ -213,8 +213,9 @@
                                             class="multiselect form-control" multiple="multiple">
                                             {{roleOptionsMultiExclude .ActiveGuild.Roles nil nil .BulkRole.FilterRoleIDs}}
                                         </select>
-                                        <div class="form-group mt-2">
+                                        <div class="form-group mt-2" id="filter-require-all-group">
                                             {{checkbox "FilterRequireAll" "FilterRequireAll" "Require ALL selected roles" $.BulkRole.FilterRequireAll}}
+                                            <small id="filter-require-all-hint" class="form-text text-muted"></small>
                                         </div>
                                     </div>
                                     <div class="form-group" id="filter-date-group" {{if eq $.BulkRole.FilterType "joined_after" "joined_before"}} {{else}} style="display: none;" {{end}}>
@@ -285,6 +286,7 @@
             // Show relevant filter group only for filter types that need additional input
             if (selectedValue === 'has_roles' || selectedValue === 'missing_roles') {
                 filterRoleGroup.style.display = 'block';
+                updateRequireAllLabel(selectedValue);
             } else if (selectedValue === 'joined_after' || selectedValue === 'joined_before') {
                 filterDateGroup.style.display = 'block';
             }
@@ -292,6 +294,25 @@
 
             // Update start button state
             updateStartButton();
+        }
+
+        // Off is the loose match under either filter type, and under "missing" it is
+        // loose enough to match nearly the whole server - spell out both states so
+        // the toggle cannot be read backwards.
+        function updateRequireAllLabel(filterType) {
+            const desc = document.querySelector('#filter-require-all-group .tgl-desc');
+            const hint = document.getElementById('filter-require-all-hint');
+            if (!desc || !hint) return;
+
+            if (filterType === 'missing_roles') {
+                desc.textContent = 'Require ALL selected roles to be missing';
+                hint.textContent = 'On: matches only members who have none of the selected roles.'
+                    + ' Off: matches members missing at least one of them, which is almost everyone.';
+            } else {
+                desc.textContent = 'Require ALL selected roles';
+                hint.textContent = 'On: matches only members who have every selected role.'
+                    + ' Off: matches members who have at least one of them.';
+            }
         }
 
         function updateStartButton() {

--- a/bulkrole/bot.go
+++ b/bulkrole/bot.go
@@ -178,7 +178,31 @@ func (config *BulkRoleConfig) processBulkRoleChunk(chunk *discordgo.GuildMembers
 	}
 }
 
-// Check if a member meets the filter criteria
+func hasAllRoles(member *discordgo.Member, roleIDs []int64) bool {
+	for _, roleID := range roleIDs {
+		if !slices.Contains(member.Roles, roleID) {
+			return false
+		}
+	}
+	return true
+}
+
+func hasAnyRole(member *discordgo.Member, roleIDs []int64) bool {
+	for _, roleID := range roleIDs {
+		if slices.Contains(member.Roles, roleID) {
+			return true
+		}
+	}
+	return false
+}
+
+// Check if a member meets the filter criteria.
+//
+// FilterRequireAll decides whether the filter's condition has to hold for every
+// selected role or just one of them:
+//
+//	has_roles      off: has any one of them          on: has all of them
+//	missing_roles  off: is missing any one of them   on: is missing all of them
 func (config *BulkRoleConfig) filterMember(member *discordgo.Member) bool {
 	switch config.FilterType {
 	case "all":
@@ -188,39 +212,17 @@ func (config *BulkRoleConfig) filterMember(member *discordgo.Member) bool {
 			return false
 		}
 		if config.FilterRequireAll {
-			for _, roleID := range config.FilterRoleIDs {
-				if !slices.Contains(member.Roles, roleID) {
-					return false
-				}
-			}
-			return true
-		} else {
-			for _, roleID := range config.FilterRoleIDs {
-				if slices.Contains(member.Roles, roleID) {
-					return true
-				}
-			}
-			return false
+			return hasAllRoles(member, config.FilterRoleIDs)
 		}
+		return hasAnyRole(member, config.FilterRoleIDs)
 	case "missing_roles":
 		if len(config.FilterRoleIDs) == 0 {
 			return false
 		}
 		if config.FilterRequireAll {
-			for _, roleID := range config.FilterRoleIDs {
-				if slices.Contains(member.Roles, roleID) {
-					return false
-				}
-			}
-			return true
-		} else {
-			for _, roleID := range config.FilterRoleIDs {
-				if !slices.Contains(member.Roles, roleID) {
-					return true
-				}
-			}
-			return false
+			return !hasAnyRole(member, config.FilterRoleIDs)
 		}
+		return !hasAllRoles(member, config.FilterRoleIDs)
 	case "bots":
 		return member.User.Bot
 	case "humans":
@@ -398,13 +400,7 @@ func (config *BulkRoleConfig) filterRoleString(prefix string) string {
 		return prefix
 	}
 
-	// Build the suffix first
-	var suffix string
-	if config.FilterRequireAll {
-		suffix = " (must have ALL)"
-	} else {
-		suffix = " (must have ANY)"
-	}
+	suffix := " (" + config.matchCriteriaText() + ")"
 
 	// Start building the role list
 	roleText := prefix + ": "
@@ -454,6 +450,22 @@ func (config *BulkRoleConfig) filterRoleString(prefix string) string {
 
 	roleText += strings.Join(addedRoles, ", ") + suffix
 	return roleText
+}
+
+// matchCriteriaText describes what the ALL/ANY toggle means for the configured
+// filter type, see filterMember.
+func (config *BulkRoleConfig) matchCriteriaText() string {
+	if config.FilterType == "missing_roles" {
+		if config.FilterRequireAll {
+			return "must have none of the selected roles"
+		}
+		return "must be missing at least one selected role"
+	}
+
+	if config.FilterRequireAll {
+		return "must have all of the selected roles"
+	}
+	return "must have at least one of the selected roles"
 }
 
 func (config *BulkRoleConfig) filterString() string {
@@ -508,13 +520,11 @@ func (config *BulkRoleConfig) sendNotificationAlert(status string, processedCoun
 	if len(filterString) > 1024 {
 		switch config.FilterType {
 		case "has_roles":
-			filterString = fmt.Sprintf("Has %d specific roles (too many to display)%s",
-				len(config.FilterRoleIDs),
-				map[bool]string{true: " (must have ALL)", false: " (must have ANY)"}[config.FilterRequireAll])
+			filterString = fmt.Sprintf("Has %d specific roles (too many to display) (%s)",
+				len(config.FilterRoleIDs), config.matchCriteriaText())
 		case "missing_roles":
-			filterString = fmt.Sprintf("Missing %d specific roles (too many to display)%s",
-				len(config.FilterRoleIDs),
-				map[bool]string{true: " (must be missing ALL)", false: " (must be missing ANY)"}[config.FilterRequireAll])
+			filterString = fmt.Sprintf("Missing %d specific roles (too many to display) (%s)",
+				len(config.FilterRoleIDs), config.matchCriteriaText())
 		default:
 			filterString = config.FilterType
 		}

--- a/bulkrole/bulkrole.go
+++ b/bulkrole/bulkrole.go
@@ -35,14 +35,19 @@ func RegisterPlugin() {
 	common.RegisterPlugin(p)
 }
 
+var (
+	validOperations  = []string{"assign", "remove"}
+	validFilterTypes = []string{"all", "has_roles", "missing_roles", "bots", "humans", "joined_after", "joined_before"}
+)
+
 type BulkRoleConfig struct {
 	TargetRole int64 `json:",string" valid:"role,true"`
 
-	Operation string `valid:"in(assign|remove)"`
+	Operation string
 
-	FilterType string `valid:"in(all|has_role|missing_role|bots|humans|joined_after|joined_before)"`
+	FilterType string
 
-	FilterRoleIDs    []int64   `json:",omitempty"`
+	FilterRoleIDs    []int64   `json:",omitempty" valid:"role,true"`
 	FilterRequireAll bool      `json:"boolean,omitempty"`
 	FilterDate       string    `json:",omitempty"`
 	FilterDateParsed time.Time `json:"-"`

--- a/bulkrole/filter_test.go
+++ b/bulkrole/filter_test.go
@@ -1,0 +1,67 @@
+package bulkrole
+
+import (
+	"testing"
+
+	"github.com/botlabs-gg/yagpdb/v2/lib/discordgo"
+)
+
+func TestFilterMemberRoleFilters(t *testing.T) {
+	const (
+		roleA int64 = 1
+		roleB int64 = 2
+		roleC int64 = 3
+		roleD int64 = 4
+		other int64 = 99
+	)
+	filterRoles := []int64{roleA, roleB, roleC, roleD}
+
+	member := func(roles ...int64) *discordgo.Member {
+		return &discordgo.Member{Roles: roles, User: &discordgo.User{ID: 1234}}
+	}
+
+	tests := []struct {
+		name       string
+		filterType string
+		requireAll bool
+		member     *discordgo.Member
+		want       bool
+	}{
+		{"missing, toggle on, holds none of them", "missing_roles", true, member(other), true},
+		{"missing, toggle on, no roles at all", "missing_roles", true, member(), true},
+		{"missing, toggle on, holds one of them", "missing_roles", true, member(other, roleB), false},
+		{"missing, toggle on, holds all four", "missing_roles", true, member(roleA, roleB, roleC, roleD), false},
+
+		{"missing, toggle off, holds none of them", "missing_roles", false, member(other), true},
+		{"missing, toggle off, holds one of them", "missing_roles", false, member(other, roleB), true},
+		{"missing, toggle off, holds three of them", "missing_roles", false, member(roleA, roleB, roleC), true},
+		{"missing, toggle off, holds all four", "missing_roles", false, member(roleA, roleB, roleC, roleD), false},
+
+		{"has, toggle on, holds all four", "has_roles", true, member(roleA, roleB, roleC, roleD), true},
+		{"has, toggle on, holds three of them", "has_roles", true, member(roleA, roleB, roleC), false},
+		{"has, toggle off, holds one of them", "has_roles", false, member(roleB), true},
+		{"has, toggle off, holds none of them", "has_roles", false, member(other), false},
+
+		{"missing, no filter roles selected", "missing_roles", true, member(other), false},
+		{"has, no filter roles selected", "has_roles", true, member(roleA), false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			roles := filterRoles
+			if tc.name == "missing, no filter roles selected" || tc.name == "has, no filter roles selected" {
+				roles = nil
+			}
+
+			config := &BulkRoleConfig{
+				FilterType:       tc.filterType,
+				FilterRoleIDs:    roles,
+				FilterRequireAll: tc.requireAll,
+			}
+
+			if got := config.filterMember(tc.member); got != tc.want {
+				t.Errorf("filterMember() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/bulkrole/web.go
+++ b/bulkrole/web.go
@@ -6,6 +6,7 @@ import (
 	"html"
 	"html/template"
 	"net/http"
+	"slices"
 	"strconv"
 	"time"
 
@@ -32,7 +33,38 @@ type Form struct {
 	BulkRoleConfig `valid:"traverse"`
 }
 
-var _ web.SimpleConfigSaver = (*Form)(nil)
+var (
+	_ web.SimpleConfigSaver = (*Form)(nil)
+	_ web.CustomValidator   = (*Form)(nil)
+)
+
+func (f *Form) Validate(tmpl web.TemplateData, guildID int64) bool {
+	ok := true
+
+	if f.TargetRole == 0 {
+		tmpl.AddAlerts(web.ErrorAlert("Please select a target role"))
+		ok = false
+	}
+
+	if !slices.Contains(validOperations, f.Operation) {
+		tmpl.AddAlerts(web.ErrorAlert("Please select an operation"))
+		ok = false
+	}
+
+	if !slices.Contains(validFilterTypes, f.FilterType) {
+		tmpl.AddAlerts(web.ErrorAlert("Please select a filter type"))
+		ok = false
+	}
+
+	if f.FilterDate != "" {
+		if _, err := time.Parse("2006-01-02", f.FilterDate); err != nil {
+			tmpl.AddAlerts(web.ErrorAlert("Invalid date format. Use YYYY-MM-DD"))
+			ok = false
+		}
+	}
+
+	return ok
+}
 
 var (
 	panelLogKeyStartedOperation   = cplogs.RegisterActionFormat(&cplogs.ActionFormat{Key: "bulkrole_started_operation", FormatString: "Started bulk role operation"})
@@ -107,8 +139,9 @@ func (p *Plugin) InitWeb() {
 
 	muxer.Handle(pat.Post("/cancel"), web.ControllerPostHandler(handlePostCancelOperation, getHandler, nil))
 
-	muxer.Handle(pat.Post(""), web.ControllerPostHandler(handlePostSaveAndStart, getHandler, nil))
-	muxer.Handle(pat.Post("/"), web.ControllerPostHandler(handlePostSaveAndStart, getHandler, nil))
+	saveAndStartHandler := web.ControllerPostHandler(handlePostSaveAndStart, getHandler, Form{})
+	muxer.Handle(pat.Post(""), saveAndStartHandler)
+	muxer.Handle(pat.Post("/"), saveAndStartHandler)
 }
 
 func handleGetBulkRoleMainPage(w http.ResponseWriter, r *http.Request) interface{} {
@@ -187,6 +220,7 @@ func handleGetBulkRoleMainPage(w http.ResponseWriter, r *http.Request) interface
 			"FilterType":          general.FilterType,
 			"FilterRoleIDs":       general.FilterRoleIDs,
 			"FilterRequireAll":    general.FilterRequireAll,
+			"MatchCriteria":       general.matchCriteriaText(),
 			"FilterDate":          general.FilterDate,
 			"NotificationChannel": general.NotificationChannel,
 			"StartedBy":           general.StartedBy,
@@ -205,57 +239,15 @@ func handlePostSaveAndStart(w http.ResponseWriter, r *http.Request) (web.Templat
 		return tmpl.AddAlerts(web.ErrorAlert("Bulk Role Manager is premium only")), nil
 	}
 
-	err := r.ParseForm()
-	if err != nil {
-		return tmpl.AddAlerts(web.ErrorAlert("Failed to parse form data")), nil
-	}
+	form := ctx.Value(common.ContextKeyParsedForm).(*Form)
+	user := web.ContextUser(ctx)
+	form.StartedBy = user.ID
+	form.StartedByUsername = user.String()
 
-	user := web.ContextUser(r.Context())
-
-	// Debug: Log the raw form values for FilterRoleIDs
-	logger.WithField("guild", activeGuild.ID).WithField("filterRoleIDs_raw", r.Form["FilterRoleIDs"]).Info("Processing FilterRoleIDs from form")
-
-	config := &BulkRoleConfig{
-		TargetRole:          parseFormInt64(r.FormValue("TargetRole")),
-		Operation:           r.FormValue("Operation"),
-		FilterType:          r.FormValue("FilterType"),
-		FilterRoleIDs:       parseFormInt64Slice(r.Form["FilterRoleIDs"]),
-		FilterRequireAll:    r.FormValue("FilterRequireAll") == "true",
-		FilterDate:          r.FormValue("FilterDate"),
-		NotificationChannel: parseFormInt64(r.FormValue("NotificationChannel")),
-		StartedBy:           user.ID,
-		StartedByUsername:   user.String(),
-	}
-
-	// Debug: Log the parsed FilterRoleIDs
-	logger.WithField("guild", activeGuild.ID).WithField("filterRoleIDs_parsed", config.FilterRoleIDs).Info("Parsed FilterRoleIDs")
-
-	if config.FilterDate != "" {
-		parsed, err := time.Parse("2006-01-02", config.FilterDate)
-		if err != nil {
-			return tmpl.AddAlerts(web.ErrorAlert("Invalid date format. Use YYYY-MM-DD")), nil
-		}
-		config.FilterDateParsed = parsed
-	}
-
-	if config.TargetRole == 0 {
-		return tmpl.AddAlerts(web.ErrorAlert("Please select a target role")), nil
-	}
-
-	if config.Operation == "" {
-		return tmpl.AddAlerts(web.ErrorAlert("Please select an operation")), nil
-	}
-
-	if config.FilterType == "" {
-		return tmpl.AddAlerts(web.ErrorAlert("Please select a filter type")), nil
-	}
-
-	err = common.SetRedisJson(KeyGeneral(activeGuild.ID), config)
+	err := form.Save(activeGuild.ID)
 	if err != nil {
 		return tmpl.AddAlerts(web.ErrorAlert("Failed to save configuration")), nil
 	}
-
-	pubsub.EvictCacheSet(configCache, activeGuild.ID)
 
 	err = internalapi.PostWithGuild(activeGuild.ID, strconv.FormatInt(activeGuild.ID, 10)+"/bulkrole/start", nil, nil)
 	if err != nil {
@@ -265,29 +257,6 @@ func handlePostSaveAndStart(w http.ResponseWriter, r *http.Request) (web.Templat
 	go cplogs.RetryAddEntry(web.NewLogEntryFromContext(r.Context(), panelLogKeyStartedOperation))
 
 	return nil, nil
-}
-
-func parseFormInt64(value string) int64 {
-	if value == "" {
-		return 0
-	}
-	parsed, err := strconv.ParseInt(value, 10, 64)
-	if err != nil {
-		return 0
-	}
-	return parsed
-}
-
-func parseFormInt64Slice(values []string) []int64 {
-	var result []int64
-	for _, value := range values {
-		if value != "" && value != "0" {
-			if parsed, err := strconv.ParseInt(value, 10, 64); err == nil {
-				result = append(result, parsed)
-			}
-		}
-	}
-	return result
 }
 
 func handlePostCancelOperation(w http.ResponseWriter, r *http.Request) (web.TemplateData, error) {


### PR DESCRIPTION
"Require ALL selected roles" never took effect: the panel renders the toggle with the checkbox template helper, which emits no value attribute, so browsers submit "on" while the handler tested for "true". The flag could never be saved as true, leaving every filter stuck in the loose mode - for "Missing specific roles" that means "missing any one of the selected roles", which matches every member not holding all of them, i.e. effectively the whole server.

Route the save through FormParserMW instead of hand-parsing r.FormValue, which is how every other plugin reads its form - gorilla/schema's bool converter handles the "on" a checkbox actually sends. This drops the three local parseForm* helpers and puts the Form wrapper and its SimpleConfigSaver, both already present but unused, to work.

Along with that:

- Add valid:"role,true" to FilterRoleIDs so role IDs are checked against the guild and deduped, as parseFormInt64Slice was doing by hand.
- Drop valid:"in(...)" from Operation and FilterType. There is no "in" validator in this codebase; ValidateStringField knows template, regex, role, channel and "", and anything else falls into a default branch that logs UNKNOWN STRING TYPE IN VALIDATION and validates nothing. Replace them with a CustomValidator checking explicit allow-lists, which also corrects has_role/missing_role to the has_roles/ missing_roles the panel and filterMember actually use.

Matching behaviour is unchanged, but say what the toggle does at the point of choice, since one static label cannot describe both ends of "missing" and the loose state is the destructive one:

	Has specific roles      on: has every selected role
	                       off: has at least one of them
	Missing specific roles  on: has none of the selected roles
	                       off: missing at least one of them,
	                            which is almost everyone

The notification embed and the in-progress operation table now share one matchCriteriaText. The embed used "(must have ALL)"/"(must have ANY)" for both filter types, so a missing-roles run reported "Missing roles: @a, @b (must have ANY)".

Cover the four combinations with a test, since a filter that quietly matches the whole server is an expensive thing to get wrong.

<!-- Please describe the changes this PR makes -->

<!-- 
If this Pull Request requires documentation changes, consider raising a PR
to our documentation at https://github.com/botlabs-gg/yagpdb-docs-v2 as well.
Please cross-link the PR below this comment if you do so.
Alternatively, you can also just create an issue over there.
-->
