### PR TITLE
tennis: add a live scores command

### DIFF
--- a/stdcommands/stdcommands.go
+++ b/stdcommands/stdcommands.go
@@ -42,6 +42,7 @@ import (
 	"github.com/botlabs-gg/yagpdb/v2/stdcommands/sleep"
 	"github.com/botlabs-gg/yagpdb/v2/stdcommands/statedbg"
 	"github.com/botlabs-gg/yagpdb/v2/stdcommands/stateinfo"
+	"github.com/botlabs-gg/yagpdb/v2/stdcommands/tennis"
 	"github.com/botlabs-gg/yagpdb/v2/stdcommands/throw"
 	"github.com/botlabs-gg/yagpdb/v2/stdcommands/toggledbg"
 	"github.com/botlabs-gg/yagpdb/v2/stdcommands/topcommands"
@@ -122,8 +123,8 @@ var funCommandList = []*commands.YAGCommand{
 	eightball.Command, advice.Command, catfact.Command, dadjoke.Command,
 	dogfact.Command, define.Command, dictionary.Command, forex.Command,
 	howlongtobeat.Command, inspire.Command, roast.Command, roll.Command,
-	throw.Command, topic.Command, weather.Command, wouldyourather.Command,
-	xkcd.Command,
+	tennis.Command, throw.Command, topic.Command, weather.Command,
+	wouldyourather.Command, xkcd.Command,
 }
 
 func funCommands(p *Plugin) {

--- a/stdcommands/tennis/tennis.go
+++ b/stdcommands/tennis/tennis.go
@@ -1,0 +1,392 @@
+package tennis
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/botlabs-gg/yagpdb/v2/commands"
+	"github.com/botlabs-gg/yagpdb/v2/common/config"
+	"github.com/botlabs-gg/yagpdb/v2/lib/dcmd"
+	"github.com/botlabs-gg/yagpdb/v2/lib/discordgo"
+)
+
+// Live scores come from the Live Tennis API (https://livetennisapi.com), a
+// third-party commercial service. It needs an API key, so this command is
+// inert until the bot's host configures one:
+//
+//	YAGPDB_LIVETENNISAPI_API_KEY=<key>
+//
+// A NOTE ON PLANS, for whoever runs this bot. The vendor's free tier allows
+// 100 requests per day, which is not enough to serve a public bot: the live
+// board below is refreshed at most once every liveBoardTTL (60s), so a day in
+// which the command is used at least once a minute costs 24*60 = 1440
+// requests. Staying inside 100/day would mean a ~14.4 minute cache, which is
+// not "live" in any useful sense. Running this on a large public instance
+// therefore needs a paid plan; at the vendor's PRO tier (10,000/day) the 1440
+// worst case is about 14% of the daily budget, with plenty of headroom.
+//
+// The cost is flat in the number of guilds and users. One cached board serves
+// every guild, fetchLiveBoard collapses concurrent misses into a single
+// upstream request, and the player search filters that same cached board
+// instead of issuing a query of its own, so it costs no requests at all. What
+// bounds the quota is the cache; the per-user and per-guild Cooldown fields
+// below are there to stop command spam on the Discord side.
+var confAPIKey = config.RegisterOption("yagpdb.livetennisapi.api_key", "Live Tennis API key for the tennis command, from https://livetennisapi.com (a paid plan is required for a public bot, see stdcommands/tennis/tennis.go)", "")
+
+const (
+	liveBoardURL = "https://api.livetennisapi.com/api/public/v1/matches?status=live&limit=200"
+
+	// liveBoardTTL is how long a fetched board is served to every guild before
+	// another upstream request is made. See the plan note above before changing
+	// it: the worst-case daily request count is 24h / liveBoardTTL.
+	liveBoardTTL = time.Minute
+
+	// maxListedMatches caps the embed so a busy day cannot blow Discord's
+	// 4096-character description limit.
+	maxListedMatches = 20
+
+	embedColor = 0xc2ff4f
+)
+
+var httpClient = &http.Client{Timeout: 10 * time.Second}
+
+// player is one side of a match. For a doubles team, Name holds both surnames
+// separated by a slash.
+type player struct {
+	Name string `json:"name"`
+}
+
+// score mirrors the vendor's Score object. Every field the API documents as
+// nullable is modelled as a pointer, because they really are null in practice:
+// a match that has just completed is served with null points and empty games
+// arrays, so decoding points into a plain []string fails on live data.
+type score struct {
+	Games      [][]int   `json:"games"`  // player-major: [p1 per-set games, p2 per-set games]
+	Points     []*string `json:"points"` // "0","15","30","40","AD", or a plain integer count in a tiebreak; entries can be null
+	Server     *int      `json:"server"` // 1, 2 or null
+	IsTiebreak bool      `json:"is_tiebreak"`
+}
+
+type match struct {
+	Tournament string `json:"tournament"`
+	Players    struct {
+		P1 player `json:"p1"`
+		P2 player `json:"p2"`
+	} `json:"players"`
+	Score *score `json:"score"` // null before the first point of a match is scored
+}
+
+type matchListResponse struct {
+	Data []match `json:"data"`
+}
+
+var (
+	boardMu      sync.Mutex
+	cachedBoard  []match
+	cachedExpiry time.Time
+)
+
+var Command = &commands.YAGCommand{
+	CmdCategory:         commands.CategoryFun,
+	Name:                "Tennis",
+	Aliases:             []string{"atp", "wta"},
+	Description:         "🎾 Shows tennis matches that are in play right now, optionally only those featuring a given player.",
+	LongDescription:     "Live scores are provided by the Live Tennis API (https://livetennisapi.com) and are only available if the host of this bot has configured an API key.\n\nSet scores are shown from the first player's point of view, `●` marks the player serving, and `BP` marks a break point.",
+	RunInDM:             true,
+	Cooldown:            10,
+	GuildScopeCooldown:  5,
+	DefaultEnabled:      true,
+	SlashCommandEnabled: true,
+	Arguments: []*dcmd.ArgDef{
+		{Name: "Player", Type: dcmd.String, Help: "Only show matches featuring this player"},
+	},
+	RunFunc: func(data *dcmd.Data) (interface{}, error) {
+		matches, err := fetchLiveBoard()
+		if err != nil {
+			return nil, err
+		}
+
+		title := "🎾 Live tennis"
+		if query := strings.TrimSpace(data.Args[0].Str()); query != "" {
+			matches = filterByPlayer(matches, query)
+			title = fmt.Sprintf("🎾 Live tennis — %q", query)
+
+			if len(matches) == 0 {
+				return fmt.Sprintf("No live match featuring %q right now.", query), nil
+			}
+		}
+
+		if len(matches) == 0 {
+			return "No tennis matches are in play right now.", nil
+		}
+
+		return &discordgo.MessageEmbed{
+			Title:       title,
+			Description: formatBoard(matches, maxListedMatches),
+			Color:       embedColor,
+			Timestamp:   time.Now().UTC().Format(time.RFC3339),
+			Footer: &discordgo.MessageEmbedFooter{
+				Text: "livetennisapi.com",
+			},
+		}, nil
+	},
+}
+
+// fetchLiveBoard returns the live board, re-fetching it only once per
+// liveBoardTTL. The lock is deliberately held across the request so that a
+// burst of misses from different guilds results in one upstream call rather
+// than one per caller.
+func fetchLiveBoard() ([]match, error) {
+	apiKey := confAPIKey.GetString()
+	if apiKey == "" {
+		return nil, commands.NewPublicError("The tennis command is not available: the host of this bot has not configured a Live Tennis API key.")
+	}
+
+	boardMu.Lock()
+	defer boardMu.Unlock()
+
+	if time.Now().Before(cachedExpiry) {
+		return cachedBoard, nil
+	}
+
+	matches, err := requestLiveBoard(apiKey)
+	if err != nil {
+		return nil, err
+	}
+
+	cachedBoard = matches
+	cachedExpiry = time.Now().Add(liveBoardTTL)
+	return cachedBoard, nil
+}
+
+func requestLiveBoard(apiKey string) ([]match, error) {
+	req, err := http.NewRequest("GET", liveBoardURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("User-Agent", "YAGPDB.xyz (https://github.com/botlabs-gg/yagpdb)")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return nil, commands.NewPublicError("The tennis command is not available: this bot's Live Tennis API key was rejected.")
+	case http.StatusTooManyRequests:
+		return nil, commands.NewPublicError("This bot has run out of Live Tennis API requests for now, try again later.")
+	default:
+		return nil, commands.NewPublicErrorF("Failed fetching live scores (HTTP %d), try again later.", resp.StatusCode)
+	}
+
+	var parsed matchListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, err
+	}
+
+	return parsed.Data, nil
+}
+
+// filterByPlayer keeps matches where either side's name contains query,
+// case-insensitively. It reads the cached board, so it costs no API requests.
+func filterByPlayer(matches []match, query string) []match {
+	if query == "" {
+		return matches
+	}
+
+	needle := strings.ToLower(query)
+	out := make([]match, 0, len(matches))
+	for _, m := range matches {
+		if strings.Contains(strings.ToLower(m.Players.P1.Name), needle) ||
+			strings.Contains(strings.ToLower(m.Players.P2.Name), needle) {
+			out = append(out, m)
+		}
+	}
+
+	return out
+}
+
+// formatBoard renders the board grouped by tournament, one line per match.
+func formatBoard(matches []match, limit int) string {
+	shown := matches
+	omitted := 0
+	if len(shown) > limit {
+		omitted = len(shown) - limit
+		shown = shown[:limit]
+	}
+
+	byTournament := make(map[string][]match)
+	for _, m := range shown {
+		byTournament[m.Tournament] = append(byTournament[m.Tournament], m)
+	}
+
+	tournaments := make([]string, 0, len(byTournament))
+	for name := range byTournament {
+		tournaments = append(tournaments, name)
+	}
+	sort.Strings(tournaments)
+
+	var b strings.Builder
+	for i, name := range tournaments {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		if name == "" {
+			name = "Other"
+		}
+		fmt.Fprintf(&b, "**%s**\n", name)
+		for _, m := range byTournament[name] {
+			b.WriteString(formatMatch(m))
+			b.WriteString("\n")
+		}
+	}
+
+	if omitted > 0 {
+		fmt.Fprintf(&b, "\n*and %d more — search for a player to narrow it down*", omitted)
+	}
+
+	return b.String()
+}
+
+// formatMatch renders one match as a single line, for example
+//
+//	Sinner ● v Alcaraz · 6-4 3-4 · 40-AD · BP
+func formatMatch(m match) string {
+	p1 := surname(m.Players.P1.Name)
+	p2 := surname(m.Players.P2.Name)
+
+	if m.Score != nil {
+		if server := m.Score.Server; server != nil {
+			switch *server {
+			case 1:
+				p1 += " ●"
+			case 2:
+				p2 += " ●"
+			}
+		}
+	}
+
+	line := p1 + " v " + p2
+
+	if sets := formatSets(m.Score); sets != "" {
+		line += " · " + sets
+	}
+
+	if points := formatPoints(m.Score); points != "" {
+		line += " · " + points
+	}
+
+	if isBreakPoint(m.Score) {
+		line += " · **BP**"
+	}
+
+	return line
+}
+
+// surname takes the last whitespace-separated word of each name, so
+// "Carlos Alcaraz" reads "Alcaraz" and the doubles team
+// "Marcel Granollers / Horacio Zeballos" reads "Granollers/Zeballos".
+func surname(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "?"
+	}
+
+	parts := strings.Split(name, "/")
+	for i, part := range parts {
+		fields := strings.Fields(part)
+		if len(fields) == 0 {
+			parts[i] = "?"
+			continue
+		}
+		parts[i] = fields[len(fields)-1]
+	}
+
+	return strings.Join(parts, "/")
+}
+
+// formatSets renders the per-set games from the first player's point of view.
+// The vendor's games array is player-major -- games[0] is player one's games
+// in each set and games[1] is player two's -- so [[6,3],[4,4]] reads "6-4 3-4".
+func formatSets(s *score) string {
+	if s == nil || len(s.Games) < 2 {
+		return ""
+	}
+
+	p1, p2 := s.Games[0], s.Games[1]
+	sets := min(len(p1), len(p2))
+
+	out := make([]string, 0, sets)
+	for i := 0; i < sets; i++ {
+		out = append(out, fmt.Sprintf("%d-%d", p1[i], p2[i]))
+	}
+
+	return strings.Join(out, " ")
+}
+
+// formatPoints renders the game in progress, or "" when it is not known. In a
+// tiebreak the two values are a running integer count rather than tennis
+// scores, so they are labelled to tell the notations apart.
+func formatPoints(s *score) string {
+	if s == nil || len(s.Points) < 2 {
+		return ""
+	}
+
+	p1, p2 := s.Points[0], s.Points[1]
+	if p1 == nil || p2 == nil {
+		return ""
+	}
+
+	if s.IsTiebreak {
+		return fmt.Sprintf("TB %s-%s", *p1, *p2)
+	}
+
+	return fmt.Sprintf("%s-%s", *p1, *p2)
+}
+
+// isBreakPoint reports whether the receiver is one point from winning the
+// game: they hold advantage, or they are at 40 while the server is not. It is
+// never true in a tiebreak, where there is no server's game to break, and it
+// is false whenever the score or the server is unknown.
+func isBreakPoint(s *score) bool {
+	if s == nil || s.IsTiebreak || s.Server == nil || len(s.Points) < 2 {
+		return false
+	}
+
+	var receiverIdx int
+	switch *s.Server {
+	case 1:
+		receiverIdx = 1
+	case 2:
+		receiverIdx = 0
+	default:
+		return false
+	}
+	serverIdx := 1 - receiverIdx
+
+	receiver, server := s.Points[receiverIdx], s.Points[serverIdx]
+	if receiver == nil || server == nil {
+		return false
+	}
+
+	switch *receiver {
+	case "AD":
+		return true
+	case "40":
+		switch *server {
+		case "0", "15", "30":
+			return true
+		}
+	}
+
+	return false
+}

--- a/stdcommands/tennis/tennis_test.go
+++ b/stdcommands/tennis/tennis_test.go
@@ -1,0 +1,375 @@
+package tennis
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func pts(values ...string) []*string {
+	out := make([]*string, 0, len(values))
+	for _, v := range values {
+		if v == "" {
+			out = append(out, nil)
+			continue
+		}
+		s := v
+		out = append(out, &s)
+	}
+	return out
+}
+
+func serverPtr(n int) *int { return &n }
+
+func TestIsBreakPoint(t *testing.T) {
+	tests := []struct {
+		name  string
+		score *score
+		want  bool
+	}{
+		{"nil score", nil, false},
+		{"nil server", &score{Points: pts("40", "AD")}, false},
+
+		{"receiver holds advantage, p1 serving", &score{Points: pts("AD", "40"), Server: serverPtr(2)}, true},
+		{"receiver holds advantage, p2 serving", &score{Points: pts("40", "AD"), Server: serverPtr(1)}, true},
+
+		{"receiver at 40, server at 0", &score{Points: pts("0", "40"), Server: serverPtr(1)}, true},
+		{"receiver at 40, server at 15", &score{Points: pts("15", "40"), Server: serverPtr(1)}, true},
+		{"receiver at 40, server at 30", &score{Points: pts("30", "40"), Server: serverPtr(1)}, true},
+		{"receiver at 40, server at 30, other side serving", &score{Points: pts("40", "30"), Server: serverPtr(2)}, true},
+
+		{"deuce is not a break point", &score{Points: pts("40", "40"), Server: serverPtr(1)}, false},
+		{"server holds advantage", &score{Points: pts("AD", "40"), Server: serverPtr(1)}, false},
+		{"server at game point", &score{Points: pts("40", "30"), Server: serverPtr(1)}, false},
+		{"start of game", &score{Points: pts("0", "0"), Server: serverPtr(1)}, false},
+
+		// A tiebreak has no server's game to break, and its points are a
+		// running integer count that must not be read as tennis scores.
+		{"tiebreak, receiver ahead", &score{Points: pts("5", "6"), Server: serverPtr(1), IsTiebreak: true}, false},
+		{"tiebreak that happens to read 40", &score{Points: pts("30", "40"), Server: serverPtr(1), IsTiebreak: true}, false},
+
+		// Completed matches are served with null points.
+		{"both points null", &score{Points: pts("", ""), Server: serverPtr(1)}, false},
+		{"receiver point null", &score{Points: pts("30", ""), Server: serverPtr(1)}, false},
+		{"server point null", &score{Points: pts("", "40"), Server: serverPtr(1)}, false},
+		{"empty points array", &score{Points: pts(), Server: serverPtr(1)}, false},
+		{"single point entry", &score{Points: pts("40"), Server: serverPtr(1)}, false},
+		{"nil points array", &score{Server: serverPtr(1)}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isBreakPoint(tt.score); got != tt.want {
+				t.Errorf("isBreakPoint() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatSets(t *testing.T) {
+	tests := []struct {
+		name  string
+		score *score
+		want  string
+	}{
+		{"nil score", nil, ""},
+		// games is player-major: [[6,3],[4,4]] is 6-4 in the first set and 3-4
+		// in the second, NOT 6-3 and 4-4.
+		{"two sets", &score{Games: [][]int{{6, 3}, {4, 4}}}, "6-4 3-4"},
+		{"one set in progress", &score{Games: [][]int{{2}, {1}}}, "2-1"},
+		{"five sets", &score{Games: [][]int{{6, 3, 6, 4}, {4, 6, 3, 6}}}, "6-4 3-6 6-3 4-6"},
+		{"completed match with empty games", &score{Games: [][]int{{}, {}}}, ""},
+		{"no games at all", &score{}, ""},
+		{"only one side present", &score{Games: [][]int{{6, 3}}}, ""},
+		// Never index past the shorter side.
+		{"ragged games arrays", &score{Games: [][]int{{6, 3}, {4}}}, "6-4"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatSets(tt.score); got != tt.want {
+				t.Errorf("formatSets() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatPoints(t *testing.T) {
+	tests := []struct {
+		name  string
+		score *score
+		want  string
+	}{
+		{"nil score", nil, ""},
+		{"game in progress", &score{Points: pts("30", "40")}, "30-40"},
+		{"advantage", &score{Points: pts("AD", "40")}, "AD-40"},
+		{"tiebreak is labelled", &score{Points: pts("5", "6"), IsTiebreak: true}, "TB 5-6"},
+		{"null points", &score{Points: pts("", "")}, ""},
+		{"one null point", &score{Points: pts("30", "")}, ""},
+		{"empty points", &score{Points: pts()}, ""},
+		{"nil points", &score{}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatPoints(tt.score); got != tt.want {
+				t.Errorf("formatPoints() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSurname(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"Carlos Alcaraz", "Alcaraz"},
+		{"Jannik Sinner", "Sinner"},
+		{"Felix Auger-Aliassime", "Auger-Aliassime"},
+		{"Jan-Lennard Struff", "Struff"},
+		{"Alcaraz", "Alcaraz"},
+		{"  Iga  Swiatek  ", "Swiatek"},
+		{"Marcel Granollers / Horacio Zeballos", "Granollers/Zeballos"},
+		{"", "?"},
+		{"   ", "?"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := surname(tt.name); got != tt.want {
+				t.Errorf("surname(%q) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatMatch(t *testing.T) {
+	newMatch := func(p1, p2 string, s *score) match {
+		var m match
+		m.Players.P1.Name = p1
+		m.Players.P2.Name = p2
+		m.Score = s
+		return m
+	}
+
+	tests := []struct {
+		name  string
+		match match
+		want  string
+	}{
+		{
+			"break point against the first player",
+			newMatch("Jannik Sinner", "Carlos Alcaraz", &score{
+				Games:  [][]int{{6, 3}, {4, 4}},
+				Points: pts("30", "40"),
+				Server: serverPtr(1),
+			}),
+			"Sinner ● v Alcaraz · 6-4 3-4 · 30-40 · **BP**",
+		},
+		{
+			"second player serving, no break point",
+			newMatch("Jannik Sinner", "Carlos Alcaraz", &score{
+				Games:  [][]int{{6}, {4}},
+				Points: pts("15", "30"),
+				Server: serverPtr(2),
+			}),
+			"Sinner v Alcaraz ● · 6-4 · 15-30",
+		},
+		{
+			"tiebreak never marks a break point",
+			newMatch("Jannik Sinner", "Carlos Alcaraz", &score{
+				Games:      [][]int{{6}, {6}},
+				Points:     pts("6", "7"),
+				Server:     serverPtr(1),
+				IsTiebreak: true,
+			}),
+			"Sinner ● v Alcaraz · 6-6 · TB 6-7",
+		},
+		{
+			"completed match with null points and empty games",
+			newMatch("Jannik Sinner", "Carlos Alcaraz", &score{
+				Games:  [][]int{{}, {}},
+				Points: pts("", ""),
+			}),
+			"Sinner v Alcaraz",
+		},
+		{
+			"match with no score yet",
+			newMatch("Jannik Sinner", "Carlos Alcaraz", nil),
+			"Sinner v Alcaraz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatMatch(tt.match); got != tt.want {
+				t.Errorf("formatMatch() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterByPlayer(t *testing.T) {
+	newMatch := func(p1, p2 string) match {
+		var m match
+		m.Players.P1.Name = p1
+		m.Players.P2.Name = p2
+		return m
+	}
+
+	board := []match{
+		newMatch("Jannik Sinner", "Carlos Alcaraz"),
+		newMatch("Iga Swiatek", "Aryna Sabalenka"),
+		newMatch("Novak Djokovic", "Daniil Medvedev"),
+	}
+
+	tests := []struct {
+		name  string
+		query string
+		want  int
+	}{
+		{"empty query returns everything", "", 3},
+		{"surname", "Alcaraz", 1},
+		{"case insensitive", "swiatek", 1},
+		{"matches the second player", "Medvedev", 1},
+		{"partial name", "Saba", 1},
+		{"first name", "Novak", 1},
+		{"no such player", "Federer", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := filterByPlayer(board, tt.query); len(got) != tt.want {
+				t.Errorf("filterByPlayer(%q) returned %d matches, want %d", tt.query, len(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatBoardGroupsAndTruncates(t *testing.T) {
+	newMatch := func(tournament, p1, p2 string) match {
+		var m match
+		m.Tournament = tournament
+		m.Players.P1.Name = p1
+		m.Players.P2.Name = p2
+		return m
+	}
+
+	board := []match{
+		newMatch("US Open", "Jannik Sinner", "Carlos Alcaraz"),
+		newMatch("Challenger Como", "A Player", "B Player"),
+		newMatch("US Open", "Iga Swiatek", "Aryna Sabalenka"),
+	}
+
+	got := formatBoard(board, 10)
+
+	// Tournaments become headers, sorted, and each one carries its matches.
+	if strings.Index(got, "**Challenger Como**") > strings.Index(got, "**US Open**") {
+		t.Errorf("tournaments are not sorted:\n%s", got)
+	}
+	if strings.Count(got, "**US Open**") != 1 {
+		t.Errorf("US Open should appear once as a header:\n%s", got)
+	}
+	for _, want := range []string{"Sinner v Alcaraz", "Swiatek v Sabalenka", "Player v Player"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("board is missing %q:\n%s", want, got)
+		}
+	}
+
+	// Over the limit, the rest are counted rather than dropped silently.
+	truncated := formatBoard(board, 2)
+	if !strings.Contains(truncated, "and 1 more") {
+		t.Errorf("expected a truncation notice:\n%s", truncated)
+	}
+}
+
+// The API serves null for points entries, for server, and for the whole score
+// object. Decoding has to survive all three, which is why those fields are
+// pointers rather than values.
+func TestDecodeListResponse(t *testing.T) {
+	const body = `{
+	  "data": [
+	    {
+	      "tournament": "US Open",
+	      "players": {"p1": {"name": "Jannik Sinner"}, "p2": {"name": "Carlos Alcaraz"}},
+	      "score": {"sets": [1, 0], "games": [[6, 3], [4, 4]], "points": ["30", "40"], "server": 1, "is_tiebreak": false}
+	    },
+	    {
+	      "tournament": "Challenger Como",
+	      "players": {"p1": {"name": "A Player"}, "p2": {"name": "B Player"}},
+	      "score": {"sets": [2, 1], "games": [[], []], "points": [null, null], "server": null, "is_tiebreak": false}
+	    },
+	    {
+	      "tournament": "ITF Cairo",
+	      "players": {"p1": {"name": "C Player"}, "p2": {"name": "D Player"}},
+	      "score": null
+	    }
+	  ],
+	  "meta": {"limit": 200, "offset": 0, "count": 3, "total": 3, "has_more": false}
+	}`
+
+	var parsed matchListResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("decoding a realistic payload failed: %v", err)
+	}
+
+	if len(parsed.Data) != 3 {
+		t.Fatalf("decoded %d matches, want 3", len(parsed.Data))
+	}
+
+	// A match in play.
+	live := parsed.Data[0]
+	if live.Score == nil {
+		t.Fatal("score of the live match decoded as nil")
+	}
+	if live.Score.Server == nil || *live.Score.Server != 1 {
+		t.Errorf("server = %v, want 1", live.Score.Server)
+	}
+	// games is player-major, so this is 6-4 3-4 and not 6-3 4-4.
+	if got := formatSets(live.Score); got != "6-4 3-4" {
+		t.Errorf("formatSets() = %q, want %q", got, "6-4 3-4")
+	}
+	if !isBreakPoint(live.Score) {
+		t.Error("30-40 on player one's serve should be a break point")
+	}
+
+	// A match whose points and server came back null.
+	nulls := parsed.Data[1]
+	if nulls.Score == nil {
+		t.Fatal("score with null members decoded as nil")
+	}
+	if len(nulls.Score.Points) != 2 {
+		t.Fatalf("decoded %d points, want 2", len(nulls.Score.Points))
+	}
+	for i, p := range nulls.Score.Points {
+		if p != nil {
+			t.Errorf("points[%d] = %q, want nil", i, *p)
+		}
+	}
+	if nulls.Score.Server != nil {
+		t.Errorf("server = %v, want nil", *nulls.Score.Server)
+	}
+	if got := formatMatch(nulls); got != "Player v Player" {
+		t.Errorf("formatMatch() = %q, want %q", got, "Player v Player")
+	}
+
+	// A match with no score object at all.
+	if parsed.Data[2].Score != nil {
+		t.Error("a null score should decode to a nil pointer")
+	}
+	if got := formatMatch(parsed.Data[2]); got != "Player v Player" {
+		t.Errorf("formatMatch() = %q, want %q", got, "Player v Player")
+	}
+}
+
+func TestFormatBoardEmptyTournamentName(t *testing.T) {
+	var m match
+	m.Players.P1.Name = "Jannik Sinner"
+	m.Players.P2.Name = "Carlos Alcaraz"
+
+	got := formatBoard([]match{m}, 10)
+	if !strings.Contains(got, "**Other**") {
+		t.Errorf("an unnamed tournament should be grouped under Other:\n%s", got)
+	}
+}


### PR DESCRIPTION
**Vendor disclosure first:** I work on the Live Tennis API, the third-party service this command calls. I am disclosing that up front so you can weigh it. If a self-interested data source is not something you want in the bot, I would rather you close this than spend review time on it. AI tooling was used while writing it; the code and the checks below are mine.

**Process, honestly.** CONTRIBUTING asks that feature ideas go to the `#suggestions` channel first. I have not done that, and I am not going to pretend otherwise. I am happy for this to wait on that step, or to be closed if this is the wrong order.

CONTRIBUTING also says to branch from `master`. I branched from **`dev`** instead, deliberately. `dev` has moved the fun and lookup commands into the new container via `funCommandList`, and the `master`-shaped registration point in `AddRootCommands` no longer exists there, so a `master`-based branch conflicts in `stdcommands.go` and would register the command in the wrong place. I checked before deciding: 46 of the last 46 merged pull requests targeted `dev`, and none targeted `master`. Basing on `dev` keeps this conflict-free and puts the command alongside `weather`, `forex` and `xkcd`. Say the word and I will rebase however you prefer.

## What it does

`tennis` lists the matches in play right now, grouped by tournament, one short line each: surnames, set score, the game in progress, a marker on the server, and a break-point marker. An optional player argument narrows the board to one name.

```
**US Open**
Sinner ● v Alcaraz · 6-4 3-4 · 30-40 · **BP**
Swiatek v Sabalenka ● · 6-4 · 15-30
```

## The API key, and the plan it needs

Credentials follow the `twitch` and `safebrowsing` pattern: one operator-level key from `common/config`, read at runtime and degrading gracefully when empty. With no key configured the command is inert and says so, and nothing else is affected.

**Being straight about cost, since this is one bot serving many guilds.** My free tier allows 100 requests a day and **that is not enough for a public instance of YAGPDB.** The board is cached for 60 seconds and shared by every guild, so the worst case is 1,440 requests a day, and that is a ceiling rather than a rate, since the fetch is lazy and only costs a request if someone actually runs the command in a given minute. Fitting 100 a day would need a cache of about 14 minutes, which is not a live score. So running this on the hosted instance would need a paid plan on our side of the fence. The arithmetic is in a comment at the top of the file rather than buried in a pull request description, and the command simply stays off until an operator opts in.

Cost is flat in guilds and users. One cached board serves everyone, concurrent misses collapse into a single upstream request because the lock is held across the fetch, and the player search filters that same cache rather than querying upstream, so it costs no requests at all. The cache bounds the API quota; the per-user and per-guild cooldowns bound command spam on the Discord side.

## Data handling

The score fields are genuinely nullable. A just-completed match comes back with null points and empty games arrays, and our own schema says not to decode them into non-nullable types. So points are a slice of pointers, the server is a pointer, and the score object itself is a pointer, with every formatter null-safe against short and ragged arrays.

The games array is player-major, so `[[6,3],[4,4]]` is 6-4 3-4 rather than 6-3 4-4. That is easy to get backwards, so it is asserted directly in the tests. Break point is derived as the receiver holding advantage, or the receiver at 40 while the server is not, and never inside a tiebreak, where those same two fields are a running integer count rather than tennis scores.

## Verification

```
go build ./...                  exit 0
go vet ./stdcommands/...        exit 0
go test ./stdcommands/tennis/   ok, 75 subtests
go test -race                   ok
```

The three CI binary builds also pass. `go vet ./...` reports 17 findings repo-wide, and all of them are pre-existing: I compared a pristine `upstream/dev` checkout against this branch and both report exactly 17, so this change adds none.

New unit tests cover the break-point rule including the tiebreak exclusion, set and point formatting, surname extraction for singles and doubles, the player filter, board grouping and truncation, and decoding a payload containing every null shape the API can return.

## What I could not verify

No live API call, because the key is not on my build machine, so the HTTP path and real-payload decoding are verified against our published schema and a hand-built fixture rather than against the wire. And nothing was run inside Discord: there is no bot token, Redis or Postgres here, so command registration, the slash surface, cooldown enforcement and embed rendering are verified by compilation, linkage into the shipped binary, and code reading, not by observation.
